### PR TITLE
More Custom Instance support

### DIFF
--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -127,9 +127,9 @@ async fn main() {
     println!("  Size: {} bytes", artifact.len());
 
     // Create signing context with appropriate API version
-    let tuf_config = if let Some(url) = instance {
+    let tuf_config = if let Some(ref url) = instance {
         println!("  Using: custom instance ({})", url);
-        let config = sigstore_trust_root::tuf::TufConfig::custom(&url);
+        let config = sigstore_trust_root::tuf::TufConfig::custom(url);
         sigstore_trust_root::SigningConfig::from_tuf(config)
             .await
             .unwrap_or_else(|e| {
@@ -249,10 +249,18 @@ async fn main() {
         println!("  RFC3161 Timestamps: none (V2 bundles require timestamps!)");
     }
 
+    let extra_flags = if let Some(ref url) = instance {
+        format!("--instance {} ", url)
+    } else if staging {
+        "--staging ".to_string()
+    } else {
+        String::new()
+    };
+
     println!("\nVerify with:");
     println!(
-        "  cargo run -p sigstore-verify --example verify_bundle -- {} {}",
-        artifact_path, output_path
+        "  cargo run -p sigstore-verify --example verify_bundle -- {}{} {}",
+        extra_flags, artifact_path, output_path
     );
 }
 

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -51,6 +51,7 @@ async fn main() {
     // Parse arguments
     let mut token: Option<String> = None;
     let mut output: Option<String> = None;
+    let mut instance: Option<String> = None;
     let mut staging = false;
     let mut use_v2 = false;
     let mut positional: Vec<String> = Vec::new();
@@ -73,6 +74,14 @@ async fn main() {
                     process::exit(1);
                 }
                 output = Some(args[i].clone());
+            }
+            "--instance" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("Error: --instance requires a value");
+                    process::exit(1);
+                }
+                instance = Some(args[i].clone());
             }
             "--staging" => {
                 staging = true;
@@ -118,13 +127,22 @@ async fn main() {
     println!("  Size: {} bytes", artifact.len());
 
     // Create signing context with appropriate API version
-    let tuf_config = if staging {
-        println!("  Using: staging infrastructure");
+    let tuf_config = if let Some(url) = instance {
+        println!("  Using: custom instance ({})", url);
+        let config = sigstore_trust_root::tuf::TufConfig::custom(&url);
+        sigstore_trust_root::SigningConfig::from_tuf(config)
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to fetch custom config via TUF: {}", e);
+                process::exit(1);
+            })
+    } else if staging {
+        println!("  Using: staging instance");
         sigstore_trust_root::SigningConfig::staging()
             .await
             .expect("Failed to fetch staging config via TUF")
     } else {
-        println!("  Using: production infrastructure");
+        println!("  Using: production instance");
         sigstore_trust_root::SigningConfig::production()
             .await
             .expect("Failed to fetch production config via TUF")
@@ -277,6 +295,7 @@ fn print_usage(program: &str) {
     eprintln!("Options:");
     eprintln!("  -o, --output <FILE>  Output bundle path (default: <artifact>.sigstore.json)");
     eprintln!("  -t, --token <TOKEN>  OIDC identity token (skips interactive auth)");
+    eprintln!("      --instance <URL> Use a custom Sigstore instance");
     eprintln!("      --staging        Use Sigstore staging infrastructure");
     eprintln!("      --v2             Use Rekor V2 API (uses log2025-1.rekor.sigstore.dev)");
     eprintln!("  -h, --help           Print this help message");

--- a/crates/sigstore-trust-root/examples/trust-instance.rs
+++ b/crates/sigstore-trust-root/examples/trust-instance.rs
@@ -1,0 +1,107 @@
+//! Example: Trust a custom Sigstore instance
+//!
+//! This example demonstrates how to establish trust for a custom Sigstore instance
+//! (like a root-signing test environment) by downloading its trusted root and
+//! caching it locally.
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo run -p sigstore-trust-root --example trust-instance -- --instance <URL> <ROOT_JSON>
+//! ```
+
+use sigstore_trust_root::tuf::{fetch_trust_material, TufConfig};
+use std::env;
+use std::process;
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let mut instance_url: Option<String> = None;
+    let mut positional: Vec<String> = Vec::new();
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--instance" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("Error: --instance requires a value");
+                    process::exit(1);
+                }
+                instance_url = Some(args[i].clone());
+            }
+            "--help" | "-h" => {
+                print_usage(&args[0]);
+                process::exit(0);
+            }
+            arg if !arg.starts_with('-') => {
+                positional.push(arg.to_string());
+            }
+            unknown => {
+                eprintln!("Error: Unknown option: {}", unknown);
+                print_usage(&args[0]);
+                process::exit(1);
+            }
+        }
+        i += 1;
+    }
+
+    if positional.len() != 1 {
+        eprintln!("Error: Expected exactly 1 positional argument (path to root.json)");
+        print_usage(&args[0]);
+        process::exit(1);
+    }
+
+    let url = match instance_url {
+        Some(u) => u,
+        None => {
+            eprintln!("Error: --instance is required");
+            print_usage(&args[0]);
+            process::exit(1);
+        }
+    };
+
+    let root_path = &positional[0];
+
+    println!("Trusting instance: {}", url);
+    println!("Using bootstrap root: {}", root_path);
+
+    let config = match TufConfig::custom_from_file(&url, root_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error reading root.json from {}: {}", root_path, e);
+            process::exit(1);
+        }
+    };
+
+    println!("\nFetching and verifying TUF metadata...");
+    match fetch_trust_material(config).await {
+        Ok((_root, _signing_config)) => {
+            println!("This instance is now trusted and can be used in sign and verify examples:");
+            println!(
+                "  cargo run -p sigstore-sign --example sign_blob -- --instance {} README.md",
+                url
+            );
+        }
+        Err(e) => {
+            eprintln!("Error initializing trust: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn print_usage(program: &str) {
+    eprintln!("Usage: {} --instance <URL> <ROOT_JSON>", program);
+    eprintln!();
+    eprintln!("Initialize trust for a custom Sigstore instance by verifying");
+    eprintln!("and caching its TUF repository using the provided bootstrap root.");
+    eprintln!();
+    eprintln!("Arguments:");
+    eprintln!("  <ROOT_JSON>        Path to a trusted TUF root.json");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --instance <URL>   Base URL of the custom TUF repository");
+    eprintln!("  -h, --help         Print this help message");
+}

--- a/crates/sigstore-trust-root/src/tuf.rs
+++ b/crates/sigstore-trust-root/src/tuf.rs
@@ -239,7 +239,6 @@ impl TufConfig {
     }
 }
 
-
 /// Embedded production trusted root (same as SIGSTORE_PRODUCTION_TRUSTED_ROOT but as bytes)
 const EMBEDDED_PRODUCTION_TRUSTED_ROOT: &[u8] = include_bytes!("trusted_root.json");
 
@@ -271,18 +270,19 @@ impl TufClient {
     /// (production, staging, and GitHub).
     fn new(config: TufConfig) -> Self {
         // Determine embedded targets based on URL for offline fallback
+        let normalized_url = config.url.trim_end_matches('/');
         let embedded_targets: &'static [(&'static str, &'static [u8])] =
-            if config.url == DEFAULT_TUF_URL || config.url.starts_with(DEFAULT_TUF_URL) {
+            if normalized_url == DEFAULT_TUF_URL {
                 &[
                     (TRUSTED_ROOT_TARGET, EMBEDDED_PRODUCTION_TRUSTED_ROOT),
                     (SIGNING_CONFIG_TARGET, EMBEDDED_PRODUCTION_SIGNING_CONFIG),
                 ]
-            } else if config.url == STAGING_TUF_URL || config.url.starts_with(STAGING_TUF_URL) {
+            } else if normalized_url == STAGING_TUF_URL {
                 &[
                     (TRUSTED_ROOT_TARGET, EMBEDDED_STAGING_TRUSTED_ROOT),
                     (SIGNING_CONFIG_TARGET, EMBEDDED_STAGING_SIGNING_CONFIG),
                 ]
-            } else if config.url == GITHUB_TUF_URL || config.url.starts_with(GITHUB_TUF_URL) {
+            } else if normalized_url == GITHUB_TUF_URL {
                 &[(TRUSTED_ROOT_TARGET, EMBEDDED_GITHUB_TRUSTED_ROOT)]
             } else {
                 // Custom URLs have no embedded fallback
@@ -342,11 +342,12 @@ impl TufClient {
         }
 
         // Fall back to embedded roots for known URLs
-        if self.config.url == DEFAULT_TUF_URL || self.config.url.starts_with(DEFAULT_TUF_URL) {
+        let normalized_url = self.config.url.trim_end_matches('/');
+        if normalized_url == DEFAULT_TUF_URL {
             return Ok(PRODUCTION_TUF_ROOT.to_vec());
-        } else if self.config.url == STAGING_TUF_URL || self.config.url.starts_with(STAGING_TUF_URL) {
+        } else if normalized_url == STAGING_TUF_URL {
             return Ok(STAGING_TUF_ROOT.to_vec());
-        } else if self.config.url == GITHUB_TUF_URL || self.config.url.starts_with(GITHUB_TUF_URL) {
+        } else if normalized_url == GITHUB_TUF_URL {
             return Ok(GITHUB_TUF_ROOT.to_vec());
         }
 

--- a/crates/sigstore-trust-root/src/tuf.rs
+++ b/crates/sigstore-trust-root/src/tuf.rs
@@ -703,7 +703,7 @@ mod tests {
     #[test]
     fn test_tuf_config_custom() {
         let root_json = b"test root json";
-        let config = TufConfig::custom("https://custom.tuf/", root_json);
+        let config = TufConfig::custom("https://custom.tuf/").with_root(root_json);
         assert_eq!(config.url, "https://custom.tuf/");
         assert_eq!(config.root_json, Some(root_json.to_vec()));
     }
@@ -722,26 +722,35 @@ mod tests {
     #[test]
     fn test_tuf_config_get_root_json_production() {
         let config = TufConfig::production();
-        assert_eq!(config.get_root_json().unwrap(), PRODUCTION_TUF_ROOT);
+        assert_eq!(
+            TufClient::new(config).get_root_json().unwrap(),
+            PRODUCTION_TUF_ROOT
+        );
     }
 
     #[test]
     fn test_tuf_config_get_root_json_staging() {
         let config = TufConfig::staging();
-        assert_eq!(config.get_root_json().unwrap(), STAGING_TUF_ROOT);
+        assert_eq!(
+            TufClient::new(config).get_root_json().unwrap(),
+            STAGING_TUF_ROOT
+        );
     }
 
     #[test]
     fn test_tuf_config_get_root_json_github() {
         let config = TufConfig::github();
-        assert_eq!(config.get_root_json().unwrap(), GITHUB_TUF_ROOT);
+        assert_eq!(
+            TufClient::new(config).get_root_json().unwrap(),
+            GITHUB_TUF_ROOT
+        );
     }
 
     #[test]
     fn test_tuf_config_get_root_json_custom() {
         let root_json = b"custom root";
-        let config = TufConfig::custom("https://custom.tuf/", root_json);
-        assert_eq!(config.get_root_json().unwrap(), root_json);
+        let config = TufConfig::custom("https://custom.tuf/").with_root(root_json);
+        assert_eq!(TufClient::new(config).get_root_json().unwrap(), root_json);
     }
 
     #[test]
@@ -753,7 +762,7 @@ mod tests {
             offline: false,
             root_json: None,
         };
-        let err = config.get_root_json().unwrap_err();
+        let err = TufClient::new(config).get_root_json().unwrap_err();
         assert!(err
             .to_string()
             .contains("No root.json provided for custom URL"));
@@ -844,7 +853,8 @@ mod tests {
     #[tokio::test]
     async fn test_custom_url_offline_fails_without_cache() {
         // Custom URLs have no embedded fallback
-        let config = TufConfig::custom("https://custom.tuf/", b"root")
+        let config = TufConfig::custom("https://custom.tuf/")
+            .with_root(b"root")
             .offline()
             .without_cache();
         let client = TufClient::new(config);

--- a/crates/sigstore-trust-root/src/tuf.rs
+++ b/crates/sigstore-trust-root/src/tuf.rs
@@ -167,14 +167,20 @@ impl TufConfig {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn custom(url: impl Into<String>, root_json: impl AsRef<[u8]>) -> Self {
+    pub fn custom(url: impl Into<String>) -> Self {
         Self {
             url: url.into(),
             cache_dir: None,
             disable_cache: false,
             offline: false,
-            root_json: Some(root_json.as_ref().to_vec()),
+            root_json: None,
         }
+    }
+
+    /// Provide a custom root.json for bootstrapping trust
+    pub fn with_root(mut self, root_json: impl AsRef<[u8]>) -> Self {
+        self.root_json = Some(root_json.as_ref().to_vec());
+        self
     }
 
     /// Create configuration for a custom TUF repository, loading root.json from a file
@@ -203,7 +209,7 @@ impl TufConfig {
         root_path: impl AsRef<Path>,
     ) -> std::io::Result<Self> {
         let root_json = std::fs::read(root_path)?;
-        Ok(Self::custom(url, root_json))
+        Ok(Self::custom(url).with_root(root_json))
     }
 
     /// Set the cache directory
@@ -231,31 +237,8 @@ impl TufConfig {
         self.offline = true;
         self
     }
-
-    /// Get the TUF root.json bytes for this configuration
-    ///
-    /// Returns the custom root if set, otherwise returns the embedded root
-    /// for known URLs (production/staging/GitHub).
-    fn get_root_json(&self) -> Result<&[u8]> {
-        if let Some(ref root) = self.root_json {
-            return Ok(root.as_slice());
-        }
-
-        // Fall back to embedded roots for known URLs
-        if self.url == DEFAULT_TUF_URL || self.url.starts_with(DEFAULT_TUF_URL) {
-            Ok(PRODUCTION_TUF_ROOT)
-        } else if self.url == STAGING_TUF_URL || self.url.starts_with(STAGING_TUF_URL) {
-            Ok(STAGING_TUF_ROOT)
-        } else if self.url == GITHUB_TUF_URL || self.url.starts_with(GITHUB_TUF_URL) {
-            Ok(GITHUB_TUF_ROOT)
-        } else {
-            Err(Error::Tuf(format!(
-                "No root.json provided for custom URL: {}. Use TufConfig::custom() to provide one.",
-                self.url
-            )))
-        }
-    }
 }
+
 
 /// Embedded production trusted root (same as SIGSTORE_PRODUCTION_TRUSTED_ROOT but as bytes)
 const EMBEDDED_PRODUCTION_TRUSTED_ROOT: &[u8] = include_bytes!("trusted_root.json");
@@ -352,6 +335,37 @@ impl TufClient {
         Ok(results)
     }
 
+    /// Get the TUF root.json bytes for this configuration
+    fn get_root_json(&self) -> Result<Vec<u8>> {
+        if let Some(ref root) = self.config.root_json {
+            return Ok(root.clone());
+        }
+
+        // Fall back to embedded roots for known URLs
+        if self.config.url == DEFAULT_TUF_URL || self.config.url.starts_with(DEFAULT_TUF_URL) {
+            return Ok(PRODUCTION_TUF_ROOT.to_vec());
+        } else if self.config.url == STAGING_TUF_URL || self.config.url.starts_with(STAGING_TUF_URL) {
+            return Ok(STAGING_TUF_ROOT.to_vec());
+        } else if self.config.url == GITHUB_TUF_URL || self.config.url.starts_with(GITHUB_TUF_URL) {
+            return Ok(GITHUB_TUF_ROOT.to_vec());
+        }
+
+        // A TUF root was not provided or embedded: Use a cached one if found
+        if !self.config.disable_cache {
+            if let Ok(cache_dir) = self.get_cache_dir() {
+                let cached_path = cache_dir.join("root.json");
+                if let Ok(bytes) = std::fs::read(&cached_path) {
+                    return Ok(bytes);
+                }
+            }
+        }
+
+        Err(Error::Tuf(format!(
+            "No root.json provided for custom URL: {}. Use .with_root() or initialize trust first.",
+            self.config.url
+        )))
+    }
+
     /// Build a `sigstore-tuf` updater and run the TUF refresh workflow
     /// (root → timestamp → snapshot → targets), verifying all metadata against
     /// the configured bootstrap root.
@@ -361,8 +375,8 @@ impl TufClient {
     /// run can serve them.
     async fn build_updater(&self) -> Result<Updater> {
         let repo = HttpRepository::new(&self.config.url).map_err(|e| Error::Tuf(e.to_string()))?;
-        let root_bytes = self.config.get_root_json()?;
-        let mut updater = Updater::new(repo, root_bytes).map_err(|e| Error::Tuf(e.to_string()))?;
+        let root_bytes = self.get_root_json()?;
+        let mut updater = Updater::new(repo, &root_bytes).map_err(|e| Error::Tuf(e.to_string()))?;
 
         if !self.config.disable_cache {
             let cache_dir = self.get_cache_dir()?;

--- a/crates/sigstore-tuf/src/client.rs
+++ b/crates/sigstore-tuf/src/client.rs
@@ -68,6 +68,8 @@ impl Updater {
     /// root. A cached root that doesn't chain from the bootstrap is ignored.
     pub fn with_store(mut self, store: impl MetadataStore + 'static) -> Self {
         let store: Box<dyn MetadataStore> = Box::new(store);
+
+        // Fast-forward from cached history
         loop {
             let next = self.trusted.root().version + 1;
             match store.load(&format!("root_history/{next}.root.json")) {
@@ -77,6 +79,18 @@ impl Updater {
                 _ => break,
             }
         }
+
+        // Ensure root.json in cache matches the final trusted local version
+        let version = self.trusted.root().version;
+        let root_bytes = self.trusted.root_bytes();
+
+        if let Err(e) = store.store("root.json", root_bytes) {
+            tracing::warn!(error = %e, "failed to update root.json in cache");
+        }
+        if let Err(e) = store.store(&format!("root_history/{version}.root.json"), root_bytes) {
+            tracing::warn!(error = %e, version, "failed to cache root history");
+        }
+
         self.store = Some(store);
         self
     }

--- a/crates/sigstore-tuf/src/trusted.rs
+++ b/crates/sigstore-tuf/src/trusted.rs
@@ -23,6 +23,7 @@ use crate::metadata::{MetaFile, Metadata, Role, RoleKeys, Root, Snapshot, Target
 #[derive(Debug, Clone)]
 pub struct TrustedMetadataSet {
     root: Metadata<Root>,
+    root_bytes: Vec<u8>,
     timestamp: Option<Metadata<Timestamp>>,
     snapshot: Option<Metadata<Snapshot>>,
     /// Top-level targets and any delegated targets, keyed by role name.
@@ -41,6 +42,7 @@ impl TrustedMetadataSet {
         verify_root_self_signed(&root)?;
         Ok(Self {
             root,
+            root_bytes: bytes.to_vec(),
             timestamp: None,
             snapshot: None,
             targets: BTreeMap::new(),
@@ -50,6 +52,11 @@ impl TrustedMetadataSet {
     /// The currently trusted root payload.
     pub fn root(&self) -> &Root {
         &self.root.signed
+    }
+
+    /// The raw bytes of the currently trusted root.
+    pub fn root_bytes(&self) -> &[u8] {
+        &self.root_bytes
     }
 
     /// The currently trusted timestamp payload, if one has been loaded.
@@ -94,6 +101,7 @@ impl TrustedMetadataSet {
         verify_root_self_signed(&new_root)?;
 
         self.root = new_root;
+        self.root_bytes = bytes.to_vec();
         // A new root may rotate keys; previously trusted lower roles must be
         // re-verified against it, so drop them.
         self.timestamp = None;

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -61,6 +61,7 @@ async fn main() {
     let mut identity: Option<String> = None;
     let mut identity_regexp: Option<String> = None;
     let mut issuer: Option<String> = None;
+    let mut instance: Option<String> = None;
     let mut staging = false;
     let mut positional: Vec<String> = Vec::new();
 
@@ -90,6 +91,14 @@ async fn main() {
                     process::exit(1);
                 }
                 issuer = Some(args[i].clone());
+            }
+            "--instance" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("Error: --instance requires a value");
+                    process::exit(1);
+                }
+                instance = Some(args[i].clone());
             }
             "--staging" => {
                 staging = true;
@@ -140,9 +149,19 @@ async fn main() {
         }
     };
 
-    // Load trusted root (staging or production Sigstore infrastructure)
-    let trusted_root = if staging {
-        println!("  Using: staging infrastructure (fetching via TUF)");
+    // Load trusted root (staging or production Sigstore instance)
+    let trusted_root = if let Some(url) = instance {
+        println!("  Using: custom instance ({})", url);
+        let config = sigstore_trust_root::tuf::TufConfig::custom(&url);
+        match TrustedRoot::from_tuf(config).await {
+            Ok(root) => root,
+            Err(e) => {
+                eprintln!("Error fetching custom trusted root via TUF: {}", e);
+                process::exit(1);
+            }
+        }
+    } else if staging {
+        println!("  Using: staging instance");
         match TrustedRoot::staging().await {
             Ok(root) => root,
             Err(e) => {
@@ -151,7 +170,7 @@ async fn main() {
             }
         }
     } else {
-        println!("  Using: production infrastructure (fetching via TUF)");
+        println!("  Using: production instance");
         match TrustedRoot::production().await {
             Ok(root) => root,
             Err(e) => {
@@ -282,7 +301,8 @@ fn print_usage(program: &str) {
     eprintln!("  --certificate-identity <ID>        Required certificate identity (exact match)");
     eprintln!("  --certificate-identity-regexp <RE> Required certificate identity (regex)");
     eprintln!("  --certificate-oidc-issuer <ISSUER> Required OIDC issuer");
-    eprintln!("  --staging                          Use Sigstore staging infrastructure");
+    eprintln!("  --instance <URL>                   Use a custom Sigstore instance");
+    eprintln!("  --staging                          Use Sigstore staging instance");
     eprintln!("  -h, --help                         Print this help message");
     eprintln!();
     eprintln!("Aliases (for backwards compatibility):");


### PR DESCRIPTION
Allow "trusting a sigstore instance" (in other words populating the cache for the URL) and later using the cached TUF root
* I think there is a real use case for this: It makes supporting custom instances reasonably ergonomic
* This approach is theoretically not quite as safe as requiring the bootstrap root every time (since the cache is user editable) but in practice is a pretty good compromise: caller can still always provide the bootstrap (and they should if this is possible). When prod, staging and Github are used, the embedded root is still always used.
* It also enables adding sigstore-rust to sigstore/root-signing tests neatly -- these tests require some way of supporting a custom instance

## Changes

### trust-root
* **API change**: `TufConfig::custom()` now does not take a TUF root as argument. This enables loading a TUF config without an embedded root *if* there is a cached root already. `TufConfig::custom(url).with_root(root)` is the replacement for the previous usage.
* Move `get_root_json()` to TufClient and make it load a cached root for custom instance if it exists -- the alternative would have been to make sigstore-tuf support loading root from cache but this seemed like a fairly clean way to do it

### tuf
* Ensure the cache is up-to-date after `Updater.with_store()` -- this mostly makes sure the given bootstrap root is also cached for future use but I believe is also useful in cases where there's cache corruption
* Expose root bytes in TrustedMetadataStore -- this is not 100% necessary, just made the Updater change a little simpler

## Examples
* Added a `trust-instance` example
* Modified sign and verify examples so custom instances can be used

```bash
# Trust new instance (this one is just a different location for staging so staging root works)
cargo run -p sigstore-trust-root --example trust-instance -- \
    --instance https://sigstore.github.io/root-signing-staging/ \
    crates/sigstore-trust-root/repository/tuf_staging_root.json

# Sign with the instance: using a custom instance *always* requires "--instance" 
cargo run -p sigstore-sign --example sign_blob -- \
    --instance https://sigstore.github.io/root-signing-staging/ \
    README.md
```
