### PR TITLE
ci(release-plz): pin --force-with-lease to fetched SHA

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -83,12 +83,17 @@ jobs:
         run: |
           head_branch="$(echo "$PR" | jq -r .head_branch)"
           git fetch origin "$head_branch"
+          # Remember the commit release-plz just pushed so we can lease against
+          # it below. --force-with-lease with no value relies on a remote-tracking
+          # ref, which git can't resolve when pushing to an explicit URL rather
+          # than the `origin` remote (it rejects with "stale info").
+          base_sha="$(git rev-parse FETCH_HEAD)"
           git checkout -B "$head_branch" FETCH_HEAD
           name="$(git log -1 --format='%an')"
           email="$(git log -1 --format='%ae')"
           # --signoff is a no-op if an identical trailer is already present.
           git -c "user.name=$name" -c "user.email=$email" \
             commit --amend --signoff --no-edit
-          git push --force-with-lease \
+          git push --force-with-lease="$head_branch:$base_sha" \
             "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" \
             "HEAD:$head_branch"


### PR DESCRIPTION
## Problem

The `Release-plz PR` job fails at the DCO sign-off step when force-pushing the amended commit:

```
! [rejected]  HEAD -> release-plz-... (stale info)
error: failed to push some refs
```

(e.g. [this run on main](https://github.com/sigstore/sigstore-rust/actions/runs/28570710459/job/84707621613))

## Cause

The step pushes to an explicit authenticated URL rather than the `origin` remote. Bare `git push --force-with-lease` needs a remote-tracking ref (`refs/remotes/origin/<branch>`) to lease against; git can't associate the anonymous URL with `origin`, so the lease has no reference value and the push is rejected with `(stale info)`.

## Fix

Capture the SHA release-plz just pushed (from `FETCH_HEAD`, before the amend) and pin the lease to it: `--force-with-lease="$head_branch:$base_sha"`. This removes the tracking-ref dependency while still protecting against a concurrent update to the branch between fetch and push.