### PR TITLE
refactor(verify)!: make invalid verification policies unrepresentable

### DIFF
--- a/crates/sigstore-conformance/src/main.rs
+++ b/crates/sigstore-conformance/src/main.rs
@@ -265,17 +265,11 @@ fn verify_bundle(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             let artifact_digest = Sha256Hash::try_from_slice(&digest_bytes)
                 .map_err(|e| format!("Invalid digest: {}", e))?;
 
-            let result = verify_with_key(artifact_digest, &bundle, &public_key, &trusted_root)?;
-            if !result.success {
-                return Err("Verification failed".into());
-            }
+            verify_with_key(artifact_digest, &bundle, &public_key, &trusted_root)?;
         } else {
             // It's a file path
             let artifact_data = fs::read(&artifact_or_digest)?;
-            let result = verify_with_key(&artifact_data, &bundle, &public_key, &trusted_root)?;
-            if !result.success {
-                return Err("Verification failed".into());
-            }
+            verify_with_key(&artifact_data, &bundle, &public_key, &trusted_root)?;
         }
 
         return Ok(());
@@ -314,11 +308,7 @@ fn verify_bundle(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             .map_err(|e| format!("Invalid digest: {}", e))?;
 
         // Verify the signature with trusted root using the digest directly
-        let result = verify(artifact_digest, &bundle, &policy, &trusted_root)?;
-
-        if !result.success {
-            return Err("Verification failed".into());
-        }
+        verify(artifact_digest, &bundle, &policy, &trusted_root)?;
 
         Ok(())
     } else {
@@ -326,11 +316,7 @@ fn verify_bundle(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         let artifact_data = fs::read(&artifact_or_digest)?;
 
         // Verify with trusted root
-        let result = verify(&artifact_data, &bundle, &policy, &trusted_root)?;
-
-        if !result.success {
-            return Err("Verification failed".into());
-        }
+        verify(&artifact_data, &bundle, &policy, &trusted_root)?;
 
         Ok(())
     }

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -260,28 +260,23 @@ async fn main() {
                 }
             }
 
