### PR TITLE
fix(verify): tighten managed-key verification

### DIFF
--- a/crates/sigstore-conformance/src/main.rs
+++ b/crates/sigstore-conformance/src/main.rs
@@ -11,7 +11,7 @@ use sigstore_trust_root::{
     SigningConfig as TufSigningConfig, TrustedRoot, SIGSTORE_PRODUCTION_TRUSTED_ROOT,
 };
 use sigstore_types::{Bundle, Sha256Hash};
-use sigstore_verify::{verify, VerificationPolicy};
+use sigstore_verify::{verify, PublicKeyVerificationPolicy, VerificationPolicy};
 
 use std::env;
 use std::fs;
@@ -265,11 +265,23 @@ fn verify_bundle(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
             let artifact_digest = Sha256Hash::try_from_slice(&digest_bytes)
                 .map_err(|e| format!("Invalid digest: {}", e))?;
 
-            verify_with_key(artifact_digest, &bundle, &public_key, &trusted_root)?;
+            verify_with_key(
+                artifact_digest,
+                &bundle,
+                &public_key,
+                &PublicKeyVerificationPolicy::default(),
+                &trusted_root,
+            )?;
         } else {
             // It's a file path
             let artifact_data = fs::read(&artifact_or_digest)?;
-            verify_with_key(&artifact_data, &bundle, &public_key, &trusted_root)?;
+            verify_with_key(
+                &artifact_data,
+                &bundle,
+                &public_key,
+                &PublicKeyVerificationPolicy::default(),
+                &trusted_root,
+            )?;
         }
 
         return Ok(());

--- a/crates/sigstore-verify/src/lib.rs
+++ b/crates/sigstore-verify/src/lib.rs
@@ -40,5 +40,6 @@ pub use sigstore_types as types;
 
 pub use error::{Error, Result};
 pub use verify::{
-    verify, verify_with_key, CertificatePolicy, VerificationPolicy, VerificationResult, Verifier,
+    verify, verify_with_key, CertificatePolicy, PublicKeyVerificationPolicy, VerificationPolicy,
+    VerificationResult, Verifier,
 };

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -3,14 +3,15 @@
 //! This module provides the main entry point for verifying Sigstore signatures.
 
 use crate::error::{Error, Result};
-use base64::Engine;
 use sigstore_bundle::validate_bundle_with_options;
 use sigstore_bundle::ValidationOptions;
 use sigstore_crypto::{parse_certificate_info, KeyAlgorithm, SigningScheme, VerificationKey};
 use sigstore_trust_root::TrustedRoot;
 
+use sigstore_types::bundle::VerificationMaterialContent;
 use sigstore_types::{
-    Artifact, Bundle, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent, Statement,
+    Artifact, Bundle, HashAlgorithm, KindVersion, Sha256Hash, Sha512Hash, SignatureContent,
+    Statement,
 };
 
 /// How the signing certificate is verified.
@@ -34,7 +35,31 @@ pub enum CertificatePolicy {
     },
 }
 
-/// Policy for verifying signatures
+/// Policy for verifying signatures made with a caller-supplied public key.
+#[derive(Debug, Clone)]
+pub struct PublicKeyVerificationPolicy {
+    /// Verify transparency log inclusion.
+    pub verify_tlog: bool,
+}
+
+impl Default for PublicKeyVerificationPolicy {
+    fn default() -> Self {
+        Self { verify_tlog: true }
+    }
+}
+
+impl PublicKeyVerificationPolicy {
+    /// Skip transparency log inclusion verification.
+    ///
+    /// WARNING: This accepts bundles without proof that the signature event
+    /// was incorporated into the log. Log-entry consistency is still checked.
+    pub fn skip_tlog_unsafe(mut self) -> Self {
+        self.verify_tlog = false;
+        self
+    }
+}
+
+/// Policy for verifying certificate-based signatures.
 #[derive(Debug, Clone)]
 pub struct VerificationPolicy {
     /// Expected identity (email or URI)
@@ -434,6 +459,17 @@ impl Verifier {
 
         Ok(result)
     }
+
+    /// Verify a managed-key bundle using a caller-supplied public key.
+    pub fn verify_with_key<'a>(
+        &self,
+        artifact: impl Into<Artifact<'a>>,
+        bundle: &Bundle,
+        public_key: &sigstore_types::DerPublicKey,
+        policy: &PublicKeyVerificationPolicy,
+    ) -> Result<VerificationResult> {
+        verify_with_key(artifact, bundle, public_key, policy, &self.trusted_root)
+    }
 }
 
 fn compute_artifact_digest_algo(artifact: &Artifact<'_>, algo: HashAlgorithm) -> Result<Vec<u8>> {
@@ -679,26 +715,6 @@ fn public_key_algorithm(public_key: &sigstore_types::DerPublicKey) -> Result<Key
     }
 }
 
