### PR TITLE
chore: release v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "hex",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "directories",
  "jiff",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "hex",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "hex",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "hex",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ambient-id",
  "base64",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-protobuf-compat"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "hex",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "hex",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "directories",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tuf"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "glob",
  "hex",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "hex",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "cms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/prefix-dev/sigstore-rust"
@@ -101,16 +101,16 @@ tempfile = "3.27.0"
 open = "5.3"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.11.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.11.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.11.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.11.0", default-features = false }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.11.0", default-features = false }
-sigstore-tuf = { path = "crates/sigstore-tuf", version = "0.11.0", default-features = false }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.11.0", default-features = false }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.11.0", default-features = false }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.11.0", default-features = false }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.11.0", default-features = false }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.11.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.11.0", default-features = false }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.11.0", default-features = false }
+sigstore-types = { path = "crates/sigstore-types", version = "0.12.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.12.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.12.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.12.0", default-features = false }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.12.0", default-features = false }
+sigstore-tuf = { path = "crates/sigstore-tuf", version = "0.12.0", default-features = false }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.12.0", default-features = false }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.12.0", default-features = false }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.12.0", default-features = false }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.12.0", default-features = false }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.12.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.12.0", default-features = false }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.12.0", default-features = false }

--- a/crates/sigstore-bundle/CHANGELOG.md
+++ b/crates/sigstore-bundle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.11.0...sigstore-bundle-v0.12.0) - 2026-08-13
+
+### Fixed
+
+- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
+
 ## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.8.0...sigstore-bundle-v0.9.0) - 2026-06-17
 
 ### Other

