### PR TITLE
trust-root: fix update-embedded-roots when root is not rotated

### DIFF
--- a/crates/sigstore-trust-root/examples/update-embedded-roots.rs
+++ b/crates/sigstore-trust-root/examples/update-embedded-roots.rs
@@ -112,8 +112,16 @@ async fn update_instance(instance: &Instance) -> Result<bool, Box<dyn std::error
     updater.refresh(now).await?;
 
     // Read the freshest verified root.json verbatim, to keep the embedded file
-    // byte-for-byte identical to what the repository serves.
-    let latest_root = std::fs::read(metadata_dir.path().join("root.json"))?;
+    // byte-for-byte identical to what the repository serves. The updater only
+    // writes `root.json` to the store when it rotates the root during this
+    // refresh; in the common steady state (embedded root already current) no
+    // rotation happens and the store has no `root.json`, so the freshest
+    // verified root is the embedded one we bootstrapped from.
+    let latest_root = match std::fs::read(metadata_dir.path().join("root.json")) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => instance.embedded_root.to_vec(),
+        Err(e) => return Err(e.into()),
+    };
 
     // Sanity check: the downloaded root.json must bootstrap on its own (it has
     // to be correctly self-signed to its `root` threshold).


### PR DESCRIPTION
The update-embedded-roots example read root.json back from the temp store after refresh, but the Updater only writes root.json when it rotates the root during the refresh. In steady state (embedded root already current) no rotation happens, the store has no root.json, and std::fs::read failed with ENOENT for every instance.

Fall back to the embedded root bytes when the store has no root.json: with no rotation, the freshest verified root is the one we bootstrapped from, so the embedded file stays byte-for-byte correct.