### PR TITLE
fix(types)!: make multi-signature DSSE envelopes unrepresentable (TOB-SIGSTORE-9)

### DIFF
--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -414,10 +414,10 @@ impl Signer {
         let dsse_envelope = DsseEnvelope::new(
             payload_type,
             payload,
-            vec![DsseSignature {
+            DsseSignature {
                 sig: signature.clone(),
                 keyid: KeyId::default(),
-            }],
+            },
         );
 
         // Create and submit DSSE Rekor entry
@@ -449,13 +449,6 @@ impl Signer {
         envelope: &DsseEnvelope,
         certificate: &DerCertificate,
     ) -> Result<TlogEntryBuilder> {
-        if envelope.signatures.len() != 1 {
-            return Err(Error::Signing(format!(
-                "DSSE envelope must contain exactly one signature, found {}",
-                envelope.signatures.len()
-            )));
-        }
-
         // Create Rekor client
         let rekor = RekorClient::new(&self.rekor_url);
 
@@ -471,7 +464,7 @@ impl Signer {
             RekorApiVersion::V2 => {
                 let hash = sigstore_crypto::sha256(&envelope.pae());
 
-                let signature = &envelope.signatures[0].sig;
+                let signature = &envelope.signature.sig;
 
                 let hashed_rekord = HashedRekordV2::new(&hash, signature, certificate);
                 let entry = rekor.create_entry_v2(hashed_rekord).await.map_err(|e| {
@@ -605,59 +598,5 @@ mod tests {
         let _context = SigningContext::new();
         let _prod = SigningContext::production();
         let _staging = SigningContext::staging();
-    }
-
-    #[tokio::test]
-    async fn test_create_dsse_rekor_entry_invalid_signature_count() {
-        let context = SigningContext::new();
-        let dummy_jwt =
-            "eyJhbGciOiJub25lIn0.eyJpc3MiOiJ0ZXN0Iiwic3ViIjoidGVzdCIsImV4cCI6MH0.signature";
-        let token = IdentityToken::from_jwt(dummy_jwt).unwrap();
-        let signer = context.signer(token);
-
-        let certificate = DerCertificate::new(vec![0x30, 0x00]);
-
-        // 1. Zero signatures
-        let envelope_zero = DsseEnvelope::new(
-            "application/vnd.in-toto+json".to_string(),
-            PayloadBytes::from_bytes(b"payload"),
-            vec![],
-        );
-
-        let res = signer
-            .create_dsse_rekor_entry(&envelope_zero, &certificate)
-            .await;
-        assert!(res.is_err());
-        let err_msg = match res {
-            Err(e) => e.to_string(),
-            _ => unreachable!(),
-        };
-        assert!(err_msg.contains("DSSE envelope must contain exactly one signature, found 0"));
-
-        // 2. Two signatures
-        let envelope_two = DsseEnvelope::new(
-            "application/vnd.in-toto+json".to_string(),
-            PayloadBytes::from_bytes(b"payload"),
-            vec![
-                DsseSignature {
-                    sig: SignatureBytes::from_bytes(b"sig1"),
-                    keyid: KeyId::default(),
-                },
-                DsseSignature {
-                    sig: SignatureBytes::from_bytes(b"sig2"),
-                    keyid: KeyId::default(),
-                },
-            ],
-        );
-
-        let res = signer
-            .create_dsse_rekor_entry(&envelope_two, &certificate)
-            .await;
-        assert!(res.is_err());
-        let err_msg = match res {
-            Err(e) => e.to_string(),
-            _ => unreachable!(),
-        };
-        assert!(err_msg.contains("DSSE envelope must contain exactly one signature, found 2"));
     }
 }

--- a/crates/sigstore-types/src/dsse.rs
+++ b/crates/sigstore-types/src/dsse.rs
@@ -7,15 +7,22 @@ use crate::encoding::{KeyId, PayloadBytes, SignatureBytes};
 use serde::{Deserialize, Serialize};
 
 /// A DSSE envelope containing a signed payload
+///
+/// The DSSE wire format carries a `signatures` list, but a DSSE envelope in a
+/// Sigstore bundle must contain exactly one signature: the bundle's
+/// verification material (certificate, timestamps, log entries) vouches for a
+/// single signature, so every verification step must consume the same
+/// signature bytes. This type enforces that invariant at deserialization,
+/// making multi-signature envelopes unrepresentable.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(try_from = "DsseEnvelopeWire", into = "DsseEnvelopeWire")]
 pub struct DsseEnvelope {
     /// Type URI of the payload
     pub payload_type: String,
     /// Payload bytes
     pub payload: PayloadBytes,
-    /// Signatures over the PAE (Pre-Authentication Encoding)
-    pub signatures: Vec<DsseSignature>,
+    /// The signature over the PAE (Pre-Authentication Encoding)
+    pub signature: DsseSignature,
 }
 
 /// A signature in a DSSE envelope
@@ -29,17 +36,50 @@ pub struct DsseSignature {
     pub keyid: KeyId,
 }
 
+/// The DSSE wire format, where `signatures` is a list
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DsseEnvelopeWire {
+    payload_type: String,
+    payload: PayloadBytes,
+    signatures: Vec<DsseSignature>,
+}
+
+impl TryFrom<DsseEnvelopeWire> for DsseEnvelope {
+    type Error = String;
+
+    fn try_from(wire: DsseEnvelopeWire) -> Result<Self, Self::Error> {
+        match <[DsseSignature; 1]>::try_from(wire.signatures) {
+            Ok([signature]) => Ok(Self {
+                payload_type: wire.payload_type,
+                payload: wire.payload,
+                signature,
+            }),
+            Err(signatures) => Err(format!(
+                "DSSE envelope must contain exactly one signature, found {}",
+                signatures.len()
+            )),
+        }
+    }
+}
+
+impl From<DsseEnvelope> for DsseEnvelopeWire {
+    fn from(envelope: DsseEnvelope) -> Self {
+        Self {
+            payload_type: envelope.payload_type,
+            payload: envelope.payload,
+            signatures: vec![envelope.signature],
+        }
+    }
+}
+
 impl DsseEnvelope {
     /// Create a new DSSE envelope
-    pub fn new(
-        payload_type: String,
-        payload: PayloadBytes,
-        signatures: Vec<DsseSignature>,
-    ) -> Self {
+    pub fn new(payload_type: String, payload: PayloadBytes, signature: DsseSignature) -> Self {
         Self {
             payload_type,
             payload,
-            signatures,
+            signature,
         }
     }
 
@@ -99,15 +139,39 @@ mod tests {
         let envelope = DsseEnvelope {
             payload_type: "application/vnd.in-toto+json".to_string(),
             payload: PayloadBytes::from_bytes(b"{\"_type\":\"https://in-toto.io/Statement/v1\"}"),
-            signatures: vec![DsseSignature {
+            signature: DsseSignature {
                 sig: SignatureBytes::from_bytes(b"\x30\x44\x02\x20"),
                 keyid: KeyId::default(),
-            }],
+            },
         };
 
         let json = serde_json::to_string(&envelope).unwrap();
+        // The wire format carries the signature as a one-element list
+        assert!(
+            json.contains(r#""signatures":[{"#),
+            "unexpected wire format: {json}"
+        );
         let parsed: DsseEnvelope = serde_json::from_str(&json).unwrap();
         assert_eq!(envelope, parsed);
+    }
+
+    /// Envelopes with any signature count other than one are rejected at
+    /// parse time.
+    #[test]
+    fn test_dsse_envelope_rejects_non_single_signatures() {
+        let no_signatures = r#"{"payloadType":"application/vnd.in-toto+json","payload":"dGVzdA==","signatures":[]}"#;
+        let err = serde_json::from_str::<DsseEnvelope>(no_signatures).unwrap_err();
+        assert!(
+            err.to_string().contains("exactly one signature, found 0"),
+            "unexpected error: {err}"
+        );
+
+        let two_signatures = r#"{"payloadType":"application/vnd.in-toto+json","payload":"dGVzdA==","signatures":[{"sig":"c2ln"},{"sig":"c2ln"}]}"#;
+        let err = serde_json::from_str::<DsseEnvelope>(two_signatures).unwrap_err();
+        assert!(
+            err.to_string().contains("exactly one signature, found 2"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -116,7 +180,7 @@ mod tests {
         let json_with_empty_keyid = r#"{"payloadType":"application/vnd.in-toto+json","payload":"dGVzdA==","signatures":[{"sig":"c2ln","keyid":""}]}"#;
 
         let envelope: DsseEnvelope = serde_json::from_str(json_with_empty_keyid).unwrap();
-        assert_eq!(envelope.signatures[0].keyid, KeyId::default());
+        assert_eq!(envelope.signature.keyid, KeyId::default());
 
         let reserialized = serde_json::to_string(&envelope).unwrap();
         assert!(
@@ -127,7 +191,7 @@ mod tests {
         // Test that missing keyid deserializes to default
         let json_without_keyid = r#"{"payloadType":"application/vnd.in-toto+json","payload":"dGVzdA==","signatures":[{"sig":"c2ln"}]}"#;
         let envelope_no_keyid: DsseEnvelope = serde_json::from_str(json_without_keyid).unwrap();
-        assert_eq!(envelope_no_keyid.signatures[0].keyid, KeyId::default());
+        assert_eq!(envelope_no_keyid.signature.keyid, KeyId::default());
 
         // Test with non-empty keyid - should be preserved
         let json_with_keyid = r#"{"payloadType":"application/vnd.in-toto+json","payload":"dGVzdA==","signatures":[{"sig":"c2ln","keyid":"test-key"}]}"#;

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -279,7 +279,7 @@ impl Verifier {
         // validate the certificate chain, so this step comes first.
         // These include TSA timestamps and (in the case of rekor v1 entries)
         // rekor log integrated time.
-        let signature = crate::verify_impl::helpers::extract_signature(&bundle.content)?;
+        let signature = crate::verify_impl::helpers::extract_signature(&bundle.content);
         let validation_times = crate::verify_impl::helpers::determine_validation_times(
             bundle,
             &signature,
@@ -391,32 +391,11 @@ impl Verifier {
         //      public key.
         // For DSSE envelopes, verify using PAE (Pre-Authentication Encoding)
         if let SignatureContent::DsseEnvelope(envelope) = &bundle.content {
-            let payload_bytes = envelope.decode_payload();
-
-            // Compute the PAE that was signed
-            let pae = sigstore_types::pae(&envelope.payload_type, &payload_bytes);
-
-            // Verify at least one signature is cryptographically valid
-            let mut any_sig_valid = false;
-            for sig in &envelope.signatures {
-                if sigstore_crypto::verify_signature(
-                    &cert_info.public_key,
-                    &pae,
-                    &sig.sig,
-                    cert_info.key_algorithm.default_signing_scheme(),
-                )
-                .is_ok()
-                {
-                    any_sig_valid = true;
-                    break;
-                }
-            }
-
-            if !any_sig_valid {
-                return Err(Error::Verification(
-                    "DSSE signature verification failed: no valid signatures found".to_string(),
-                ));
-            }
+            verify_dsse_envelope_signature(
+                envelope,
+                &cert_info.public_key,
+                cert_info.key_algorithm.default_signing_scheme(),
+            )?;
 
             // Verify the payload binds the artifact
             verify_dsse_artifact_binding(envelope, &artifact)?;
@@ -477,6 +456,20 @@ fn compute_artifact_digest_algo(artifact: &Artifact<'_>, algo: HashAlgorithm) ->
             Ok(hash.to_vec())
         }
     }
+}
+
+/// Verify the DSSE envelope's signature over its PAE with the given key.
+fn verify_dsse_envelope_signature(
+    envelope: &sigstore_types::DsseEnvelope,
+    public_key: &sigstore_types::DerPublicKey,
+    scheme: SigningScheme,
+) -> Result<()> {
+    // Compute the PAE that was signed
+    let payload_bytes = envelope.decode_payload();
+    let pae = sigstore_types::pae(&envelope.payload_type, &payload_bytes);
+
+    sigstore_crypto::verify_signature(public_key, &pae, &envelope.signature.sig, scheme)
+        .map_err(|e| Error::Verification(format!("DSSE signature verification failed: {}", e)))
 }
 
 /// Verify that a DSSE envelope's payload binds the artifact being verified.
@@ -750,25 +743,7 @@ pub fn verify_with_key<'a>(
             )?;
         }
         SignatureContent::DsseEnvelope(envelope) => {
-            let payload_bytes = envelope.decode_payload();
-            let pae = sigstore_types::pae(&envelope.payload_type, &payload_bytes);
-
-            // Verify at least one signature is valid
-            let mut any_sig_valid = false;
-            for sig in &envelope.signatures {
-                if sigstore_crypto::verify_signature(public_key, &pae, &sig.sig, signing_scheme)
-                    .is_ok()
-                {
-                    any_sig_valid = true;
-                    break;
-                }
-            }
-
-            if !any_sig_valid {
-                return Err(Error::Verification(
-                    "DSSE signature verification failed: no valid signatures found".to_string(),
-                ));
-            }
+            verify_dsse_envelope_signature(envelope, public_key, signing_scheme)?;
 
             // Verify the payload binds the artifact
             verify_dsse_artifact_binding(envelope, &artifact)?;
@@ -846,11 +821,18 @@ mod tests {
         );
     }
 
+    fn unused_signature() -> sigstore_types::DsseSignature {
+        sigstore_types::DsseSignature {
+            sig: sigstore_types::SignatureBytes::from_bytes(b"unused"),
+            keyid: sigstore_types::KeyId::default(),
+        }
+    }
+
     fn in_toto_envelope(payload: &str) -> sigstore_types::DsseEnvelope {
         sigstore_types::DsseEnvelope::new(
             "application/vnd.in-toto+json".to_string(),
             sigstore_types::PayloadBytes::from_bytes(payload.as_bytes()),
-            vec![],
+            unused_signature(),
         )
     }
 
@@ -898,11 +880,54 @@ mod tests {
         let envelope = sigstore_types::DsseEnvelope::new(
             "application/vnd.example+json".to_string(),
             sigstore_types::PayloadBytes::from_bytes(b"{}"),
-            vec![],
+            unused_signature(),
         );
 
         let artifact = Artifact::from(b"hello world".as_slice());
         let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
         assert!(err.to_string().contains("unsupported DSSE payload type"));
+    }
+
+    const DSSE_TEST_PAYLOAD: &[u8] = br#"{"hello":"world"}"#;
+
+    fn dsse_envelope_signed_over(
+        keypair: &sigstore_crypto::KeyPair,
+        data: &[u8],
+    ) -> sigstore_types::DsseEnvelope {
+        sigstore_types::DsseEnvelope::new(
+            "application/vnd.in-toto+json".to_string(),
+            sigstore_types::PayloadBytes::from_bytes(DSSE_TEST_PAYLOAD),
+            sigstore_types::DsseSignature {
+                sig: keypair.sign(data).unwrap(),
+                keyid: sigstore_types::KeyId::default(),
+            },
+        )
+    }
+
+    #[test]
+    fn test_dsse_envelope_valid_signature_verifies() {
+        let keypair = sigstore_crypto::KeyPair::generate_ecdsa_p256().unwrap();
+        let pae = sigstore_types::pae("application/vnd.in-toto+json", DSSE_TEST_PAYLOAD);
+        let envelope = dsse_envelope_signed_over(&keypair, &pae);
+
+        let public_key = keypair.public_key_der().unwrap();
+        verify_dsse_envelope_signature(&envelope, &public_key, keypair.default_scheme())
+            .expect("an envelope with a valid signature must verify");
+    }
+
+    #[test]
+    fn test_dsse_envelope_invalid_signature_is_hard_error() {
+        let keypair = sigstore_crypto::KeyPair::generate_ecdsa_p256().unwrap();
+        // Signature over something other than the PAE: must fail.
+        let envelope = dsse_envelope_signed_over(&keypair, b"not the PAE");
+
+        let public_key = keypair.public_key_der().unwrap();
+        let err = verify_dsse_envelope_signature(&envelope, &public_key, keypair.default_scheme())
+            .expect_err("an invalid signature must fail verification");
+        assert!(
+            err.to_string()
+                .contains("DSSE signature verification failed"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -188,17 +188,10 @@ fn validate_signature_match(
                 }
             }
             SignatureContent::DsseEnvelope(envelope) => {
-                // Compare against the first DSSE envelope signature
-                if let Some(first_sig) = envelope.signatures.first() {
-                    if &first_sig.sig != rekor_sig {
-                        return Err(Error::Verification(
-                            "DSSE signature in bundle does not match signature in Rekor entry"
-                                .to_string(),
-                        ));
-                    }
-                } else {
+                if &envelope.signature.sig != rekor_sig {
                     return Err(Error::Verification(
-                        "No signatures found in DSSE envelope".to_string(),
+                        "DSSE signature in bundle does not match signature in Rekor entry"
+                            .to_string(),
                     ));
                 }
             }

--- a/crates/sigstore-verify/src/verify_impl/helpers.rs
+++ b/crates/sigstore-verify/src/verify_impl/helpers.rs
@@ -31,17 +31,14 @@ pub fn extract_certificate(
 }
 
 /// Extract signature from bundle content (needed for TSA verification)
-pub fn extract_signature(content: &SignatureContent) -> Result<SignatureBytes> {
+///
+/// `DsseEnvelope` holds exactly one signature by construction, so the
+/// signature handed to timestamp verification is necessarily the same one
+/// that payload verification consumes (TOB-SIGSTORE-9).
+pub fn extract_signature(content: &SignatureContent) -> SignatureBytes {
     match content {
-        SignatureContent::MessageSignature(msg_sig) => Ok(msg_sig.signature.clone()),
-        SignatureContent::DsseEnvelope(envelope) => {
-            if envelope.signatures.is_empty() {
-                return Err(Error::Verification(
-                    "no signatures in DSSE envelope".to_string(),
-                ));
-            }
-            Ok(envelope.signatures[0].sig.clone())
-        }
+        SignatureContent::MessageSignature(msg_sig) => msg_sig.signature.clone(),
+        SignatureContent::DsseEnvelope(envelope) => envelope.signature.sig.clone(),
     }
 }
 
@@ -390,7 +387,7 @@ mod tests {
             "../../test_data/bundles/cosign-v3-blob.sigstore.json"
         ))
         .unwrap();
-        let signature = extract_signature(&bundle.content).unwrap();
+        let signature = extract_signature(&bundle.content);
 
         let times = determine_validation_times(&bundle, &signature, &trusted_root).unwrap();
 
@@ -403,6 +400,24 @@ mod tests {
             .integrated_time
             .unwrap();
         assert!(times.contains(&integrated_time));
+    }
+
+    /// The signature handed to TSA timestamp verification is the envelope's
+    /// single signature.
+    #[test]
+    fn extract_signature_returns_the_dsse_signature() {
+        let content = SignatureContent::DsseEnvelope(sigstore_types::DsseEnvelope::new(
+            "application/vnd.in-toto+json".to_string(),
+            sigstore_types::PayloadBytes::from_bytes(b"{}"),
+            sigstore_types::DsseSignature {
+                sig: SignatureBytes::from_bytes(b"signature-0"),
+                keyid: sigstore_types::KeyId::default(),
+            },
+        ));
+        assert_eq!(
+            extract_signature(&content),
+            SignatureBytes::from_bytes(b"signature-0")
+        );
     }
 
     /// Regression test for the Sigstore staging multi-region rollout (July 2026).

--- a/crates/sigstore-verify/src/verify_impl/rekor.rs
+++ b/crates/sigstore-verify/src/verify_impl/rekor.rs
@@ -139,43 +139,29 @@ fn verify_dsse_v001(
         VerificationMaterialContent::PublicKey { .. } => None,
     };
 
-    // Verify that the signatures in the bundle match what's in Rekor
+    // Verify that the signature in the bundle matches what's in Rekor
     // This prevents signature substitution attacks
     // IMPORTANT: We must verify BOTH the signature bytes AND the verifier (certificate)
-    if envelope.signatures.len() != rekor_signatures.len() {
+    // The bundle's envelope holds exactly one signature by construction.
+    if rekor_signatures.len() != 1 {
         return Err(Error::Verification(format!(
-            "DSSE signature count mismatch: bundle has {}, Rekor entry has {}",
-            envelope.signatures.len(),
+            "DSSE signature count mismatch: bundle has 1, Rekor entry has {}",
             rekor_signatures.len()
         )));
     }
+    let rekor_sig = &rekor_signatures[0];
 
-    // Check that each signature in the bundle exists in the Rekor entry
-    // We must match both the signature AND the verifier to prevent signature substitution
-    for bundle_sig in &envelope.signatures {
-        let mut found = false;
-        for rekor_sig in rekor_signatures {
-            if bundle_sig.sig.as_bytes() != rekor_sig.signature.as_bytes() {
-                continue;
-            }
-            match &bundle_cert {
-                Some(cert) => {
-                    // Convert Rekor's PEM verifier to DER for canonical comparison
-                    let rekor_cert_der = rekor_sig
-                        .to_certificate()
-                        .map_err(|e| Error::Verification(format!("{}", e)))?;
-                    if cert.as_bytes() == rekor_cert_der.as_bytes() {
-                        found = true;
-                        break;
-                    }
-                }
-                None => {
-                    found = true;
-                    break;
-                }
-            }
-        }
-        if !found {
+    if envelope.signature.sig.as_bytes() != rekor_sig.signature.as_bytes() {
+        return Err(Error::Verification(
+            "DSSE signature in bundle does not match any signature in Rekor entry (signature or verifier mismatch)".to_string(),
+        ));
+    }
+    if let Some(cert) = &bundle_cert {
+        // Convert Rekor's PEM verifier to DER for canonical comparison
+        let rekor_cert_der = rekor_sig
+            .to_certificate()
+            .map_err(|e| Error::Verification(format!("{}", e)))?;
+        if cert.as_bytes() != rekor_cert_der.as_bytes() {
             return Err(Error::Verification(
                 "DSSE signature in bundle does not match any signature in Rekor entry (signature or verifier mismatch)".to_string(),
             ));
@@ -221,23 +207,16 @@ fn verify_intoto_v002(
         ));
     }
 
-    // Validate that the signatures match
+    // Validate that the bundle's single signature is present in the Rekor entry
     let mut found_match = false;
-    for bundle_sig in &envelope.signatures {
-        for rekor_sig in rekor_signatures {
-            // The Rekor signature is also double-base64-encoded, decode it once
-            let rekor_sig_decoded = base64::engine::general_purpose::STANDARD
-                .decode(rekor_sig.sig.as_bytes())
-                .map_err(|e| {
-                    Error::Verification(format!("failed to decode Rekor signature: {}", e))
-                })?;
+    for rekor_sig in rekor_signatures {
+        // The Rekor signature is also double-base64-encoded, decode it once
+        let rekor_sig_decoded = base64::engine::general_purpose::STANDARD
+            .decode(rekor_sig.sig.as_bytes())
+            .map_err(|e| Error::Verification(format!("failed to decode Rekor signature: {}", e)))?;
 
-            if bundle_sig.sig.as_bytes() == rekor_sig_decoded.as_slice() {
-                found_match = true;
-                break;
-            }
-        }
-        if found_match {
+        if envelope.signature.sig.as_bytes() == rekor_sig_decoded.as_slice() {
+            found_match = true;
             break;
         }
     }

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -107,7 +107,7 @@ fn test_parse_v03_dsse_bundle() {
     match &bundle.content {
         sigstore_verify::types::SignatureContent::DsseEnvelope(env) => {
             assert_eq!(env.payload_type, "application/vnd.in-toto+json");
-            assert!(!env.signatures.is_empty());
+            assert!(!env.signature.sig.as_bytes().is_empty());
         }
         _ => panic!("Expected DSSE envelope"),
     }
@@ -513,7 +513,7 @@ fn test_parse_dsse_bundle_from_python() {
     match &bundle.content {
         sigstore_verify::types::SignatureContent::DsseEnvelope(env) => {
             assert_eq!(env.payload_type, "application/vnd.in-toto+json");
-            assert_eq!(env.signatures.len(), 1, "Should have exactly 1 signature");
+            assert!(!env.signature.sig.as_bytes().is_empty());
         }
         _ => panic!("Expected DSSE envelope"),
     }
@@ -524,19 +524,21 @@ fn test_parse_dsse_bundle_from_python() {
     assert_eq!(entry.kind_version.kind, "intoto");
 }
 
+/// Regression test for TOB-SIGSTORE-9: DSSE bundles with multiple signatures
+/// are rejected at parse time — the `DsseEnvelope` type only admits a single
+/// signature, so no verification path (payload, timestamp, Rekor
+/// consistency) can ever consume different signatures.
+/// Equivalent to sigstore-go's TestSigstoreBundle2Sig, which expects
+/// ErrDSSEInvalidSignatureCount (at verification time; we are stricter and
+/// reject when parsing the bundle).
 #[test]
-fn test_parse_dsse_bundle_with_multiple_signatures() {
-    // DSSE bundle with 2 signatures
-    let bundle = Bundle::from_json(DSSE_2SIGS_BUNDLE).expect("Failed to parse DSSE 2-sigs bundle");
-
-    // Check DSSE envelope has multiple signatures
-    match &bundle.content {
-        sigstore_verify::types::SignatureContent::DsseEnvelope(env) => {
-            assert_eq!(env.payload_type, "application/vnd.in-toto+json");
-            assert_eq!(env.signatures.len(), 2, "Should have exactly 2 signatures");
-        }
-        _ => panic!("Expected DSSE envelope"),
-    }
+fn test_dsse_bundle_with_2_signatures_rejected_at_parse() {
+    let err = Bundle::from_json(DSSE_2SIGS_BUNDLE)
+        .expect_err("multi-signature DSSE bundles must fail to parse");
+    assert!(
+        err.to_string().contains("exactly one signature"),
+        "expected the single-signature invariant to be the failure cause, got: {err}"
+    );
 }
 
 #[test]
@@ -596,36 +598,6 @@ fn test_bundle_v03_certificate_extraction() {
 }
 
 // ==== Sigstore-go Equivalent Tests ====
-
-/// Test that DSSE bundles with multiple signatures fail verification
-/// Equivalent to sigstore-go's TestSigstoreBundle2Sig which expects ErrDSSEInvalidSignatureCount
-#[test]
-fn test_dsse_bundle_with_2_signatures_should_fail() {
-    let bundle = Bundle::from_json(DSSE_2SIGS_BUNDLE).expect("Failed to parse DSSE 2-sigs bundle");
-
-    // Verify the bundle has 2 signatures
-    match &bundle.content {
-        sigstore_verify::types::SignatureContent::DsseEnvelope(env) => {
-            assert_eq!(env.signatures.len(), 2, "Bundle should have 2 signatures");
-        }
-        _ => panic!("Expected DSSE envelope"),
-    }
-
-    // Verification should fail because we only support single signatures
-    // Use extracted digest or dummy - doesn't matter since validation should fail first
-    let artifact_digest =
-        extract_artifact_digest(&bundle).unwrap_or_else(|| Sha256Hash::from_bytes([0u8; 32]));
-    let policy = VerificationPolicy::default();
-
-    let result = verify(artifact_digest, &bundle, &policy, &production_root());
-
-    // This should fail - multiple signatures are not supported
-    // sigstore-go returns ErrDSSEInvalidSignatureCount for this case
-    assert!(
-        result.is_err(),
-        "Verification should fail for bundles with multiple signatures"
-    );
-}
 
 /// Test GitHub Actions provenance bundle certificate extension extraction
 /// Equivalent to sigstore-go's TestSummarizeCertificateWithActionsBundle
@@ -901,7 +873,7 @@ fn test_parse_conda_attestation_bundle() {
                 env.payload_type, "application/vnd.in-toto+json",
                 "Should have in-toto payload type"
             );
-            assert_eq!(env.signatures.len(), 1, "Should have exactly 1 signature");
+            assert!(!env.signature.sig.as_bytes().is_empty());
 
             // Decode payload and verify it's a conda attestation
             let payload_bytes = env.decode_payload();


### PR DESCRIPTION
Require DSSE envelopes in Sigstore bundles to contain exactly one signature, ensuring payload, timestamp, and Rekor verification all use the same signature bytes.

`DsseEnvelope` now stores a single `DsseSignature`; serde preserves the one-element `signatures` wire format and rejects any other count while parsing. Verification no longer searches for any valid signature.

**BREAKING CHANGE:** Replace `DsseEnvelope.signatures: Vec<DsseSignature>` with `DsseEnvelope.signature: DsseSignature`. `DsseEnvelope::new` accepts one signature, and `Bundle::from_json` rejects DSSE envelopes without exactly one signature.

Addresses TOB-SIGSTORE-9.