-            if result.success {
-                println!("\nVerification: SUCCESS");
-                if let Some(id) = &result.identity {
-                    println!("  Identity: {}", id);
-                }
-                if let Some(iss) = &result.issuer {
-                    println!("  Issuer: {}", iss);
-                }
-                if let Some(time) = result.integrated_time {
-                    use jiff::Timestamp;
-                    if let Ok(dt) = Timestamp::from_second(time) {
-                        println!("  Signed at: {}", dt);
-                    }
-                }
-                for warning in &result.warnings {
-                    println!("  Warning: {}", warning);
-                }
-                process::exit(0);
-            } else {
-                eprintln!("\nVerification: FAILED");
-                process::exit(1);
+            println!("\nVerification: SUCCESS");
+            if let Some(id) = &result.identity {
+                println!("  Identity: {}", id);
             }
+            if let Some(iss) = &result.issuer {
+                println!("  Issuer: {}", iss);
+            }
+            if let Some(time) = result.integrated_time {
+                use jiff::Timestamp;
+                if let Ok(dt) = Timestamp::from_second(time) {
+                    println!("  Signed at: {}", dt);
+                }
+            }
+            for warning in &result.warnings {
+                println!("  Warning: {}", warning);
+            }
+            process::exit(0);
         }
         Err(e) => {
             eprintln!("\nVerification error: {}", e);

--- a/crates/sigstore-verify/examples/verify_conda_attestation.rs
+++ b/crates/sigstore-verify/examples/verify_conda_attestation.rs
@@ -144,31 +144,26 @@ async fn main() {
     println!();
     match verify(&artifact, &bundle, &policy, &trusted_root) {
         Ok(result) => {
-            if result.success {
-                println!("Verification: SUCCESS");
-                println!();
-                println!("Certificate Details:");
-                if let Some(id) = &result.identity {
-                    println!("  Identity (SAN): {}", id);
-                }
-                if let Some(iss) = &result.issuer {
-                    println!("  OIDC Issuer: {}", iss);
-                }
-                if let Some(time) = result.integrated_time {
-                    use jiff::Timestamp;
-                    if let Ok(dt) = Timestamp::from_second(time) {
-                        println!("  Signed at: {}", dt);
-                    }
-                }
-                for warning in &result.warnings {
-                    println!();
-                    println!("Warning: {}", warning);
-                }
-                process::exit(0);
-            } else {
-                eprintln!("Verification: FAILED");
-                process::exit(1);
+            println!("Verification: SUCCESS");
+            println!();
+            println!("Certificate Details:");
+            if let Some(id) = &result.identity {
+                println!("  Identity (SAN): {}", id);
             }
+            if let Some(iss) = &result.issuer {
+                println!("  OIDC Issuer: {}", iss);
+            }
+            if let Some(time) = result.integrated_time {
+                use jiff::Timestamp;
+                if let Ok(dt) = Timestamp::from_second(time) {
+                    println!("  Signed at: {}", dt);
+                }
+            }
+            for warning in &result.warnings {
+                println!();
+                println!("Warning: {}", warning);
+            }
+            process::exit(0);
         }
         Err(e) => {
             eprintln!("Verification error: {}", e);

--- a/crates/sigstore-verify/src/lib.rs
+++ b/crates/sigstore-verify/src/lib.rs
@@ -19,8 +19,7 @@
 //!     .require_identity("user@example.com")
 //!     .require_issuer("https://accounts.google.com");
 //!
-//! let result = verify(&artifact, &bundle, &policy, &trusted_root)?;
-//! assert!(result.success);
+//! verify(&artifact, &bundle, &policy, &trusted_root)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -41,6 +40,6 @@ pub use sigstore_types as types;
 
 pub use error::{Error, Result};
 pub use verify::{
-    verify, verify_with_key, VerificationPolicy, VerificationResult, Verifier,
+    verify, verify_with_key, CertificatePolicy, VerificationPolicy, VerificationResult, Verifier,
     DEFAULT_CLOCK_SKEW_SECONDS,
 };

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -13,6 +13,27 @@ use sigstore_types::{Artifact, Bundle, HashAlgorithm, SignatureContent, Statemen
 /// Default clock skew tolerance in seconds (60 seconds = 1 minute)
 pub const DEFAULT_CLOCK_SKEW_SECONDS: i64 = 60;
 
+/// How the signing certificate is verified.
+///
+/// SCT verification depends on the issuer identified while verifying the
+/// certificate chain, so it cannot be requested independently. Nesting the
+/// `verify_sct` flag inside the [`CertificatePolicy::Verify`] variant makes the
+/// invalid "verify SCT but not the chain" combination unrepresentable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CertificatePolicy {
+    /// Skip certificate chain verification (and, necessarily, SCT verification).
+    ///
+    /// WARNING: This is unsafe for production use. Only use for testing with
+    /// bundles that don't chain to the trusted root.
+    Skip,
+    /// Verify the certificate chains to the trusted root, is valid at the time
+    /// of signing, and has the CODE_SIGNING EKU.
+    Verify {
+        /// Also verify the certificate's embedded Signed Certificate Timestamp.
+        verify_sct: bool,
+    },
+}
+
 /// Policy for verifying signatures
 #[derive(Debug, Clone)]
 pub struct VerificationPolicy {
@@ -22,12 +43,8 @@ pub struct VerificationPolicy {
     pub issuer: Option<String>,
     /// Verify transparency log inclusion
     pub verify_tlog: bool,
-    /// Verify timestamp
-    pub verify_timestamp: bool,
-    /// Verify certificate chain
-    pub verify_certificate: bool,
-    /// Verify the signing certificate's Signed Certificate Timestamp (SCT)
-    pub verify_sct: bool,
+    /// How the signing certificate (and its SCT) is verified
+    pub certificate: CertificatePolicy,
     /// Clock skew tolerance in seconds for time validation
     ///
     /// This allows for a tolerance when checking that integrated times
@@ -41,9 +58,7 @@ impl Default for VerificationPolicy {
             identity: None,
             issuer: None,
             verify_tlog: true,
-            verify_timestamp: true,
-            verify_certificate: true,
-            verify_sct: true,
+            certificate: CertificatePolicy::Verify { verify_sct: true },
             clock_skew_seconds: DEFAULT_CLOCK_SKEW_SECONDS,
         }
     }
@@ -84,19 +99,13 @@ impl VerificationPolicy {
         self
     }
 
-    /// Skip timestamp verification
-    pub fn skip_timestamp(mut self) -> Self {
-        self.verify_timestamp = false;
-        self
-    }
-
     /// Skip certificate chain verification
     ///
     /// WARNING: This is unsafe for production use. Only use for testing
-    /// with bundles that don't chain to the trusted root.
+    /// with bundles that don't chain to the trusted root. This also skips SCT
+    /// verification, which depends on the verified certificate chain.
     pub fn skip_certificate_chain(mut self) -> Self {
-        self.verify_certificate = false;
-        self.verify_sct = false;
+        self.certificate = CertificatePolicy::Skip;
         self
     }
 
@@ -107,7 +116,9 @@ impl VerificationPolicy {
     /// certificate chain is still verified unless `skip_certificate_chain()` is
     /// also used.
     pub fn skip_sct(mut self) -> Self {
-        self.verify_sct = false;
+        if let CertificatePolicy::Verify { verify_sct } = &mut self.certificate {
+            *verify_sct = false;
+        }
         self
     }
 
@@ -122,10 +133,12 @@ impl VerificationPolicy {
 }
 
 /// Result of verification
+///
+/// This is returned only when verification *succeeds* — any failure is reported
+/// as an [`Err`]. It carries metadata extracted during verification (identity,
+/// issuer, integrated time) plus any non-fatal warnings.
 #[derive(Debug)]
 pub struct VerificationResult {
-    /// Whether verification succeeded
-    pub success: bool,
     /// Identity from the certificate
     pub identity: Option<String>,
     /// Issuer from the certificate
@@ -137,26 +150,20 @@ pub struct VerificationResult {
 }
 
 impl VerificationResult {
-    /// Create a successful result
-    pub fn success() -> Self {
+    /// Create an empty result to be populated as verification proceeds.
+    pub fn new() -> Self {
         Self {
-            success: true,
             identity: None,
             issuer: None,
             integrated_time: None,
             warnings: Vec::new(),
         }
     }
+}
 
-    /// Create a failed result
-    pub fn failure() -> Self {
-        Self {
-            success: false,
-            identity: None,
-            issuer: None,
-            integrated_time: None,
-            warnings: Vec::new(),
-        }
+impl Default for VerificationResult {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -231,7 +238,7 @@ impl Verifier {
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
         let artifact = artifact.into();
-        let mut result = VerificationResult::success();
+        let mut result = VerificationResult::new();
 
         // Validate bundle structure first. This is a purely structural
         // (shape/required-fields) check; all cryptographic verification of
@@ -270,33 +277,28 @@ impl Verifier {
         //      is valid at the time of signing, and has CODE_SIGNING EKU.
         //      The verified path yields the leaf's direct issuer, which SCT
         //      verification needs to reconstruct the RFC 6962 signed data.
-        let mut issuer_spki = None;
-        if policy.verify_certificate {
-            issuer_spki = Some(crate::verify_impl::helpers::verify_certificate_chain(
+        //
+        // (2): Verify the signing certificate's SCT. This is nested here because
+        //      it consumes the issuer produced by chain verification; the type
+        //      system therefore guarantees the issuer is available whenever SCT
+        //      verification runs.
+        if let CertificatePolicy::Verify { verify_sct } = policy.certificate {
+            let issuer_spki = crate::verify_impl::helpers::verify_certificate_chain(
                 &bundle.verification_material.content,
                 validation_time,
                 &self.trusted_root,
-            )?);
+            )?;
 
             // Also verify the certificate is within its validity period
             crate::verify_impl::helpers::validate_certificate_time(validation_time, &cert_info)?;
-        }
 
-        // (2): Verify the signing certificate's SCT.
-        if policy.verify_sct {
-            // SCT verification depends on the issuer from the verified chain.
-            // `skip_certificate_chain()` disables both, so this is always set
-            // when SCT verification runs.
-            let issuer_spki = issuer_spki.as_ref().ok_or_else(|| {
-                Error::Verification(
-                    "SCT verification requires certificate chain verification".to_string(),
-                )
-            })?;
-            crate::verify_impl::sct::verify_sct(
-                cert.as_bytes(),
-                issuer_spki.as_bytes(),
-                &self.trusted_root,
-            )?;
+            if verify_sct {
+                crate::verify_impl::sct::verify_sct(
+                    cert.as_bytes(),
+                    issuer_spki.as_bytes(),
+                    &self.trusted_root,
+                )?;
+            }
         }
 
         // (3): Verify against the given `VerificationPolicy`.
@@ -561,8 +563,7 @@ fn verify_message_signature_crypto(
 /// let bundle = Bundle::from_json(&bundle_json)?;
 /// let artifact = std::fs::read("artifact.txt")?;
 ///
-/// let result = verify(&artifact, &bundle, &sigstore_verify::VerificationPolicy::default(), &trusted_root)?;
-/// assert!(result.success);
+/// verify(&artifact, &bundle, &sigstore_verify::VerificationPolicy::default(), &trusted_root)?;
 /// # Ok(())
 /// # }
 /// ```
@@ -602,8 +603,7 @@ pub fn verify<'a>(
 /// let key_pem = std::fs::read_to_string("key.pub")?;
 /// let public_key = DerPublicKey::from_pem(&key_pem)?;
 ///
-/// let result = verify_with_key(&artifact, &bundle, &public_key, &trusted_root)?;
-/// assert!(result.success);
+/// verify_with_key(&artifact, &bundle, &public_key, &trusted_root)?;
 /// # Ok(())
 /// # }
 /// ```
@@ -617,7 +617,7 @@ pub fn verify_with_key<'a>(
     use sigstore_crypto::{detect_key_type, KeyType, SigningScheme};
 
     let artifact = artifact.into();
-    let result = VerificationResult::success();
+    let result = VerificationResult::new();
 
     // Validate bundle structure (structural only; the cryptographic checks
     // follow below)
@@ -709,9 +709,10 @@ mod tests {
     fn test_verification_policy_default() {
         let policy = VerificationPolicy::default();
         assert!(policy.verify_tlog);
-        assert!(policy.verify_timestamp);
-        assert!(policy.verify_certificate);
-        assert!(policy.verify_sct);
+        assert_eq!(
+            policy.certificate,
+            CertificatePolicy::Verify { verify_sct: true }
+        );
     }
 
     #[test]
@@ -733,16 +734,17 @@ mod tests {
     fn test_skip_sct_keeps_certificate_chain_verification() {
         let policy = VerificationPolicy::default().skip_sct();
 
-        assert!(policy.verify_certificate);
-        assert!(!policy.verify_sct);
+        assert_eq!(
+            policy.certificate,
+            CertificatePolicy::Verify { verify_sct: false }
+        );
     }
 
     #[test]
     fn test_skip_certificate_chain_preserves_legacy_sct_skip() {
         let policy = VerificationPolicy::default().skip_certificate_chain();
 
-        assert!(!policy.verify_certificate);
-        assert!(!policy.verify_sct);
+        assert_eq!(policy.certificate, CertificatePolicy::Skip);
     }
 
     fn in_toto_envelope(payload: &str) -> sigstore_types::DsseEnvelope {

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -158,7 +158,7 @@ fn test_tampered_inclusion_proof_fails_verification() {
     // ...but the verification path must reject the invalid Merkle proof.
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let err = verify(artifact_digest, &bundle, &policy, &production_root())
         .expect_err("verification must fail with a tampered inclusion proof");
@@ -181,7 +181,7 @@ fn test_tampered_canonicalized_body_fails_verification() {
 
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     assert!(
@@ -204,7 +204,6 @@ fn test_verifier_creation() {
 
     // V03_BUNDLE is from sigstore-python tests (staging) - skip crypto verifications
     let policy = VerificationPolicy::default()
-        .skip_timestamp()
         .skip_certificate_chain()
         .skip_tlog();
 
@@ -221,13 +220,12 @@ fn test_verify_with_policy() {
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
 
     // Test with default policy (requires tlog verification)
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     assert!(result.is_ok(), "Verification failed: {:?}", result.err());
 
     let verification = result.unwrap();
-    assert!(verification.success);
     assert!(verification.integrated_time.is_some());
 }
 
@@ -239,7 +237,7 @@ fn test_verify_extracts_integrated_time() {
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
 
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root()).unwrap();
 
@@ -262,7 +260,6 @@ fn test_skip_tlog_verification() {
     // V03_BUNDLE is from sigstore-python tests and may not chain to production Fulcio
     let policy = VerificationPolicy::default()
         .skip_tlog()
-        .skip_timestamp()
         .skip_certificate_chain();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
@@ -285,7 +282,6 @@ fn test_verify_github_bundle_with_explicit_embedded_root() {
         "GitHub bundle verification failed: {:?}",
         result.err()
     );
-    assert!(result.unwrap().success);
 }
 
 // ==== Policy Tests ====
@@ -295,8 +291,7 @@ fn test_policy_builder() {
     let policy = VerificationPolicy::default()
         .require_identity("test@example.com")
         .require_issuer("https://accounts.google.com")
-        .skip_tlog()
-        .skip_timestamp();
+        .skip_tlog();
 
     assert_eq!(policy.identity, Some("test@example.com".to_string()));
     assert_eq!(
@@ -304,7 +299,6 @@ fn test_policy_builder() {
         Some("https://accounts.google.com".to_string())
     );
     assert!(!policy.verify_tlog);
-    assert!(!policy.verify_timestamp);
 }
 
 #[test]
@@ -358,10 +352,9 @@ fn test_full_verification_flow() {
     // Run full verification - extract digest from bundle
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root()).unwrap();
-    assert!(result.success);
     assert_eq!(result.integrated_time, Some(1738060096));
 }
 
@@ -399,10 +392,9 @@ fn test_full_verification_flow_happy_path() {
     // Run full verification - extract digest from bundle
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root()).unwrap();
-    assert!(result.success);
     assert_eq!(result.integrated_time, Some(1734374576));
 }
 
@@ -414,7 +406,6 @@ fn test_verification_with_different_bundle_versions() {
     let artifact_digest =
         extract_artifact_digest(&v03_msg).expect("Bundle should have artifact digest");
     let policy = VerificationPolicy::default()
-        .skip_timestamp()
         .skip_certificate_chain()
         .skip_tlog();
 
@@ -425,7 +416,7 @@ fn test_verification_with_different_bundle_versions() {
     let v03_dsse = Bundle::from_json(V03_BUNDLE_DSSE).unwrap();
     let dsse_artifact_digest =
         extract_artifact_digest(&v03_dsse).expect("DSSE bundle should have artifact digest");
-    let dsse_policy = VerificationPolicy::default().skip_timestamp();
+    let dsse_policy = VerificationPolicy::default();
     let result = verify(
         dsse_artifact_digest,
         &v03_dsse,
@@ -588,7 +579,7 @@ fn test_dsse_bundle_with_2_signatures_should_fail() {
     // Use extracted digest or dummy - doesn't matter since validation should fail first
     let artifact_digest =
         extract_artifact_digest(&bundle).unwrap_or_else(|| Sha256Hash::from_bytes([0u8; 32]));
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
 
@@ -696,7 +687,7 @@ fn test_bundle_no_cert_v1() {
     // Use extracted digest or dummy - doesn't matter since validation should fail first
     let artifact_digest =
         extract_artifact_digest(&bundle).unwrap_or_else(|| Sha256Hash::from_bytes([0u8; 32]));
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     assert!(
@@ -757,7 +748,7 @@ fn test_bundle_no_log_entry() {
     // Use extracted digest or dummy - doesn't matter since validation should fail first
     let artifact_digest =
         extract_artifact_digest(&bundle).unwrap_or_else(|| Sha256Hash::from_bytes([0u8; 32]));
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     assert!(
@@ -802,7 +793,7 @@ fn test_bundle_v3_no_signed_time() {
     // Use extracted digest or dummy - we're testing handling of missing signed time
     let artifact_digest =
         extract_artifact_digest(&bundle).unwrap_or_else(|| Sha256Hash::from_bytes([0u8; 32]));
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     // Whether this succeeds or fails depends on implementation
@@ -943,7 +934,6 @@ fn test_verify_conda_package_attestation() {
     );
 
     let verification = result.unwrap();
-    assert!(verification.success);
     assert_eq!(
         verification.identity.as_deref(),
         Some("https://github.com/prefix-dev/sigstore-example/.github/workflows/action.yaml@refs/heads/main")
@@ -1066,7 +1056,7 @@ fn test_verify_fails_with_unknown_log_entry_kind() {
         Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     assert!(result.is_err());
@@ -1089,7 +1079,7 @@ fn test_verify_fails_with_unknown_log_entry_version() {
         Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     assert!(result.is_err());
@@ -1116,7 +1106,7 @@ fn test_verify_fails_with_mismatched_log_entry_kind() {
         Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     assert!(result.is_err());
@@ -1140,7 +1130,7 @@ fn test_verify_fails_with_mismatched_hashedrekord_version_for_dsse() {
         Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default().skip_timestamp();
+    let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root());
     assert!(result.is_err());
@@ -1169,7 +1159,6 @@ fn test_verify_dsse_with_hashedrekord_v002() {
         "Verification failed for DSSE with HashedRekordV2: {:?}",
         result.err()
     );
-    assert!(result.unwrap().success);
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #154. Tightens the verification API so states that can't verify aren't expressible, removing runtime guards and vestigial fields.

## Changes

### 1. `CertificatePolicy` enum replaces the `verify_certificate` + `verify_sct` bools
SCT verification consumes the issuer produced by chain verification (see #154). The two independent bools allowed the invalid combination "verify SCT but skip the chain", which was caught by a runtime error and an `Option` unwrap mid-verify.

```rust
pub enum CertificatePolicy {
    Skip,                          // verifies neither chain nor SCT
    Verify { verify_sct: bool },   // SCT flag only exists when the chain is verified
}
```

The invalid state is now unrepresentable; the issuer flows out of `verify_certificate_chain` as a plain value.

### 2. Remove `verify_timestamp` / `skip_timestamp()`
These were **never read**. A verified signing time (RFC3161 TSA timestamp or Rekor integrated time) is always required to validate short-lived Fulcio certs, so `skip_timestamp()` was a silent no-op advertising an unsafe option that doesn't — and shouldn't — exist.

This matches sigstore-python: its verifier establishes time from TSA/integrated-time sources, enforces `VERIFIED_TIME_THRESHOLD = 1` ("not enough sources of verified time"), and exposes **no** timestamp-skipping flag.

### 3. Remove `VerificationResult::success` (+ dead `failure()`)
Every failure returns `Err`, so `success` was always `true` on the `Ok` path — a trap for callers who checked the bool instead of the `Result`. `failure()` was never constructed.

## Breaking changes
- `VerificationPolicy`: `verify_certificate`/`verify_sct`/`verify_timestamp` fields and `skip_timestamp()` are gone; use the new `certificate: CertificatePolicy` field. `skip_certificate_chain()` and `skip_sct()` are unchanged.
- `VerificationResult`: no `success` field — a returned `Ok` already means success.

Updated call sites: examples, conformance runner, doctests, and tests.

## Test
Full `sigstore-verify` suite (9 lib + 47 integration + 4 doctests) passes; workspace builds `--all-targets`; fmt + clippy clean.