### PR TITLE
ci(release-plz): guard sign-off step on prs_created

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -76,7 +76,7 @@ jobs:
       # sign-off itself. Amend the commit it just pushed to append a
       # `Signed-off-by` trailer matching the commit author, then force-push.
       - name: Add DCO sign-off to release PR commit
-        if: steps.release-plz.outputs.pr != ''
+        if: steps.release-plz.outputs.prs_created == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           PR: ${{ steps.release-plz.outputs.pr }}


### PR DESCRIPTION
The DCO sign-off step added in #143 guarded on `steps.release-plz.outputs.pr != ""`. When release-plz has nothing to release it sets the `pr` output to `{}` (an empty JSON object), which is *not* equal to `""`, so the step ran anyway with `PR={}`:

```
head_branch="$(echo '{}' | jq -r .head_branch)"   # → "null"
git fetch origin null                              # → fatal: couldn't find remote ref null → exit 128
```

This made the `Release-plz PR` job fail on every push to `main` that does not produce a release PR (e.g. [this run](https://github.com/sigstore/sigstore-rust/actions/runs/28449047112/job/84305982466)).

Guard on the action’s dedicated boolean output `prs_created` instead, so the step only runs when a release PR was actually created (and `pr` is populated with a real `head_branch`).