--- a/crates/sigstore-crypto/CHANGELOG.md
+++ b/crates/sigstore-crypto/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.11.0...sigstore-crypto-v0.12.0) - 2026-08-13
+
+### Fixed
+
+- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
+
+### Other
+
+- tuf, crypto: Support ML-DSA ([#142](https://github.com/sigstore/sigstore-rust/pull/142))
+- *(crypto)* [**breaking**] unify signature verification behind VerificationKey (TOB-SIGSTORE-6) ([#168](https://github.com/sigstore/sigstore-rust/pull/168))
+
 ## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.8.0...sigstore-crypto-v0.9.0) - 2026-06-17
 
 ### Other

--- a/crates/sigstore-rekor/CHANGELOG.md
+++ b/crates/sigstore-rekor/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-rekor-v0.11.0...sigstore-rekor-v0.12.0) - 2026-08-13
+
+### Fixed
+
+- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
+
 ## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-rekor-v0.6.1...sigstore-rekor-v0.6.2) - 2026-02-04
 
 ### Other

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.11.0...sigstore-sign-v0.12.0) - 2026-08-13
+
+### Fixed
+
+- *(types)* [**breaking**] make multi-signature DSSE envelopes unrepresentable (TOB-SIGSTORE-9) ([#170](https://github.com/sigstore/sigstore-rust/pull/170))
+- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
+
 ## [0.10.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.9.0...sigstore-sign-v0.10.0) - 2026-06-29
 
 ### Added

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.11.0...sigstore-tsa-v0.12.0) - 2026-08-13
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.8.0...sigstore-tsa-v0.9.0) - 2026-06-17
 
 ### Other

--- a/crates/sigstore-tuf/CHANGELOG.md
+++ b/crates/sigstore-tuf/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tuf-v0.11.0...sigstore-tuf-v0.12.0) - 2026-08-13
+
+### Fixed
+
+- *(tuf)* reverify cached delegated roles ([#173](https://github.com/sigstore/sigstore-rust/pull/173))
+- *(tuf)* keep wildcards within path segments ([#174](https://github.com/sigstore/sigstore-rust/pull/174))
+
+### Other
+
+- tuf, crypto: Support ML-DSA ([#142](https://github.com/sigstore/sigstore-rust/pull/142))
+
 ## [0.10.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tuf-v0.9.0...sigstore-tuf-v0.10.0) - 2026-06-29
 
 ### Added

--- a/crates/sigstore-types/CHANGELOG.md
+++ b/crates/sigstore-types/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.11.0...sigstore-types-v0.12.0) - 2026-08-13
+
+### Fixed
+
+- *(types)* [**breaking**] make multi-signature DSSE envelopes unrepresentable (TOB-SIGSTORE-9) ([#170](https://github.com/sigstore/sigstore-rust/pull/170))
+- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
+
+### Other
+
+- fix rustfmt in sigstore-types re-exports ([#172](https://github.com/sigstore/sigstore-rust/pull/172))
+
 ## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.8.0...sigstore-types-v0.9.0) - 2026-06-17
 
 ### Other

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.11.0...sigstore-verify-v0.12.0) - 2026-08-13
+
+### Fixed
+
+- *(types)* [**breaking**] make multi-signature DSSE envelopes unrepresentable (TOB-SIGSTORE-9) ([#170](https://github.com/sigstore/sigstore-rust/pull/170))
+- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
+- *(verify)* [**breaking**] authenticate signature timestamps and bind log entries to the bundle ([#160](https://github.com/sigstore/sigstore-rust/pull/160))
+
+### Other
+
+- *(crypto)* [**breaking**] unify signature verification behind VerificationKey (TOB-SIGSTORE-6) ([#168](https://github.com/sigstore/sigstore-rust/pull/168))
+
 ## [0.11.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.10.0...sigstore-verify-v0.11.0) - 2026-07-08
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `sigstore-crypto`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `sigstore-merkle`: 0.11.0 -> 0.12.0
* `sigstore-tsa`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `sigstore-tuf`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `sigstore-trust-root`: 0.11.0 -> 0.12.0
* `sigstore-cache`: 0.11.0 -> 0.12.0
* `sigstore-rekor`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `sigstore-bundle`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `sigstore-oidc`: 0.11.0 -> 0.12.0
* `sigstore-fulcio`: 0.11.0 -> 0.12.0
* `sigstore-verify`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `sigstore-sign`: 0.11.0 -> 0.12.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.11.0...sigstore-types-v0.12.0) - 2026-08-13

### Fixed

- *(types)* [**breaking**] make multi-signature DSSE envelopes unrepresentable (TOB-SIGSTORE-9) ([#170](https://github.com/sigstore/sigstore-rust/pull/170))
- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))

### Other

- fix rustfmt in sigstore-types re-exports ([#172](https://github.com/sigstore/sigstore-rust/pull/172))
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.11.0...sigstore-crypto-v0.12.0) - 2026-08-13

### Fixed

- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))

### Other

- tuf, crypto: Support ML-DSA ([#142](https://github.com/sigstore/sigstore-rust/pull/142))
- *(crypto)* [**breaking**] unify signature verification behind VerificationKey (TOB-SIGSTORE-6) ([#168](https://github.com/sigstore/sigstore-rust/pull/168))
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-merkle-v0.8.0...sigstore-merkle-v0.9.0) - 2026-06-17

### Other

- fix overflow at maximum tree size ([#116](https://github.com/sigstore/sigstore-rust/pull/116))
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.11.0...sigstore-tsa-v0.12.0) - 2026-08-13

### Other

- update Cargo.toml dependencies
</blockquote>

## `sigstore-tuf`

<blockquote>

## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tuf-v0.11.0...sigstore-tuf-v0.12.0) - 2026-08-13

### Fixed

- *(tuf)* reverify cached delegated roles ([#173](https://github.com/sigstore/sigstore-rust/pull/173))
- *(tuf)* keep wildcards within path segments ([#174](https://github.com/sigstore/sigstore-rust/pull/174))

### Other

- tuf, crypto: Support ML-DSA ([#142](https://github.com/sigstore/sigstore-rust/pull/142))
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.11.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.10.0...sigstore-trust-root-v0.11.0) - 2026-07-08

### Other

- refresh embedded TUF data ([#149](https://github.com/sigstore/sigstore-rust/pull/149))
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-cache-v0.7.0...sigstore-cache-v0.8.0) - 2026-05-21

### Other

- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-rekor-v0.11.0...sigstore-rekor-v0.12.0) - 2026-08-13

### Fixed

- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.11.0...sigstore-bundle-v0.12.0) - 2026-08-13

### Fixed

- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.8.0...sigstore-oidc-v0.9.0) - 2026-06-17

### Other

- Don't advertize unreliable parsing mechanism ([#118](https://github.com/sigstore/sigstore-rust/pull/118))
- Include OIDC in signing config, use TUF in examples ([#102](https://github.com/sigstore/sigstore-rust/pull/102))
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-fulcio-v0.6.1...sigstore-fulcio-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.11.0...sigstore-verify-v0.12.0) - 2026-08-13

### Fixed

- *(types)* [**breaking**] make multi-signature DSSE envelopes unrepresentable (TOB-SIGSTORE-9) ([#170](https://github.com/sigstore/sigstore-rust/pull/170))
- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
- *(verify)* [**breaking**] authenticate signature timestamps and bind log entries to the bundle ([#160](https://github.com/sigstore/sigstore-rust/pull/160))

### Other

- *(crypto)* [**breaking**] unify signature verification behind VerificationKey (TOB-SIGSTORE-6) ([#168](https://github.com/sigstore/sigstore-rust/pull/168))
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.12.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.11.0...sigstore-sign-v0.12.0) - 2026-08-13

### Fixed

- *(types)* [**breaking**] make multi-signature DSSE envelopes unrepresentable (TOB-SIGSTORE-9) ([#170](https://github.com/sigstore/sigstore-rust/pull/170))
- *(verify)* [**breaking**] remove clock skew, and use `jiff` Timestamp in the interfaces ([#164](https://github.com/sigstore/sigstore-rust/pull/164))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).