-fn verify_public_key_hint(hint: &str, public_key: &sigstore_types::DerPublicKey) -> Result<()> {
-    let expected = sigstore_crypto::sha256(public_key.as_bytes());
-    let decoded = base64::engine::general_purpose::STANDARD
-        .decode(hint)
-        .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(hint))
-        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(hint))
-        .or_else(|_| base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(hint))
-        .map_err(|_| {
-            Error::Verification("public key hint is not a supported SHA-256 key hint".to_string())
-        })?;
-
-    if decoded != expected.as_bytes() {
-        return Err(Error::Verification(
-            "public key hint does not match supplied public key".to_string(),
-        ));
-    }
-
-    Ok(())
-}
-
 /// Verify an artifact against a bundle using a provided public key
 ///
 /// This is used for managed key verification where the bundle contains a public key
@@ -713,7 +729,7 @@ fn verify_public_key_hint(hint: &str, public_key: &sigstore_types::DerPublicKey)
 /// # Example
 ///
 /// ```no_run
-/// use sigstore_verify::verify_with_key;
+/// use sigstore_verify::{verify_with_key, PublicKeyVerificationPolicy};
 /// use sigstore_trust_root::TrustedRoot;
 /// use sigstore_types::{Bundle, DerPublicKey};
 ///
@@ -725,7 +741,13 @@ fn verify_public_key_hint(hint: &str, public_key: &sigstore_types::DerPublicKey)
 /// let key_pem = std::fs::read_to_string("key.pub")?;
 /// let public_key = DerPublicKey::from_pem(&key_pem)?;
 ///
-/// verify_with_key(&artifact, &bundle, &public_key, &trusted_root)?;
+/// verify_with_key(
+///     &artifact,
+///     &bundle,
+///     &public_key,
+///     &PublicKeyVerificationPolicy::default(),
+///     &trusted_root,
+/// )?;
 /// # Ok(())
 /// # }
 /// ```
@@ -733,21 +755,25 @@ pub fn verify_with_key<'a>(
     artifact: impl Into<Artifact<'a>>,
     bundle: &Bundle,
     public_key: &sigstore_types::DerPublicKey,
