### PR TITLE
refactor(crypto)!: unify signature verification behind VerificationKey (TOB-SIGSTORE-6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,6 @@ dependencies = [
  "sigstore-types",
  "spki",
  "thiserror",
- "tracing",
  "x509-cert",
 ]
 

--- a/crates/sigstore-crypto/Cargo.toml
+++ b/crates/sigstore-crypto/Cargo.toml
@@ -22,7 +22,6 @@ base64 = { workspace = true }
 pem = { workspace = true }
 x509-cert = { workspace = true }
 jiff = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/crates/sigstore-crypto/src/checkpoint.rs
+++ b/crates/sigstore-crypto/src/checkpoint.rs
@@ -3,8 +3,8 @@
 //! This module provides cryptographic verification capabilities for checkpoints
 //! through an extension trait on `sigstore_types::Checkpoint`.
 
-use crate::{Error, Result};
-use sigstore_types::{DerPublicKey, KeyHint, SignatureBytes};
+use crate::{Error, Result, VerificationKey};
+use sigstore_types::{DerPublicKey, KeyHint};
 
 // Re-export checkpoint types from sigstore-types
 pub use sigstore_types::{Checkpoint, CheckpointSignature};
@@ -16,125 +16,6 @@ pub fn compute_key_hint(public_key: &DerPublicKey) -> KeyHint {
     let hash = crate::hash::sha256(public_key.as_bytes());
     let bytes = hash.as_bytes();
     KeyHint::new([bytes[0], bytes[1], bytes[2], bytes[3]])
-}
-
-// OID constants for key type identification
-use const_oid::db::rfc5912::ID_EC_PUBLIC_KEY;
-use const_oid::ObjectIdentifier;
-
-/// id-Ed25519: 1.3.101.112
-const ID_ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
-
-/// Key type detected from SPKI
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KeyType {
-    /// Ed25519 key
-    Ed25519,
-    /// ECDSA P-256 key
-    EcdsaP256,
-    /// Unknown/unsupported key type
-    Unknown,
-}
-
-/// Detect the key type from SPKI-encoded public key bytes.
-///
-/// This parses the SubjectPublicKeyInfo structure to determine the algorithm.
-pub fn detect_key_type(public_key: &DerPublicKey) -> KeyType {
-    use spki::SubjectPublicKeyInfoRef;
-
-    match SubjectPublicKeyInfoRef::try_from(public_key.as_bytes()) {
-        Ok(spki) => {
-            if spki.algorithm.oid == ID_ED25519 {
-                KeyType::Ed25519
-            } else if spki.algorithm.oid == ID_EC_PUBLIC_KEY {
-                KeyType::EcdsaP256
-            } else {
-                tracing::warn!("Unknown key algorithm OID: {}", spki.algorithm.oid);
-                KeyType::Unknown
-            }
-        }
-        Err(_) => {
-            // If we can't parse as SPKI, might be raw key bytes
-            // Check if it looks like a raw Ed25519 key (32 bytes)
-            if public_key.as_bytes().len() == 32 {
-                KeyType::Ed25519
-            } else {
-                KeyType::Unknown
-            }
-        }
-    }
-}
-
-/// Extract raw key bytes from SPKI-encoded public key.
-///
-/// For Ed25519, this extracts the 32-byte raw key from the SPKI wrapper.
-/// For ECDSA, the full SPKI is typically used by aws-lc-rs.
-pub fn extract_raw_key(public_key: &DerPublicKey) -> Result<Vec<u8>> {
-    use spki::SubjectPublicKeyInfoRef;
-
-    match SubjectPublicKeyInfoRef::try_from(public_key.as_bytes()) {
-        Ok(spki) => {
-            let raw_bytes = spki.subject_public_key.raw_bytes();
-            Ok(raw_bytes.to_vec())
-        }
-        Err(_) => {
-            // Already raw bytes
-            Ok(public_key.as_bytes().to_vec())
-        }
-    }
-}
-
-/// Verify an Ed25519 signature.
-///
-/// Accepts either SPKI-encoded or raw 32-byte public keys.
-pub fn verify_ed25519(
-    public_key: &DerPublicKey,
-    signature: &SignatureBytes,
-    message: &[u8],
-) -> Result<()> {
-    use aws_lc_rs::signature as sig;
-
-    // Extract raw key bytes from SPKI if needed
-    let raw_key = extract_raw_key(public_key)?;
-
-    let pk = sig::UnparsedPublicKey::new(&sig::ED25519, &raw_key);
-    pk.verify(message, signature.as_bytes())
-        .map_err(|_| Error::Verification("Ed25519 verification failed".to_string()))
-}
-
-/// Verify an ECDSA P-256 signature.
-///
-/// Expects SPKI-encoded public key (as produced by x509 certificates).
-pub fn verify_ecdsa_p256(
-    public_key: &DerPublicKey,
-    signature: &SignatureBytes,
-    message: &[u8],
-) -> Result<()> {
-    use aws_lc_rs::signature as sig;
-
-    // aws-lc-rs expects the full SPKI for ECDSA, or raw uncompressed point
-    let pk = sig::UnparsedPublicKey::new(&sig::ECDSA_P256_SHA256_ASN1, public_key.as_bytes());
-
-    pk.verify(message, signature.as_bytes())
-        .map_err(|_| Error::Verification("ECDSA P-256 verification failed".to_string()))
-}
-
-/// Verify a signature using automatic key type detection.
-///
-/// This function detects the key type from the SPKI structure and calls
-/// the appropriate verification function.
-pub fn verify_signature_auto(
-    public_key: &DerPublicKey,
-    signature: &SignatureBytes,
-    message: &[u8],
-) -> Result<()> {
-    match detect_key_type(public_key) {
-        KeyType::Ed25519 => verify_ed25519(public_key, signature, message),
-        KeyType::EcdsaP256 => verify_ecdsa_p256(public_key, signature, message),
-        KeyType::Unknown => Err(Error::Verification(
-            "unsupported or unrecognized public key type".to_string(),
-        )),
-    }
 }
 
 /// Extension trait for checkpoint signature verification.
@@ -165,8 +46,8 @@ impl CheckpointVerifyExt for Checkpoint {
         // The signed data is the checkpoint text (without the signatures part)
         let signed_data = self.signed_data();
 
-        // Use automatic key type detection
-        verify_signature_auto(public_key, &signature.signature, signed_data)
+        VerificationKey::from_spki_auto(public_key)?
+            .verify(signed_data, &signature.signature)
             .map_err(|e| Error::Checkpoint(format!("Signature verification failed: {}", e)))
     }
 }

