### PR TITLE
ci(interop): install sigstore-python in an isolated env via uv

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -274,13 +274,6 @@ jobs:
 
       - name: Install sigstore-python
         run: |
-          # Install into an isolated environment rather than `pip install`.
-          # A bare `pip install` on the runner does a user install: it pulls a
-          # fresh `cryptography` into ~/.local but leaves the system's old
-          # `pyOpenSSL` (in /usr/lib/python3/dist-packages) in place. The stale
-          # pyOpenSSL is ABI-incompatible with new cryptography and crashes on
-          # import with `module 'lib' has no attribute 'GEN_EMAIL'`. uv resolves
-          # every dependency together, so the two stay consistent.
           uv tool install sigstore
           BIN_DIR="$(uv tool dir --bin)"
           echo "$BIN_DIR" >> "$GITHUB_PATH"

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -269,10 +269,22 @@ jobs:
       # =========================================
       # SIGSTORE-PYTHON: Cross-implementation verification
       # =========================================
+      - name: Install uv
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+
       - name: Install sigstore-python
         run: |
-          pip install sigstore
-          sigstore --version
+          # Install into an isolated environment rather than `pip install`.
+          # A bare `pip install` on the runner does a user install: it pulls a
+          # fresh `cryptography` into ~/.local but leaves the system's old
+          # `pyOpenSSL` (in /usr/lib/python3/dist-packages) in place. The stale
+          # pyOpenSSL is ABI-incompatible with new cryptography and crashes on
+          # import with `module 'lib' has no attribute 'GEN_EMAIL'`. uv resolves
+          # every dependency together, so the two stay consistent.
+          uv tool install sigstore
+          BIN_DIR="$(uv tool dir --bin)"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
+          "$BIN_DIR/sigstore" --version
 
       - name: "[Python] Verify sigstore-rust V1 bundle"
         run: |


### PR DESCRIPTION
## What

The `Install sigstore-python` step in the interop workflow fails at `pip install sigstore` with:

```
AttributeError: module 'lib' has no attribute 'GEN_EMAIL'
```

(e.g. https://github.com/sigstore/sigstore-rust/actions/runs/28927283718/job/85817726519)

## Why

It's a **split-environment** problem, not a sigstore bug. On the runner, `pip install sigstore` does a *user* install:

```
Defaulting to user installation because normal site-packages is not writeable
```

That pulls a fresh `cryptography-49.0.0` into `~/.local/...`, but treats the **system** `pyOpenSSL` as already-satisfied and leaves it in place:

```
Requirement already satisfied: pyOpenSSL>=23.0.0 in /usr/lib/python3/dist-packages (from sigstore) (23.2.0)
```

`pyOpenSSL 23.2.0` is ABI-incompatible with `cryptography 49`'s CFFI bindings — it references `_lib.GEN_EMAIL`, a symbol that no longer exists — so it aborts on import (via `tuf → securesystemslib → boto3 → urllib3.contrib.pyopenssl → OpenSSL.crypto`).

## Fix

Install via `uv tool install sigstore` instead. uv resolves the whole dependency set together into an isolated environment, so `cryptography` and `pyOpenSSL` stay consistent, and there's no bleed-through from system `dist-packages`. The tool bin dir is added to `$GITHUB_PATH` so the later `sigstore verify` steps keep working unchanged.

`setup-uv` is pinned by SHA, matching how this repo pins its other actions.