+    policy: &PublicKeyVerificationPolicy,
     trusted_root: &TrustedRoot,
 ) -> Result<VerificationResult> {
-    let artifact = artifact.into();
-    let result = VerificationResult::new();
-
-    if let sigstore_types::bundle::VerificationMaterialContent::PublicKey { hint } =
-        &bundle.verification_material.content
-    {
-        verify_public_key_hint(hint, public_key)?;
+    if !matches!(
+        &bundle.verification_material.content,
+        VerificationMaterialContent::PublicKey { .. }
+    ) {
+        return Err(Error::Verification(
+            "bundle contains a certificate but public-key verification was requested".to_string(),
+        ));
     }
+
+    let artifact = artifact.into();
+    let mut result = VerificationResult::new();
 
     // Validate bundle structure (structural only; the cryptographic checks
     // follow below)
     let options = ValidationOptions {
-        require_inclusion_proof: true,
+        require_inclusion_proof: policy.verify_tlog,
         require_timestamp: false,
     };
     validate_bundle_with_options(bundle, &options)
@@ -757,9 +783,25 @@ pub fn verify_with_key<'a>(
     let signing_scheme = signing_scheme_for_content(key_algorithm, &bundle.content)?;
 
     // Verify transparency log entries (Merkle inclusion proofs, checkpoints,
-    // SETs) without certificate time validation
-    for entry in &bundle.verification_material.tlog_entries {
-        crate::verify_impl::tlog::verify_entry_inclusion(entry, trusted_root)?;
+    // SETs) without certificate time validation.
+    if policy.verify_tlog {
+        for entry in &bundle.verification_material.tlog_entries {
+            crate::verify_impl::tlog::verify_entry_inclusion(entry, trusted_root)?;
+
+            let is_rekor_v1 = matches!(
+                entry.kind_version,
+                KindVersion::HashedRekordV001 | KindVersion::DsseV001 | KindVersion::IntotoV002
+            );
+            if is_rekor_v1 && entry.inclusion_promise.is_some() {
+                if let Some(time) = entry.integrated_time {
+                    crate::verify_impl::tlog::validate_integrated_time_not_in_future(
+                        time,
+                        jiff::Timestamp::now(),
+                    )?;
+                    result.integrated_time = Some(time);
+                }
+            }
+        }
     }
 
     // Verify the signature
@@ -809,24 +851,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn public_key_hint_accepts_all_protojson_base64_variants() {
-        let key = sigstore_types::DerPublicKey::from_bytes(b"test public key");
-        let digest = sigstore_crypto::sha256(key.as_bytes());
-        for hint in [
-            base64::engine::general_purpose::STANDARD.encode(digest),
-            base64::engine::general_purpose::STANDARD_NO_PAD.encode(digest),
-            base64::engine::general_purpose::URL_SAFE.encode(digest),
-            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest),
-        ] {
-            verify_public_key_hint(&hint, &key).unwrap();
-        }
-
-        // Prefixes are not part of the protobuf field's encoding.
-        let prefixed = format!(
-            "sha256:{}",
-            base64::engine::general_purpose::STANDARD.encode(digest)
+    fn public_key_policy_defaults_to_tlog_verification() {
+        assert!(PublicKeyVerificationPolicy::default().verify_tlog);
+        assert!(
+            !PublicKeyVerificationPolicy::default()
+                .skip_tlog_unsafe()
+                .verify_tlog
         );
-        assert!(verify_public_key_hint(&prefixed, &key).is_err());
     }
 
     #[test]

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -63,13 +63,7 @@ fn validate_integrated_time(
     not_before: jiff::Timestamp,
     not_after: jiff::Timestamp,
 ) -> Result<()> {
-    // Check that integrated time is not in the future
-    if time > now {
-        return Err(Error::Verification(format!(
-            "integrated time {} is in the future (current time: {})",
-            time, now
-        )));
-    }
+    validate_integrated_time_not_in_future(time, now)?;
 
     // Check that integrated time is within certificate validity period
     if time < not_before {
@@ -86,6 +80,19 @@ fn validate_integrated_time(
         )));
     }
 
+    Ok(())
+}
+
+pub(crate) fn validate_integrated_time_not_in_future(
+    time: jiff::Timestamp,
+    now: jiff::Timestamp,
+) -> Result<()> {
+    if time > now {
+        return Err(Error::Verification(format!(
+            "integrated time {} is in the future (current time: {})",
+            time, now
+        )));
+    }
     Ok(())
 }
 

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -6,7 +6,7 @@ use sigstore_trust_root::{SigstoreInstance, TrustedRoot, SIGSTORE_PRODUCTION_TRU
 use sigstore_types::{ArtifactDigest, DigestBytes, HashAlgorithm, LogIndex, Sha256Hash};
 use sigstore_verify::bundle::{validate_bundle, validate_bundle_with_options, ValidationOptions};
 use sigstore_verify::types::Bundle;
-use sigstore_verify::{verify, VerificationPolicy, Verifier};
+use sigstore_verify::{verify, PublicKeyVerificationPolicy, VerificationPolicy, Verifier};
 use x509_cert::der::Decode;
 
 /// Extract the expected artifact digest from a bundle
@@ -1362,108 +1362,83 @@ fn managed_key_public_key() -> sigstore_types::DerPublicKey {
 }
 
 #[test]
-fn test_verify_with_key_validates_public_key_hint() {
+fn test_verify_with_key_treats_public_key_hint_as_opaque() {
     use sigstore_verify::verify_with_key;
 
-    let mut json: serde_json::Value = serde_json::from_str(MANAGED_KEY_BUNDLE).unwrap();
-    json["verificationMaterial"]["publicKey"]["hint"] =
-        serde_json::json!("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    let bundle = Bundle::from_json(&serde_json::to_string(&json).unwrap()).unwrap();
-    let public_key = managed_key_public_key();
+    for hint in [
+        "opaque-key-name",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    ] {
+        let mut json: serde_json::Value = serde_json::from_str(MANAGED_KEY_BUNDLE).unwrap();
+        json["verificationMaterial"]["publicKey"]["hint"] = serde_json::json!(hint);
+        let bundle = Bundle::from_json(&serde_json::to_string(&json).unwrap()).unwrap();
+        let result = verify_with_key(
+            MANAGED_KEY_ARTIFACT,
+            &bundle,
+            &managed_key_public_key(),
+            &PublicKeyVerificationPolicy::default(),
+            &production_root(),
+        );
 
-    let result = verify_with_key(
+        assert!(
+            result.is_ok(),
+            "opaque hint {hint:?} was rejected: {result:?}"
+        );
+    }
+}
+
+#[test]
+fn test_verifier_with_key_accepts_digest_and_reports_integrated_time() {
+    let bundle = Bundle::from_json(MANAGED_KEY_BUNDLE).unwrap();
+    let expected_time = bundle.verification_material.tlog_entries[0].integrated_time;
+    let verifier = Verifier::new(&production_root());
+
+    let result = verifier
+        .verify_with_key(
+            sigstore_crypto::sha256(MANAGED_KEY_ARTIFACT),
+            &bundle,
+            &managed_key_public_key(),
+            &PublicKeyVerificationPolicy::default(),
+        )
+        .unwrap();
+
+    assert_eq!(result.integrated_time, expected_time);
+}
+
+#[test]
+fn test_verify_with_key_can_skip_tlog_inclusion() {
+    use sigstore_verify::verify_with_key;
+
+    let mut bundle = Bundle::from_json(MANAGED_KEY_BUNDLE).unwrap();
+    bundle.verification_material.tlog_entries[0].inclusion_proof = None;
+
+    verify_with_key(
         MANAGED_KEY_ARTIFACT,
         &bundle,
-        &public_key,
+        &managed_key_public_key(),
+        &PublicKeyVerificationPolicy::default().skip_tlog_unsafe(),
         &production_root(),
-    );
-
-    assert!(result.is_err());
-    assert!(result
-        .err()
-        .unwrap()
-        .to_string()
-        .contains("public key hint does not match supplied public key"));
+    )
+    .unwrap();
 }
 
 #[test]
-fn test_verify_with_key_accepts_managed_key_bundle_digest_only() {
+fn test_verify_with_key_rejects_certificate_bundle() {
     use sigstore_verify::verify_with_key;
 
-    let bundle = Bundle::from_json(MANAGED_KEY_BUNDLE).unwrap();
-    let public_key = managed_key_public_key();
-    let digest = sigstore_crypto::sha256(MANAGED_KEY_ARTIFACT);
-
-    let result = verify_with_key(digest, &bundle, &public_key, &production_root());
-
-    assert!(
-        result.is_ok(),
-        "managed-key digest-only verification failed: {:?}",
-        result.err()
-    );
-}
-
-#[test]
-fn test_verify_dsse_with_key_fails_with_tampered_artifact() {
-    use sigstore_verify::verify_with_key;
-
-    let bundle =
-        Bundle::from_json(CONDA_ATTESTATION_BUNDLE).expect("Failed to parse conda attestation");
-
-    // Extract the public key from the signing certificate inside the bundle
-    let cert = bundle
-        .signing_certificate()
-        .expect("Should have a signing certificate");
-    let cert_info = sigstore_crypto::parse_certificate_info(cert.as_bytes())
-        .expect("Failed to parse certificate info");
-    let public_key = cert_info.public_key;
-
-    // Use a completely different/tampered package content
-    let tampered_package = b"this is not the original package content";
-
-    // Verify using key-based verification. This should fail because the tampered package
-    // does not match the subject in the in-toto statement payload of the DSSE envelope.
-    let result = verify_with_key(
-        tampered_package.as_slice(),
-        &bundle,
-        &public_key,
-        &production_root(),
-    );
-
-    assert!(
-        result.is_err(),
-        "Key-based verification of DSSE envelope must fail when artifact does not match the payload subjects. Result was: {:?}",
-        result
-    );
-}
-
-/// Key-based verification of an untampered DSSE bundle succeeds, including
-/// the transparency log consistency checks.
-#[test]
-fn test_verify_dsse_with_key_succeeds_with_correct_artifact() {
-    use sigstore_verify::verify_with_key;
-
-    let bundle =
-        Bundle::from_json(CONDA_ATTESTATION_BUNDLE).expect("Failed to parse conda attestation");
-
-    let cert = bundle
-        .signing_certificate()
-        .expect("Should have a signing certificate");
-    let cert_info = sigstore_crypto::parse_certificate_info(cert.as_bytes())
-        .expect("Failed to parse certificate info");
-
+    let bundle = Bundle::from_json(CONDA_ATTESTATION_BUNDLE).unwrap();
     let result = verify_with_key(
         CONDA_PACKAGE,
         &bundle,
-        &cert_info.public_key,
+        &managed_key_public_key(),
+        &PublicKeyVerificationPolicy::default(),
         &production_root(),
     );
 
-    assert!(
-        result.is_ok(),
-        "Key-based verification of untampered DSSE bundle should succeed: {:?}",
-        result.err()
-    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("bundle contains a certificate but public-key verification was requested"));
 }
 
 /// verify_with_key must reject bundles whose transparency log entry disagrees


### PR DESCRIPTION
## Summary
- reject certificate-backed bundles when caller-supplied public-key verification is requested
- treat `publicKey.hint` as the opaque, implementation-defined identifier specified by protobuf-specs; the signature establishes whether the supplied key is correct
- give managed-key verification its own policy, including an explicit unsafe opt-out from transparency-log inclusion verification
- expose managed-key verification through both the free function and `Verifier`
- report authenticated Rekor v1 integrated times and reject future timestamps
- replace the stale verification refactor with a focused change on current `main`

## Tests
- `cargo test -p sigstore-verify --all-targets`
- `cargo clippy --all-targets -p sigstore-verify -p sigstore-conformance -- -D warnings`