--- a/crates/sigstore-crypto/src/lib.rs
+++ b/crates/sigstore-crypto/src/lib.rs
@@ -11,10 +11,7 @@ pub mod signing;
 pub mod verification;
 pub mod x509;
 
-pub use checkpoint::{
-    compute_key_hint, detect_key_type, extract_raw_key, verify_ecdsa_p256, verify_ed25519,
-    verify_signature_auto, Checkpoint, CheckpointSignature, CheckpointVerifyExt, KeyType,
-};
+pub use checkpoint::{compute_key_hint, Checkpoint, CheckpointSignature, CheckpointVerifyExt};
 pub use error::{Error, Result};
 pub use hash::{sha256, sha256_reader, sha384, sha512, Sha256Hasher};
 pub use keyring::Keyring;

--- a/crates/sigstore-crypto/src/verification.rs
+++ b/crates/sigstore-crypto/src/verification.rs
@@ -8,8 +8,13 @@ use aws_lc_rs::signature::{
     RSA_PKCS1_2048_8192_SHA512, RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384,
     RSA_PSS_2048_8192_SHA512,
 };
+use const_oid::db::rfc5912::{ID_EC_PUBLIC_KEY, SECP_256_R_1};
+use const_oid::ObjectIdentifier;
 use sigstore_types::{DerPublicKey, SignatureBytes};
 use spki::SubjectPublicKeyInfoRef;
