### PR TITLE
fix(verify)!: remove clock skew, and use `jiff` Timestamp in the interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,7 @@ version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
+ "jiff",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -1907,6 +1908,7 @@ dependencies = [
  "der",
  "digest",
  "hex",
+ "jiff",
  "pem",
  "rand_core 0.9.5",
  "sha2",
@@ -1974,6 +1976,7 @@ version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
+ "jiff",
  "reqwest",
  "serde",
  "serde_json",
@@ -2081,6 +2084,7 @@ version = "0.11.0"
 dependencies = [
  "base64",
  "hex",
+ "jiff",
  "pem",
  "serde",
  "serde_json",

--- a/crates/sigstore-bundle/Cargo.toml
+++ b/crates/sigstore-bundle/Cargo.toml
@@ -19,6 +19,7 @@ sigstore-tsa = { workspace = true, default-features = false }
 sigstore-rekor = { workspace = true, default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
+jiff = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }

--- a/crates/sigstore-bundle/src/builder.rs
+++ b/crates/sigstore-bundle/src/builder.rs
@@ -137,7 +137,7 @@ pub struct TlogEntryBuilder {
     log_id: String,
     kind: String,
     kind_version: String,
-    integrated_time: i64,
+    integrated_time: Option<jiff::Timestamp>,
     canonicalized_body: Vec<u8>,
     inclusion_promise: Option<InclusionPromise>,
     inclusion_proof: Option<InclusionProof>,
@@ -151,7 +151,7 @@ impl TlogEntryBuilder {
             log_id: String::new(),
             kind: "hashedrekord".to_string(),
             kind_version: "0.0.1".to_string(),
-            integrated_time: 0,
+            integrated_time: None,
             canonicalized_body: Vec::new(),
             inclusion_promise: None,
             inclusion_proof: None,
@@ -227,9 +227,9 @@ impl TlogEntryBuilder {
         self
     }
 
-    /// Set the integrated time (Unix timestamp).
-    pub fn integrated_time(mut self, time: i64) -> Self {
-        self.integrated_time = time;
+    /// Set the integrated time.
+    pub fn integrated_time(mut self, time: jiff::Timestamp) -> Self {
+        self.integrated_time = Some(time);
         self
     }
 

--- a/crates/sigstore-bundle/tests/bundle_v3_tests.rs
+++ b/crates/sigstore-bundle/tests/bundle_v3_tests.rs
@@ -74,7 +74,10 @@ fn test_parse_v3_bundle() {
     assert_eq!(bundle.verification_material.tlog_entries.len(), 1);
     let entry = &bundle.verification_material.tlog_entries[0];
     assert_eq!(entry.log_index, LogIndex::new(25915956));
-    assert_eq!(entry.integrated_time, 1712085549);
+    assert_eq!(
+        entry.integrated_time,
+        Some(jiff::Timestamp::from_second(1712085549).unwrap())
+    );
     assert_eq!(entry.kind_version.kind, "hashedrekord");
     assert_eq!(entry.kind_version.version, "0.0.1");
 

--- a/crates/sigstore-crypto/Cargo.toml
+++ b/crates/sigstore-crypto/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = { workspace = true }
 base64 = { workspace = true }
 pem = { workspace = true }
 x509-cert = { workspace = true }
+jiff = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sigstore-crypto/src/x509.rs
+++ b/crates/sigstore-crypto/src/x509.rs
@@ -25,10 +25,10 @@ pub struct CertificateInfo {
     pub identity: Option<String>,
     /// Issuer from certificate (OIDC issuer URL from Fulcio extension)
     pub issuer: Option<String>,
-    /// Not valid before (Unix timestamp)
-    pub not_before: i64,
-    /// Not valid after (Unix timestamp)
-    pub not_after: i64,
+    /// Not valid before
+    pub not_before: jiff::Timestamp,
+    /// Not valid after
+    pub not_after: jiff::Timestamp,
     /// Public key in DER-encoded SPKI format
     pub public_key: DerPublicKey,
     /// Key algorithm derived from the public key algorithm
@@ -41,18 +41,12 @@ pub fn parse_certificate_info(cert_der: &[u8]) -> Result<CertificateInfo> {
         .map_err(|e| Error::InvalidCertificate(format!("failed to parse certificate: {}", e)))?;
 
     // Extract validity times
-    let not_before = cert
-        .tbs_certificate
-        .validity
-        .not_before
-        .to_unix_duration()
-        .as_secs() as i64;
-    let not_after = cert
-        .tbs_certificate
-        .validity
-        .not_after
-        .to_unix_duration()
-        .as_secs() as i64;
+    let not_before =
+        jiff::Timestamp::try_from(cert.tbs_certificate.validity.not_before.to_system_time())
+            .map_err(|e| Error::InvalidCertificate(format!("invalid notBefore time: {}", e)))?;
+    let not_after =
+        jiff::Timestamp::try_from(cert.tbs_certificate.validity.not_after.to_system_time())
+            .map_err(|e| Error::InvalidCertificate(format!("invalid notAfter time: {}", e)))?;
 
     // Extract public key in SPKI (SubjectPublicKeyInfo) DER format
     // This is required by aws-lc-rs UnparsedPublicKey, which expects the full SPKI,

--- a/crates/sigstore-rekor/Cargo.toml
+++ b/crates/sigstore-rekor/Cargo.toml
@@ -20,6 +20,7 @@ sigstore-merkle = { workspace = true }
 sigstore-cache = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+jiff = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/sigstore-rekor/src/client.rs
+++ b/crates/sigstore-rekor/src/client.rs
@@ -232,7 +232,13 @@ impl RekorClient {
 
         // Convert V2 entry to LogEntry
         let log_index = entry_v2.log_index.parse::<i64>().unwrap_or_default();
-        let integrated_time = entry_v2.integrated_time.parse::<i64>().unwrap_or_default();
+        // Rekor V2 entries have no integrated time; the field is "0" when absent.
+        let integrated_time = entry_v2
+            .integrated_time
+            .parse::<i64>()
+            .ok()
+            .filter(|&t| t != 0)
+            .and_then(|t| jiff::Timestamp::from_second(t).ok());
 
         let verification = Some(crate::entry::Verification {
             inclusion_proof: entry_v2
@@ -322,7 +328,13 @@ impl RekorClient {
 
         // Convert V2 entry to LogEntry
         let log_index = entry_v2.log_index.parse::<i64>().unwrap_or_default();
-        let integrated_time = entry_v2.integrated_time.parse::<i64>().unwrap_or_default();
+        // Rekor V2 entries have no integrated time; the field is "0" when absent.
+        let integrated_time = entry_v2
+            .integrated_time
+            .parse::<i64>()
+            .ok()
+            .filter(|&t| t != 0)
+            .and_then(|t| jiff::Timestamp::from_second(t).ok());
 
         let verification = Some(crate::entry::Verification {
             inclusion_proof: entry_v2

--- a/crates/sigstore-rekor/src/entry.rs
+++ b/crates/sigstore-rekor/src/entry.rs
@@ -48,8 +48,14 @@ pub struct LogEntry {
     pub uuid: EntryUuid,
     /// Body of the entry (base64 encoded canonicalized body)
     pub body: CanonicalizedBody,
-    /// Integrated time (Unix timestamp)
-    pub integrated_time: i64,
+    /// Integrated time. Always present in Rekor V1 API responses; `None` for
+    /// entries converted from the V2 API, which has no integrated time.
+    #[serde(
+        default,
+        with = "jiff::fmt::serde::timestamp::second::optional",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub integrated_time: Option<jiff::Timestamp>,
     /// Log ID (hex-encoded SHA-256 of the log's public key)
     #[serde(rename = "logID")]
     pub log_id: HexLogId,

--- a/crates/sigstore-sign/examples/sign_attestation.rs
+++ b/crates/sigstore-sign/examples/sign_attestation.rs
@@ -218,14 +218,9 @@ async fn main() {
             entry.kind_version.kind, entry.kind_version.version
         );
         println!("  Log Index: {}", entry.log_index);
-        let ts = entry.integrated_time;
-        if ts == 0 {
-            println!("  Integrated Time: (uses RFC3161 timestamps)");
-        } else {
-            use jiff::Timestamp;
-            if let Ok(dt) = Timestamp::from_second(ts) {
-                println!("  Integrated Time: {}", dt);
-            }
+        match entry.integrated_time {
+            Some(dt) => println!("  Integrated Time: {}", dt),
+            None => println!("  Integrated Time: (uses RFC3161 timestamps)"),
         }
     }
 

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -219,15 +219,10 @@ async fn main() {
             entry.kind_version.kind, entry.kind_version.version
         );
         println!("  Log Index: {}", entry.log_index);
-        // For V2, integrated_time is always 0 - RFC3161 timestamps are used instead
-        let ts = entry.integrated_time;
-        if ts == 0 && entry.kind_version.version == "0.0.2" {
-            println!("  Integrated Time: (V2 uses RFC3161 timestamps)");
-        } else {
-            use jiff::Timestamp;
-            if let Ok(dt) = Timestamp::from_second(ts) {
-                println!("  Integrated Time: {}", dt);
-            }
+        // For V2, integrated_time is absent - RFC3161 timestamps are used instead
+        match entry.integrated_time {
+            Some(dt) => println!("  Integrated Time: {}", dt),
+            None => println!("  Integrated Time: (V2 uses RFC3161 timestamps)"),
         }
         // Show if we have inclusion proof (V2) vs just promise (V1)
         if entry.inclusion_proof.is_some() {

--- a/crates/sigstore-types/Cargo.toml
+++ b/crates/sigstore-types/Cargo.toml
@@ -12,6 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
+jiff = { workspace = true }
 thiserror = { workspace = true }
 pem = { workspace = true }
 

--- a/crates/sigstore-types/src/bundle.rs
+++ b/crates/sigstore-types/src/bundle.rs
@@ -7,8 +7,8 @@
 use crate::checkpoint::Checkpoint;
 use crate::dsse::DsseEnvelope;
 use crate::encoding::{
-    string_i64, CanonicalizedBody, DerCertificate, DigestBytes, LogIndex, LogKeyId, Sha256Hash,
-    SignatureBytes, SignedTimestamp, TimestampToken,
+    string_i64, string_timestamp_opt, CanonicalizedBody, DerCertificate, DigestBytes, LogIndex,
+    LogKeyId, Sha256Hash, SignatureBytes, SignedTimestamp, TimestampToken,
 };
 use crate::error::{Error, Result};
 use crate::hash::HashAlgorithm;
@@ -23,11 +23,6 @@ where
 {
     let opt = Option::deserialize(deserializer)?;
     Ok(opt.unwrap_or_default())
-}
-
-/// Helper for skip_serializing_if to check if i64 is zero
-fn is_zero(value: &i64) -> bool {
-    *value == 0
 }
 
 /// Sigstore bundle media types
@@ -239,10 +234,15 @@ pub struct TransparencyLogEntry {
     pub log_id: LogId,
     /// Kind and version of the entry
     pub kind_version: KindVersion,
-    /// Integrated time (Unix timestamp)
-    /// For Rekor V2 entries, this field may be omitted (defaults to 0)
-    #[serde(default, with = "string_i64", skip_serializing_if = "is_zero")]
-    pub integrated_time: i64,
+    /// Integrated time. `None` for Rekor V2 entries, which omit the field
+    /// (or set it to 0, indistinguishable from absent per proto3) and use
+    /// RFC 3161 timestamps instead.
+    #[serde(
+        default,
+        with = "string_timestamp_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub integrated_time: Option<jiff::Timestamp>,
     /// Inclusion promise (Signed Entry Timestamp)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inclusion_promise: Option<InclusionPromise>,

--- a/crates/sigstore-types/src/encoding.rs
+++ b/crates/sigstore-types/src/encoding.rs
@@ -114,6 +114,41 @@ pub mod string_i64 {
     }
 }
 
+/// Serde helper for optional timestamps serialized as string-encoded Unix
+/// seconds (protobuf JSON `int64`).
+///
+/// Proto3 semantics make `0` and "absent" indistinguishable, so both map to
+/// `None`. Any other value must be representable as a `jiff::Timestamp`, or
+/// deserialization fails: an unrepresentable timestamp is rejected at parse
+/// time instead of being carried around as a raw integer.
+pub mod string_timestamp_opt {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(value: &Option<jiff::Timestamp>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let seconds = value.map_or(0, |ts| ts.as_second());
+        serializer.serialize_str(&seconds.to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<jiff::Timestamp>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let seconds = s
+            .parse::<i64>()
+            .map_err(|_| serde::de::Error::custom(format!("invalid integer: {}", s)))?;
+        if seconds == 0 {
+            return Ok(None);
+        }
+        jiff::Timestamp::from_second(seconds)
+            .map(Some)
+            .map_err(|e| serde::de::Error::custom(format!("invalid timestamp {}: {}", seconds, e)))
+    }
+}
+
 // ============================================================================
 // Macro for creating base64-encoded newtype wrappers
 // ============================================================================

--- a/crates/sigstore-types/src/lib.rs
+++ b/crates/sigstore-types/src/lib.rs
@@ -21,7 +21,8 @@ pub use bundle::{
 pub use checkpoint::{Checkpoint, CheckpointSignature};
 pub use dsse::{pae, DsseEnvelope, DsseSignature};
 pub use encoding::{
-    base64_bytes, base64_bytes_option, hex_bytes, string_i64, CanonicalizedBody, DerCertificate,
+    base64_bytes, base64_bytes_option, hex_bytes, string_i64, string_timestamp_opt,
+    CanonicalizedBody, DerCertificate,
     DerPublicKey, DigestBytes, EntryUuid, HexHash, HexLogId, KeyHint, KeyId, LogIndex, LogKeyId,
     PayloadBytes, PemContent, Sha256Hash, SignatureBytes, SignedTimestamp, TimestampToken,
 };

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -268,10 +268,7 @@ async fn main() {
                 println!("  Issuer: {}", iss);
             }
             if let Some(time) = result.integrated_time {
-                use jiff::Timestamp;
-                if let Ok(dt) = Timestamp::from_second(time) {
-                    println!("  Signed at: {}", dt);
-                }
+                println!("  Signed at: {}", time);
             }
             for warning in &result.warnings {
                 println!("  Warning: {}", warning);

--- a/crates/sigstore-verify/examples/verify_conda_attestation.rs
+++ b/crates/sigstore-verify/examples/verify_conda_attestation.rs
@@ -154,10 +154,7 @@ async fn main() {
                 println!("  OIDC Issuer: {}", iss);
             }
             if let Some(time) = result.integrated_time {
-                use jiff::Timestamp;
-                if let Ok(dt) = Timestamp::from_second(time) {
-                    println!("  Signed at: {}", dt);
-                }
+                println!("  Signed at: {}", time);
             }
             for warning in &result.warnings {
                 println!();

--- a/crates/sigstore-verify/src/lib.rs
+++ b/crates/sigstore-verify/src/lib.rs
@@ -41,5 +41,4 @@ pub use sigstore_types as types;
 pub use error::{Error, Result};
 pub use verify::{
     verify, verify_with_key, CertificatePolicy, VerificationPolicy, VerificationResult, Verifier,
-    DEFAULT_CLOCK_SKEW_SECONDS,
 };

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -13,9 +13,6 @@ use sigstore_trust_root::TrustedRoot;
 
 use sigstore_types::{Artifact, Bundle, HashAlgorithm, SignatureContent, Statement};
 
-/// Default clock skew tolerance in seconds (60 seconds = 1 minute)
-pub const DEFAULT_CLOCK_SKEW_SECONDS: i64 = 60;
-
 /// How the signing certificate is verified.
 ///
 /// SCT verification depends on the issuer identified while verifying the
@@ -56,11 +53,6 @@ pub struct VerificationPolicy {
     pub verify_tlog: bool,
     /// How the signing certificate (and its SCT) is verified
     pub certificate: CertificatePolicy,
-    /// Clock skew tolerance in seconds for time validation
-    ///
-    /// This allows for a tolerance when checking that integrated times
-    /// are not in the future. Default is 60 seconds.
-    pub clock_skew_seconds: i64,
 }
 
 impl Default for VerificationPolicy {
@@ -70,7 +62,6 @@ impl Default for VerificationPolicy {
             issuer: None,
             verify_tlog: true,
             certificate: CertificatePolicy::Verify { verify_sct: true },
-            clock_skew_seconds: DEFAULT_CLOCK_SKEW_SECONDS,
         }
     }
 }
@@ -150,15 +141,6 @@ impl VerificationPolicy {
         if let CertificatePolicy::Verify { verify_sct } = &mut self.certificate {
             *verify_sct = false;
         }
-        self
-    }
-
-    /// Set the clock skew tolerance in seconds
-    ///
-    /// This allows for a tolerance when checking that integrated times
-    /// are not in the future. Default is 60 seconds.
-    pub fn with_clock_skew_seconds(mut self, seconds: i64) -> Self {
-        self.clock_skew_seconds = seconds;
         self
     }
 }
@@ -398,7 +380,6 @@ impl Verifier {
                 &self.trusted_root,
                 cert_info.not_before,
                 cert_info.not_after,
-                policy.clock_skew_seconds,
             )?;
 
             if let Some(time) = integrated_time {

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -157,7 +157,7 @@ pub struct VerificationResult {
     /// Issuer from the certificate
     pub issuer: Option<String>,
     /// Integrated time from transparency log
-    pub integrated_time: Option<i64>,
+    pub integrated_time: Option<jiff::Timestamp>,
     /// Any warnings during verification
     pub warnings: Vec<String>,
 }

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -222,8 +222,11 @@ fn validate_integrated_time(entry: &TransparencyLogEntry, bundle: &Bundle) -> Re
         let bundle_cert_der = bundle_cert.as_bytes();
 
         // Only validate integrated time for hashedrekord 0.0.1
-        // For 0.0.2 (Rekor v2), integrated_time is not present (0)
-        if entry.kind_version.version == "0.0.1" && entry.integrated_time != 0 {
+        // For 0.0.2 (Rekor v2), integrated_time is not present
+        let v1_integrated_time = entry
+            .integrated_time
+            .filter(|_| entry.kind_version.version == "0.0.1");
+        if let Some(integrated_time) = v1_integrated_time {
             let cert = Certificate::from_der(bundle_cert_der).map_err(|e| {
                 Error::Verification(format!(
                     "failed to parse certificate for time validation: {}",
@@ -231,25 +234,13 @@ fn validate_integrated_time(entry: &TransparencyLogEntry, bundle: &Bundle) -> Re
                 ))
             })?;
 
-            // Convert certificate validity times to Unix timestamps
-            use std::time::UNIX_EPOCH;
-            let not_before_system = cert.tbs_certificate.validity.not_before.to_system_time();
-            let not_after_system = cert.tbs_certificate.validity.not_after.to_system_time();
-
-            let not_before = not_before_system
-                .duration_since(UNIX_EPOCH)
-                .map_err(|e| {
-                    Error::Verification(format!("failed to convert notBefore to Unix time: {}", e))
-                })?
-                .as_secs() as i64;
-            let not_after = not_after_system
-                .duration_since(UNIX_EPOCH)
-                .map_err(|e| {
-                    Error::Verification(format!("failed to convert notAfter to Unix time: {}", e))
-                })?
-                .as_secs() as i64;
-
-            let integrated_time = entry.integrated_time;
+            let not_before = jiff::Timestamp::try_from(
+                cert.tbs_certificate.validity.not_before.to_system_time(),
+            )
+            .map_err(|e| Error::Verification(format!("invalid notBefore time: {}", e)))?;
+            let not_after =
+                jiff::Timestamp::try_from(cert.tbs_certificate.validity.not_after.to_system_time())
+                    .map_err(|e| Error::Verification(format!("invalid notAfter time: {}", e)))?;
 
             if integrated_time < not_before || integrated_time > not_after {
                 return Err(Error::Verification(format!(

--- a/crates/sigstore-verify/src/verify_impl/helpers.rs
+++ b/crates/sigstore-verify/src/verify_impl/helpers.rs
@@ -53,7 +53,7 @@ pub fn extract_tsa_timestamps(
     bundle: &Bundle,
     signature_bytes: &[u8],
     trusted_root: &TrustedRoot,
-) -> Result<Vec<i64>> {
+) -> Result<Vec<jiff::Timestamp>> {
     use sigstore_tsa::{verify_timestamp_response, VerifyOpts as TsaVerifyOpts};
 
     let mut timestamps = Vec::new();
@@ -105,14 +105,14 @@ pub fn extract_tsa_timestamps(
             )));
         }
 
-        timestamps.push(result.time.as_second());
+        timestamps.push(result.time);
     }
 
     Ok(timestamps)
 }
 
 /// Check if bundle contains V2 tlog entries (hashedrekord/dsse v0.0.2)
-/// V2 entries have integrated_time=0 and require RFC3161 timestamps
+/// V2 entries have no integrated time and require RFC3161 timestamps
 pub fn has_v2_tlog_entries(bundle: &Bundle) -> bool {
     bundle
         .verification_material
@@ -126,7 +126,7 @@ pub fn has_v2_tlog_entries(bundle: &Bundle) -> bool {
 /// Per sigstore-python, integrated_time is only valid as a timestamp source when:
 /// 1. The entry has an inclusion_promise (SET) that cryptographically binds it
 /// 2. The entry is a V1 type (hashedrekord/dsse v0.0.1)
-/// 3. The integrated_time is > 0
+/// 3. The entry carries an integrated time
 ///
 /// The SET is verified here, before the integrated time is trusted: the SET
 /// signature covers `integratedTime`, so this is what authenticates the
@@ -139,7 +139,7 @@ pub fn has_v2_tlog_entries(bundle: &Bundle) -> bool {
 fn extract_v1_integrated_times_with_promise(
     bundle: &Bundle,
     trusted_root: &TrustedRoot,
-) -> Result<Vec<i64>> {
+) -> Result<Vec<jiff::Timestamp>> {
     let mut times = Vec::new();
 
     for entry in &bundle.verification_material.tlog_entries {
@@ -151,8 +151,7 @@ fn extract_v1_integrated_times_with_promise(
             continue;
         }
 
-        let time = entry.integrated_time;
-        if time > 0 {
+        if let Some(time) = entry.integrated_time {
             crate::verify_impl::tlog::verify_set(entry, trusted_root)?;
             times.push(time);
         }
@@ -192,7 +191,7 @@ pub fn determine_validation_times(
     bundle: &Bundle,
     signature: &SignatureBytes,
     trusted_root: &TrustedRoot,
-) -> Result<Vec<i64>> {
+) -> Result<Vec<jiff::Timestamp>> {
     let mut times = extract_tsa_timestamps(bundle, signature.as_bytes(), trusted_root)?;
     times.extend(extract_v1_integrated_times_with_promise(
         bundle,
@@ -209,21 +208,24 @@ pub fn determine_validation_times(
     if is_v2 {
         Err(Error::Verification(
             "V2 bundle requires RFC3161 timestamp but none could be verified. \
-             V2 tlog entries have integrated_time=0 by design. \
+             V2 tlog entries have no integrated time by design. \
              Ensure TSA certificates are present in the trusted root."
                 .to_string(),
         ))
     } else {
         Err(Error::Verification(
             "No verified timestamp found. V1 bundles require either an RFC3161 timestamp \
-             or a tlog entry with both integrated_time > 0 and an inclusion_promise (SET)."
+             or a tlog entry with both an integrated time and an inclusion_promise (SET)."
                 .to_string(),
         ))
     }
 }
 
 /// Validate certificate is within validity period
-pub fn validate_certificate_time(validation_time: i64, cert_info: &CertificateInfo) -> Result<()> {
+pub fn validate_certificate_time(
+    validation_time: jiff::Timestamp,
+    cert_info: &CertificateInfo,
+) -> Result<()> {
     if validation_time < cert_info.not_before {
         return Err(Error::Verification(format!(
             "certificate not yet valid: validation time {} is before not_before {}",
@@ -254,7 +256,7 @@ pub fn validate_certificate_time(validation_time: i64, cert_info: &CertificateIn
 /// have different keys (as in Sigstore staging's multi-region deployment).
 pub fn verify_certificate_chain(
     verification_material: &VerificationMaterialContent,
-    validation_time: i64,
+    validation_time: jiff::Timestamp,
     trusted_root: &TrustedRoot,
 ) -> Result<DerPublicKey> {
     // Extract the end-entity certificate and any intermediates from the bundle
@@ -321,8 +323,9 @@ pub fn verify_certificate_chain(
     })?;
 
     // Convert validation time to webpki UnixTime
-    let verification_time =
-        UnixTime::since_unix_epoch(std::time::Duration::from_secs(validation_time as u64));
+    let verification_time = UnixTime::since_unix_epoch(std::time::Duration::from_secs(
+        validation_time.as_second() as u64,
+    ));
 
     // Verify the certificate chain with CODE_SIGNING EKU
     // This performs:
@@ -396,7 +399,9 @@ mod tests {
             2,
             "expected one TSA timestamp and one integratedTime, got {times:?}"
         );
-        let integrated_time = bundle.verification_material.tlog_entries[0].integrated_time;
+        let integrated_time = bundle.verification_material.tlog_entries[0]
+            .integrated_time
+            .unwrap();
         assert!(times.contains(&integrated_time));
     }
 
@@ -416,7 +421,7 @@ mod tests {
     #[test]
     fn sct_verifies_with_multiple_same_named_intermediates() {
         // The leaf's SCT timestamp / notBefore; used as the chain validation time.
-        const VALIDATION_TIME: i64 = 1_783_488_311;
+        let validation_time = jiff::Timestamp::from_second(1_783_488_311).unwrap();
 
         let trusted_root = TrustedRoot::from_json(include_str!(
             "../../test_data/sct-multi-intermediate/staging_trusted_root.json"
@@ -453,7 +458,7 @@ mod tests {
         // The canonical flow: the issuer comes from the verified chain, then SCT
         // verification uses it. Before the fix, SCT verification returned
         // Err("SCT signature verification failed: ... signature invalid").
-        let issuer_spki = verify_certificate_chain(material, VALIDATION_TIME, &trusted_root)
+        let issuer_spki = verify_certificate_chain(material, validation_time, &trusted_root)
             .expect("certificate chain should verify against the staging root");
         let cert = extract_certificate(material).unwrap();
         super::super::sct::verify_sct(cert.as_bytes(), issuer_spki.as_bytes(), &trusted_root)

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -32,20 +32,18 @@ use sigstore_types::{Bundle, SignatureBytes, TransparencyLogEntry};
 pub fn verify_tlog_entries(
     bundle: &Bundle,
     trusted_root: &TrustedRoot,
-    not_before: i64,
-    not_after: i64,
-) -> Result<Option<i64>> {
-    let mut integrated_time_result: Option<i64> = None;
+    not_before: jiff::Timestamp,
+    not_after: jiff::Timestamp,
+) -> Result<Option<jiff::Timestamp>> {
+    let mut integrated_time_result: Option<jiff::Timestamp> = None;
 
     for entry in &bundle.verification_material.tlog_entries {
         // Verify Merkle inclusion proof, checkpoint signature and SET
         verify_entry_inclusion(entry, trusted_root)?;
 
-        // Validate integrated time (0 indicates missing/invalid time in v2 entries)
-        let time = entry.integrated_time;
-        if time > 0 {
-            let now = jiff::Timestamp::now().as_second();
-            validate_integrated_time(time, now, not_before, not_after)?;
+        // Validate integrated time (absent in v2 entries, which use RFC 3161)
+        if let Some(time) = entry.integrated_time {
+            validate_integrated_time(time, jiff::Timestamp::now(), not_before, not_after)?;
             integrated_time_result = Some(time);
         }
     }
@@ -55,7 +53,12 @@ pub fn verify_tlog_entries(
 
 /// Validate an entry's integrated time: it must not be in the future and
 /// must fall within the certificate validity window.
-fn validate_integrated_time(time: i64, now: i64, not_before: i64, not_after: i64) -> Result<()> {
+fn validate_integrated_time(
+    time: jiff::Timestamp,
+    now: jiff::Timestamp,
+    not_before: jiff::Timestamp,
+    not_after: jiff::Timestamp,
+) -> Result<()> {
     // Check that integrated time is not in the future
     if time > now {
         return Err(Error::Verification(format!(
@@ -214,18 +217,10 @@ pub fn verify_set(entry: &TransparencyLogEntry, trusted_root: &TrustedRoot) -> R
         .as_ref()
         .ok_or(Error::Verification("Missing inclusion promise".into()))?;
 
-    let integrated_time = entry.integrated_time;
-
-    // Find the key for the log ID. When the entry carries a real integrated
+    // Find the key for the log ID. When the entry carries an integrated
     // time, require the log key's validity window to cover it: an entry must
     // have been integrated while the log key was valid.
-    let log_key = if integrated_time > 0 {
-        let integrated_ts = jiff::Timestamp::from_second(integrated_time).map_err(|e| {
-            Error::Verification(format!(
-                "Invalid integrated time {}: {}",
-                integrated_time, e
-            ))
-        })?;
+    let log_key = if let Some(integrated_ts) = entry.integrated_time {
         trusted_root
             .rekor_key_for_log_at(&entry.log_id.key_id, integrated_ts)
             .map_err(|e| {
@@ -255,7 +250,9 @@ pub fn verify_set(entry: &TransparencyLogEntry, trusted_root: &TrustedRoot) -> R
 
     let payload = RekorPayload {
         body,
-        integrated_time,
+        // The SET payload is wire-format Rekor V1 JSON, where "absent" is
+        // the proto3 default of 0.
+        integrated_time: entry.integrated_time.map_or(0, |ts| ts.as_second()),
         log_index,
         log_id: log_id_hex,
     };
@@ -278,19 +275,22 @@ pub fn verify_set(entry: &TransparencyLogEntry, trusted_root: &TrustedRoot) -> R
 mod tests {
     use super::*;
 
+    fn ts(seconds: i64) -> jiff::Timestamp {
+        jiff::Timestamp::from_second(seconds).unwrap()
+    }
+
     const NOW: i64 = 1_700_000_000;
-    const NOT_BEFORE: i64 = NOW - 600;
-    const NOT_AFTER: i64 = NOW + 600;
 
     #[test]
     fn test_integrated_time_in_future_rejected() {
         // Even one second in the future must be rejected.
-        let err = validate_integrated_time(NOW + 1, NOW, NOT_BEFORE, NOT_AFTER).unwrap_err();
+        let err = validate_integrated_time(ts(NOW + 1), ts(NOW), ts(NOW - 600), ts(NOW + 600))
+            .unwrap_err();
         assert!(err.to_string().contains("is in the future"));
     }
 
     #[test]
     fn test_integrated_time_at_now_accepted() {
-        assert!(validate_integrated_time(NOW, NOW, NOT_BEFORE, NOT_AFTER).is_ok());
+        assert!(validate_integrated_time(ts(NOW), ts(NOW), ts(NOW - 600), ts(NOW + 600)).is_ok());
     }
 }

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -22,20 +22,18 @@ use sigstore_types::{Bundle, SignatureBytes, TransparencyLogEntry};
 /// - the inclusion promise (SET), if present.
 ///
 /// It also validates the entry's integrated time against the certificate
-/// validity window.
+/// validity window and the current time.
 ///
 /// # Arguments
 /// * `bundle` - The bundle containing transparency log entries
 /// * `trusted_root` - Trusted root for cryptographic verification
 /// * `not_before` - Certificate validity start time (Unix timestamp)
 /// * `not_after` - Certificate validity end time (Unix timestamp)
-/// * `clock_skew_seconds` - Tolerance in seconds for future time checks
 pub fn verify_tlog_entries(
     bundle: &Bundle,
     trusted_root: &TrustedRoot,
     not_before: i64,
     not_after: i64,
-    clock_skew_seconds: i64,
 ) -> Result<Option<i64>> {
     let mut integrated_time_result: Option<i64> = None;
 
@@ -46,35 +44,42 @@ pub fn verify_tlog_entries(
         // Validate integrated time (0 indicates missing/invalid time in v2 entries)
         let time = entry.integrated_time;
         if time > 0 {
-            // Check that integrated time is not in the future (with clock skew tolerance)
             let now = jiff::Timestamp::now().as_second();
-            if time > now + clock_skew_seconds {
-                return Err(Error::Verification(format!(
-                    "integrated time {} is in the future (current time: {}, tolerance: {}s)",
-                    time, now, clock_skew_seconds
-                )));
-            }
-
-            // Check that integrated time is within certificate validity period
-            if time < not_before {
-                return Err(Error::Verification(format!(
-                    "integrated time {} is before certificate validity (not_before: {})",
-                    time, not_before
-                )));
-            }
-
-            if time > not_after {
-                return Err(Error::Verification(format!(
-                    "integrated time {} is after certificate validity (not_after: {})",
-                    time, not_after
-                )));
-            }
-
+            validate_integrated_time(time, now, not_before, not_after)?;
             integrated_time_result = Some(time);
         }
     }
 
     Ok(integrated_time_result)
+}
+
+/// Validate an entry's integrated time: it must not be in the future and
+/// must fall within the certificate validity window.
+fn validate_integrated_time(time: i64, now: i64, not_before: i64, not_after: i64) -> Result<()> {
+    // Check that integrated time is not in the future
+    if time > now {
+        return Err(Error::Verification(format!(
+            "integrated time {} is in the future (current time: {})",
+            time, now
+        )));
+    }
+
+    // Check that integrated time is within certificate validity period
+    if time < not_before {
+        return Err(Error::Verification(format!(
+            "integrated time {} is before certificate validity (not_before: {})",
+            time, not_before
+        )));
+    }
+
+    if time > not_after {
+        return Err(Error::Verification(format!(
+            "integrated time {} is after certificate validity (not_after: {})",
+            time, not_after
+        )));
+    }
+
+    Ok(())
 }
 
 /// Cryptographically verify the log-inclusion material of a single tlog entry.
@@ -267,4 +272,25 @@ pub fn verify_set(entry: &TransparencyLogEntry, trusted_root: &TrustedRoot) -> R
         .map_err(|e| Error::Verification(format!("SET verification failed: {}", e)))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: i64 = 1_700_000_000;
+    const NOT_BEFORE: i64 = NOW - 600;
+    const NOT_AFTER: i64 = NOW + 600;
+
+    #[test]
+    fn test_integrated_time_in_future_rejected() {
+        // Even one second in the future must be rejected.
+        let err = validate_integrated_time(NOW + 1, NOW, NOT_BEFORE, NOT_AFTER).unwrap_err();
+        assert!(err.to_string().contains("is in the future"));
+    }
+
+    #[test]
+    fn test_integrated_time_at_now_accepted() {
+        assert!(validate_integrated_time(NOW, NOW, NOT_BEFORE, NOT_AFTER).is_ok());
+    }
 }

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -246,12 +246,11 @@ fn test_verify_extracts_integrated_time() {
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root()).unwrap();
 
-    assert!(result.integrated_time.is_some());
-    let time = result.integrated_time.unwrap();
-    assert!(time > 0, "Integrated time should be positive");
-
     // The integrated time in the bundle is 1738060096 (2025-01-28)
-    assert_eq!(time, 1738060096);
+    assert_eq!(
+        result.integrated_time,
+        Some(jiff::Timestamp::from_second(1738060096).unwrap())
+    );
 }
 
 #[test]
@@ -283,7 +282,9 @@ fn test_backdated_integrated_time_rejected_even_when_tlog_skipped() {
     let entry = &mut bundle.verification_material.tlog_entries[0];
     // Backdate the integrated time; the inclusion promise (SET) stays intact,
     // so its signature no longer matches the claimed time.
-    entry.integrated_time -= 86_400;
+    entry.integrated_time = entry
+        .integrated_time
+        .map(|t| t - jiff::SignedDuration::from_hours(24));
 
     let artifact_digest =
         extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
@@ -383,7 +384,10 @@ fn test_full_verification_flow() {
     let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root()).unwrap();
-    assert_eq!(result.integrated_time, Some(1738060096));
+    assert_eq!(
+        result.integrated_time,
+        Some(jiff::Timestamp::from_second(1738060096).unwrap())
+    );
 }
 
 #[test]
@@ -423,7 +427,10 @@ fn test_full_verification_flow_happy_path() {
     let policy = VerificationPolicy::default();
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root()).unwrap();
-    assert_eq!(result.integrated_time, Some(1734374576));
+    assert_eq!(
+        result.integrated_time,
+        Some(jiff::Timestamp::from_second(1734374576).unwrap())
+    );
 }
 
 #[test]
@@ -1052,7 +1059,10 @@ fn test_parse_cosign_v3_blob_bundle() {
     );
 
     // Check integrated time is present
-    assert!(entry.integrated_time > 0, "Expected integrated time > 0");
+    assert!(
+        entry.integrated_time.is_some(),
+        "Expected an integrated time"
+    );
 }
 
 /// Test full verification of cosign-produced bundle


### PR DESCRIPTION
Trail of Bits recommended us to remove the clock skew configuration:

> A trusted but compromised Rekor log returns a valid v1 SET whose integration time is 60
seconds in the future. The log neglects to incorporate the entry into the public view until the integration time has passed. A verifier using the default policy accepts a bundle including that SET during the 60 second grace period. Third party monitors do not see the signature event until the window elapses. This breaks the expectation that clients should only accept logged bundles.
> In this scenario, the future-dated integration time must fall within the signing certificate's validity window.

> ### Recommendations
> Short term, remove the configurable clock skew grace period.

I also prefer to use "concrete" types wherever possible, because a `i64` or `u64` doesn't let us know whether it is seconds, nanoseconds, unix epoch or whatever date format. Ideally, we should parse early, at the "boundary" from protocol to Rust code. 