### PR TITLE
ci: run conformance weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "17 5 * * 1"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Run CI weekly so the `conformance-results` artifact is refreshed before its 7-day retention period expires.

This keeps sigstore-rust represented in the nightly conformance report even when `main` has no recent pushes.