+
+/// id-Ed25519: 1.3.101.112
+const ID_ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
 
 /// A public key for verification
 pub struct VerificationKey {
@@ -33,6 +38,45 @@ impl VerificationKey {
 
         Ok(Self {
             bytes: raw_bytes,
+            scheme,
+        })
+    }
+
+    /// Create a verification key from a DER-encoded SPKI public key,
+    /// detecting the signing scheme from the SPKI algorithm identifier
+    ///
+    /// Ed25519 and ECDSA P-256 (with SHA-256) keys are supported; these are
+    /// the key types used for transparency log checkpoints and signed entry
+    /// timestamps. Malformed or unsupported keys are rejected with a precise
+    /// error. For other schemes the caller must know the scheme out-of-band
+    /// and use [`VerificationKey::from_spki`].
+    pub fn from_spki_auto(key: &DerPublicKey) -> Result<Self> {
+        let spki = SubjectPublicKeyInfoRef::try_from(key.as_bytes())
+            .map_err(|e| Error::InvalidKey(format!("Invalid SPKI: {e}")))?;
+
+        let scheme = if spki.algorithm.oid == ID_ED25519 {
+            SigningScheme::Ed25519
+        } else if spki.algorithm.oid == ID_EC_PUBLIC_KEY {
+            match spki.algorithm.parameters_oid() {
+                Ok(curve) if curve == SECP_256_R_1 => SigningScheme::EcdsaP256Sha256,
+                Ok(curve) => {
+                    return Err(Error::InvalidKey(format!(
+                        "Unsupported EC curve OID: {curve}"
+                    )));
+                }
+                Err(e) => {
+                    return Err(Error::InvalidKey(format!("Invalid EC key parameters: {e}")));
+                }
+            }
+        } else {
+            return Err(Error::InvalidKey(format!(
+                "Unsupported key algorithm OID: {}",
+                spki.algorithm.oid
+            )));
+        };
+
+        Ok(Self {
+            bytes: spki.subject_public_key.raw_bytes().to_vec(),
             scheme,
         })
     }
@@ -309,5 +353,83 @@ mod tests {
         let sha256 = crate::hash::sha256(data);
         assert!(vk256.verify(data, &sig).is_err());
         assert!(vk256.verify_prehashed(sha256.as_bytes(), &sig).is_err());
+    }
+
+    fn spki_der(
+        oid: ObjectIdentifier,
+        curve: Option<ObjectIdentifier>,
+        key_bytes: &[u8],
+    ) -> DerPublicKey {
+        use der::{asn1::BitString, Encode as _};
+        use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
+
+        let spki = SubjectPublicKeyInfo {
+            algorithm: AlgorithmIdentifier {
+                oid,
+                parameters: curve.map(|c| der::Any::encode_from(&c).unwrap()),
+            },
+            subject_public_key: BitString::from_bytes(key_bytes).unwrap(),
+        };
+        DerPublicKey::new(spki.to_der().unwrap())
+    }
+
+    #[test]
+    fn test_from_spki_auto_ecdsa_p256_roundtrip() {
+        let kp = KeyPair::generate_ecdsa_p256().unwrap();
+        let data = b"checkpoint-style message";
+        let sig = kp.sign(data).unwrap();
+
+        let pubkey = kp.public_key_der().unwrap();
+        let vk = VerificationKey::from_spki_auto(&pubkey).unwrap();
+        assert_eq!(vk.scheme(), SigningScheme::EcdsaP256Sha256);
+        assert!(vk.verify(data, &sig).is_ok());
+    }
+
+    #[test]
+    fn test_from_spki_auto_ed25519_roundtrip() {
+        use aws_lc_rs::rand::SystemRandom;
+        use aws_lc_rs::signature::{Ed25519KeyPair, KeyPair as AwsKeyPair};
+
+        let pkcs8 = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
+        let kp = Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap();
+
+        let data = b"checkpoint-style message";
+        let sig = SignatureBytes::new(kp.sign(data).as_ref().to_vec());
+        let pubkey = spki_der(ID_ED25519, None, kp.public_key().as_ref());
+
+        let vk = VerificationKey::from_spki_auto(&pubkey).unwrap();
+        assert_eq!(vk.scheme(), SigningScheme::Ed25519);
+        assert!(vk.verify(data, &sig).is_ok());
+    }
+
+    #[test]
+    fn test_from_spki_auto_rejects_malformed_key() {
+        let garbage = DerPublicKey::new(vec![0x30, 0x03, 0x01, 0x01, 0xff]);
+        assert!(matches!(
+            VerificationKey::from_spki_auto(&garbage),
+            Err(Error::InvalidKey(_))
+        ));
+    }
+
+    #[test]
+    fn test_from_spki_auto_rejects_unsupported_algorithm() {
+        // rsaEncryption: 1.2.840.113549.1.1.1
+        let rsa_oid = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
+        let key = spki_der(rsa_oid, None, &[0u8; 16]);
+        assert!(matches!(
+            VerificationKey::from_spki_auto(&key),
+            Err(Error::InvalidKey(_))
+        ));
+    }
+
+    #[test]
+    fn test_from_spki_auto_rejects_unsupported_ec_curve() {
+        use const_oid::db::rfc5912::SECP_384_R_1;
+
+        let key = spki_der(ID_EC_PUBLIC_KEY, Some(SECP_384_R_1), &[0u8; 97]);
+        assert!(matches!(
+            VerificationKey::from_spki_auto(&key),
+            Err(Error::InvalidKey(_))
+        ));
     }
 }

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -6,9 +6,7 @@ use crate::error::{Error, Result};
 use base64::Engine;
 use sigstore_bundle::validate_bundle_with_options;
 use sigstore_bundle::ValidationOptions;
