### PR TITLE
chore: release v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "directories",
  "jiff",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ambient-id",
  "base64",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "directories",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tuf"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "globset",
  "hex",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64",
  "cms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/prefix-dev/sigstore-rust"
@@ -100,16 +100,16 @@ tempfile = "3.27.0"
 open = "5.3"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.10.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.10.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.10.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.10.0", default-features = false }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.10.0", default-features = false }
-sigstore-tuf = { path = "crates/sigstore-tuf", version = "0.10.0", default-features = false }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.10.0", default-features = false }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.10.0", default-features = false }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.10.0", default-features = false }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.10.0", default-features = false }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.10.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.10.0", default-features = false }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.10.0", default-features = false }
+sigstore-types = { path = "crates/sigstore-types", version = "0.11.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.11.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.11.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.11.0", default-features = false }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.11.0", default-features = false }
+sigstore-tuf = { path = "crates/sigstore-tuf", version = "0.11.0", default-features = false }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.11.0", default-features = false }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.11.0", default-features = false }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.11.0", default-features = false }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.11.0", default-features = false }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.11.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.11.0", default-features = false }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.11.0", default-features = false }

--- a/crates/sigstore-trust-root/CHANGELOG.md
+++ b/crates/sigstore-trust-root/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.10.0...sigstore-trust-root-v0.11.0) - 2026-07-08
+
+### Other
+
+- refresh embedded TUF data ([#149](https://github.com/sigstore/sigstore-rust/pull/149))
+
 ## [0.10.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.9.0...sigstore-trust-root-v0.10.0) - 2026-06-29
 
 ### Added

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.10.0...sigstore-verify-v0.11.0) - 2026-07-08
+
+### Fixed
+
+- *(verify)* source SCT issuer from the verified cert chain ([#154](https://github.com/sigstore/sigstore-rust/pull/154))
+
+### Other
+
+- *(verify)* [**breaking**] make invalid verification policies unrepresentable ([#155](https://github.com/sigstore/sigstore-rust/pull/155))
+
 ## [0.10.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.9.0...sigstore-verify-v0.10.0) - 2026-06-29
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.10.0 -> 0.11.0
* `sigstore-crypto`: 0.10.0 -> 0.11.0
* `sigstore-merkle`: 0.10.0 -> 0.11.0
* `sigstore-tsa`: 0.10.0 -> 0.11.0
* `sigstore-tuf`: 0.10.0 -> 0.11.0
* `sigstore-trust-root`: 0.10.0 -> 0.11.0 (✓ API compatible changes)
* `sigstore-cache`: 0.10.0 -> 0.11.0
* `sigstore-rekor`: 0.10.0 -> 0.11.0
* `sigstore-bundle`: 0.10.0 -> 0.11.0
* `sigstore-oidc`: 0.10.0 -> 0.11.0
* `sigstore-fulcio`: 0.10.0 -> 0.11.0
* `sigstore-verify`: 0.10.0 -> 0.11.0 (✓ API compatible changes)
* `sigstore-sign`: 0.10.0 -> 0.11.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.8.0...sigstore-types-v0.9.0) - 2026-06-17

### Other

- harden message-signature verification, drop digest leak ([#119](https://github.com/sigstore/sigstore-rust/pull/119))
- add `DigestBytes` for multi-algorithm digest encoding ([#109](https://github.com/sigstore/sigstore-rust/pull/109))
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.8.0...sigstore-crypto-v0.9.0) - 2026-06-17

### Other

- harden message-signature verification, drop digest leak ([#119](https://github.com/sigstore/sigstore-rust/pull/119))
- support sha256/384/512 digests, fail closed on unsupported signing schemes, and add `KeyAlgorithm` ([#109](https://github.com/sigstore/sigstore-rust/pull/109))
- If a Fulcio OID is found, it must be parseable ([#108](https://github.com/sigstore/sigstore-rust/pull/108))
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-merkle-v0.8.0...sigstore-merkle-v0.9.0) - 2026-06-17

### Other

- fix overflow at maximum tree size ([#116](https://github.com/sigstore/sigstore-rust/pull/116))
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.8.0...sigstore-tsa-v0.9.0) - 2026-06-17

### Other

- fail-closed if no root certs provided ([#114](https://github.com/sigstore/sigstore-rust/pull/114))
- Verify TSA response nonce ([#113](https://github.com/sigstore/sigstore-rust/pull/113))
- Make our use of jiff more idiomatic ([#100](https://github.com/sigstore/sigstore-rust/pull/100))
</blockquote>

## `sigstore-tuf`

<blockquote>

## [0.10.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tuf-v0.9.0...sigstore-tuf-v0.10.0) - 2026-06-29

### Added

- *(trust-root)* [**breaking**] support trusting custom Sigstore instances over TUF ([#136](https://github.com/sigstore/sigstore-rust/pull/136))
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.11.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.10.0...sigstore-trust-root-v0.11.0) - 2026-07-08

### Other

- refresh embedded TUF data ([#149](https://github.com/sigstore/sigstore-rust/pull/149))
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-cache-v0.7.0...sigstore-cache-v0.8.0) - 2026-05-21

### Other

- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-rekor-v0.6.1...sigstore-rekor-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.8.0...sigstore-bundle-v0.9.0) - 2026-06-17

### Other

- separate structural validation from crypto verification ([#123](https://github.com/sigstore/sigstore-rust/pull/123))
- Various improvements ([#109](https://github.com/sigstore/sigstore-rust/pull/109))
- Support dsse as hashedrekord ([#99](https://github.com/sigstore/sigstore-rust/pull/99))
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.8.0...sigstore-oidc-v0.9.0) - 2026-06-17

### Other

- Don't advertize unreliable parsing mechanism ([#118](https://github.com/sigstore/sigstore-rust/pull/118))
- Include OIDC in signing config, use TUF in examples ([#102](https://github.com/sigstore/sigstore-rust/pull/102))
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-fulcio-v0.6.1...sigstore-fulcio-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.11.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.10.0...sigstore-verify-v0.11.0) - 2026-07-08

### Fixed

- *(verify)* source SCT issuer from the verified cert chain ([#154](https://github.com/sigstore/sigstore-rust/pull/154))

### Other

- *(verify)* [**breaking**] make invalid verification policies unrepresentable ([#155](https://github.com/sigstore/sigstore-rust/pull/155))
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.10.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.9.0...sigstore-sign-v0.10.0) - 2026-06-29

### Added

- *(trust-root)* [**breaking**] support trusting custom Sigstore instances over TUF ([#136](https://github.com/sigstore/sigstore-rust/pull/136))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).