### PR TITLE
style: fix rustfmt in sigstore-types re-exports

### DIFF
--- a/crates/sigstore-types/src/lib.rs
+++ b/crates/sigstore-types/src/lib.rs
@@ -22,9 +22,9 @@ pub use checkpoint::{Checkpoint, CheckpointSignature};
 pub use dsse::{pae, DsseEnvelope, DsseSignature};
 pub use encoding::{
     base64_bytes, base64_bytes_option, hex_bytes, string_i64, string_timestamp_opt,
-    CanonicalizedBody, DerCertificate,
-    DerPublicKey, DigestBytes, EntryUuid, HexHash, HexLogId, KeyHint, KeyId, LogIndex, LogKeyId,
-    PayloadBytes, PemContent, Sha256Hash, SignatureBytes, SignedTimestamp, TimestampToken,
+    CanonicalizedBody, DerCertificate, DerPublicKey, DigestBytes, EntryUuid, HexHash, HexLogId,
+    KeyHint, KeyId, LogIndex, LogKeyId, PayloadBytes, PemContent, Sha256Hash, SignatureBytes,
+    SignedTimestamp, TimestampToken,
 };
 pub use error::{Error, Result};
 pub use hash::HashAlgorithm;


### PR DESCRIPTION
The Rustfmt CI job on `main` has been failing since #164 landed: the `pub use encoding::{...}` re-export block in `crates/sigstore-types/src/lib.rs` was not wrapped the way `cargo fmt` expects.

This is the output of `cargo fmt --all` — no functional changes. Verified locally that `cargo fmt --all -- --check` passes afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)