-use sigstore_crypto::{
-    detect_key_type, parse_certificate_info, KeyAlgorithm, KeyType, SigningScheme,
-};
+use sigstore_crypto::{parse_certificate_info, KeyAlgorithm, SigningScheme, VerificationKey};
 use sigstore_trust_root::TrustedRoot;
 
 use sigstore_types::{Artifact, Bundle, HashAlgorithm, SignatureContent, Statement};
@@ -632,13 +630,25 @@ pub fn verify<'a>(
     verifier.verify(artifact, bundle, policy)
 }
 
+/// Derive the key algorithm from the public key's SPKI algorithm identifier.
+///
+/// Parsing goes through [`VerificationKey::from_spki_auto`], so malformed
+/// SPKI structures, unknown algorithm OIDs, and unsupported EC curves are
+/// rejected eagerly with precise errors (TOB-SIGSTORE-6). The scheme itself
+/// is still resolved from the bundle content afterwards, so a declared
+/// SHA-384 message digest keeps selecting ECDSA-P256-SHA384.
 fn public_key_algorithm(public_key: &sigstore_types::DerPublicKey) -> Result<KeyAlgorithm> {
-    match detect_key_type(public_key) {
-        KeyType::Ed25519 => Ok(KeyAlgorithm::Ed25519),
-        KeyType::EcdsaP256 => Ok(KeyAlgorithm::EcdsaP256),
-        KeyType::Unknown => Err(Error::Verification(
-            "unsupported or unrecognized public key type".to_string(),
-        )),
+    let key = VerificationKey::from_spki_auto(public_key)
+        .map_err(|e| Error::Verification(format!("invalid public key: {e}")))?;
+    match key.scheme() {
+        SigningScheme::Ed25519 => Ok(KeyAlgorithm::Ed25519),
+        SigningScheme::EcdsaP256Sha256 | SigningScheme::EcdsaP256Sha384 => {
+            Ok(KeyAlgorithm::EcdsaP256)
+        }
+        other => Err(Error::Verification(format!(
+            "unsupported public key scheme: {}",
+            other.name()
+        ))),
     }
 }
 

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -6,7 +6,7 @@
 use crate::error::{Error, Result};
 use base64::Engine;
 use serde::Serialize;
-use sigstore_crypto::{verify_signature_auto, Checkpoint};
+use sigstore_crypto::{Checkpoint, VerificationKey};
 use sigstore_trust_root::TrustedRoot;
 use sigstore_types::bundle::InclusionProof;
 use sigstore_types::{Bundle, SignatureBytes, TransparencyLogEntry};
@@ -185,9 +185,14 @@ pub fn verify_checkpoint(
                 // Found matching key, verify the signature using automatic key type detection
                 let message = checkpoint.signed_data();
 
-                verify_signature_auto(public_key, &sig.signature, message).map_err(|e| {
-                    Error::Verification(format!("Checkpoint signature verification failed: {}", e))
-                })?;
+                VerificationKey::from_spki_auto(public_key)?
+                    .verify(message, &sig.signature)
+                    .map_err(|e| {
+                        Error::Verification(format!(
+                            "Checkpoint signature verification failed: {}",
+                            e
+                        ))
+                    })?;
 
                 return Ok(());
             }
@@ -265,7 +270,8 @@ pub fn verify_set(entry: &TransparencyLogEntry, trusted_root: &TrustedRoot) -> R
 
     // Use automatic key type detection from the SPKI structure,
     // rather than hardcoding ECDSA P-256 (matches checkpoint verification behavior)
-    verify_signature_auto(&log_key, &signature, &canonical_json)
+    VerificationKey::from_spki_auto(&log_key)?
+        .verify(&canonical_json, &signature)
         .map_err(|e| Error::Verification(format!("SET verification failed: {}", e)))?;
 
     Ok(())


### PR DESCRIPTION
Consolidate public-key signature verification behind `VerificationKey`.

Add `VerificationKey::from_spki_auto` to parse SPKI keys once, select the supported Ed25519 or ECDSA P-256 scheme, and reject malformed or unsupported keys before verification. `verify_signature_auto` now delegates to this constructor, removing the duplicate key parsing and verification paths from `checkpoint.rs` and `sigstore-verify`.

Raw, non-SPKI Ed25519 keys are no longer accepted; all in-tree key sources already provide SPKI-encoded keys.

**BREAKING CHANGE:** Remove `verify_ed25519`, `verify_ecdsa_p256`, `extract_raw_key`, `detect_key_type`, and `KeyType` from `sigstore-crypto`. Use `VerificationKey::from_spki_auto` or `verify_signature_auto` instead.

Addresses TOB-SIGSTORE-6.
