### PR TITLE
fix(tuf): reverify cached delegated roles

### DIFF
--- a/crates/sigstore-tuf/examples/conformance_client.rs
+++ b/crates/sigstore-tuf/examples/conformance_client.rs
@@ -9,7 +9,8 @@
 //! conformance_client --metadata-dir <DIR> init <TRUSTED_ROOT>
 //! conformance_client --metadata-dir <DIR> --metadata-url <URL> refresh
 //! conformance_client --metadata-dir <DIR> --metadata-url <URL> \
-//!     --target-name <PATH> --target-base-url <URL> --target-dir <DIR> download
+//!     --target-name <PATH> [--target-name <PATH> ...] \
+//!     --target-base-url <URL> --target-dir <DIR> download
 //! ```
 //!
 //! Exit code 0 on success, 1 on any failure. The harness wraps invocations in
@@ -55,7 +56,7 @@ impl MetadataStore for ConformanceStore {
 struct Args {
     metadata_dir: Option<String>,
     metadata_url: Option<String>,
-    target_name: Option<String>,
+    target_names: Vec<String>,
     target_dir: Option<String>,
     target_base_url: Option<String>,
     positionals: Vec<String>,
@@ -75,7 +76,10 @@ fn parse_args() -> std::result::Result<Args, String> {
         match tok.as_str() {
             "--metadata-dir" => take(&mut args.metadata_dir)?,
             "--metadata-url" => take(&mut args.metadata_url)?,
-            "--target-name" => take(&mut args.target_name)?,
+            "--target-name" => args.target_names.push(
+                it.next()
+                    .ok_or_else(|| format!("missing value for {tok}"))?,
+            ),
             "--target-dir" => take(&mut args.target_dir)?,
             "--target-base-url" => take(&mut args.target_base_url)?,
             "-v" | "--verbose" => {}
@@ -133,10 +137,9 @@ async fn cmd_refresh(args: &Args) -> Result<()> {
 /// `download`: refresh, resolve the target (walking delegations), verify and
 /// write it into the target dir.
 async fn cmd_download(args: &Args) -> Result<()> {
-    let target_name = args
-        .target_name
-        .as_ref()
-        .ok_or_else(|| Error::Transport("--target-name is required".into()))?;
+    if args.target_names.is_empty() {
+        return Err(Error::Transport("--target-name is required".into()));
+    }
     let target_dir = args
         .target_dir
         .as_ref()
@@ -147,28 +150,31 @@ async fn cmd_download(args: &Args) -> Result<()> {
     let now = jiff::Timestamp::now();
     updater.refresh(now).await?;
 
-    // Resolve the target (walking delegations) so we can check the cache before
-    // fetching the artifact itself.
-    let info = updater
-        .get_targetinfo(target_name, now)
-        .await?
-        .ok_or_else(|| Error::Malformed(format!("unknown target {target_name:?}")))?;
-    let out = target_dir.join(safe_target_filename(target_name));
+    for target_name in &args.target_names {
+        // Resolve each target with the same updater so delegation-cache state is
+        // retained across all requested target lookups.
+        let info = updater
+            .get_targetinfo(target_name, now)
+            .await?
+            .ok_or_else(|| Error::Malformed(format!("unknown target {target_name:?}")))?;
+        let out = target_dir.join(safe_target_filename(target_name));
 
-    // Artifact cache: if we already have a byte-identical copy, don't download
-    // it again (tuf-conformance's test_artifact_cache checks this).
-    if let Ok(existing) = std::fs::read(&out) {
-        if target_bytes_match(&existing, &info) {
-            return Ok(());
+        // Artifact cache: if we already have a byte-identical copy, don't download
+        // it again (tuf-conformance's test_artifact_cache checks this).
+        if let Ok(existing) = std::fs::read(&out) {
+            if target_bytes_match(&existing, &info) {
+                continue;
+            }
         }
-    }
 
-    let bytes = updater.download_target(&info, target_name).await?;
-    if let Some(parent) = out.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| Error::Transport(format!("creating target dir: {e}")))?;
+        let bytes = updater.download_target(&info, target_name).await?;
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| Error::Transport(format!("creating target dir: {e}")))?;
+        }
+        std::fs::write(&out, &bytes)
+            .map_err(|e| Error::Transport(format!("writing target: {e}")))?;
     }
-    std::fs::write(&out, &bytes).map_err(|e| Error::Transport(format!("writing target: {e}")))?;
     Ok(())
 }
 

--- a/crates/sigstore-tuf/src/client.rs
+++ b/crates/sigstore-tuf/src/client.rs
@@ -332,20 +332,28 @@ impl Updater {
             // not re-fetched, so repeated resolutions don't re-download metadata.
             // A delegated role the snapshot does not pin is not trusted: skip it
             // without fetching, rather than failing the whole search.
-            if role != "targets" && self.trusted.targets_role(&role).is_none() {
-                let pinned = self
-                    .trusted
-                    .snapshot()
-                    .map(|s| s.meta.contains_key(&format!("{role}.json")))
-                    .unwrap_or(false);
-                if !pinned {
-                    tracing::debug!(%role, "delegated role not in snapshot; skipping");
-                    continue;
+            if role != "targets" {
+                if self.trusted.targets_role(&role).is_none() {
+                    let pinned = self
+                        .trusted
+                        .snapshot()
+                        .map(|s| s.meta.contains_key(&format!("{role}.json")))
+                        .unwrap_or(false);
+                    if !pinned {
+                        tracing::debug!(%role, "delegated role not in snapshot; skipping");
+                        continue;
+                    }
+                    let bytes = self.fetch_targets_metadata(&role).await?;
+                    self.trusted
+                        .update_delegated_targets(&bytes, &role, &delegator, now)?;
+                    self.cache_put(&format!("{}.json", encode_role(&role)), &bytes);
+                } else {
+                    // The same role name can be reachable through parents with
+                    // different authorities. Its cached envelope is usable only
+                    // if it also satisfies the current parent's delegation.
+                    self.trusted
+                        .verify_delegated_targets(&role, &delegator, now)?;
                 }
-                let bytes = self.fetch_targets_metadata(&role).await?;
-                self.trusted
-                    .update_delegated_targets(&bytes, &role, &delegator, now)?;
-                self.cache_put(&format!("{}.json", encode_role(&role)), &bytes);
             }
             visited.insert(role.clone());
 

--- a/crates/sigstore-tuf/src/trusted.rs
+++ b/crates/sigstore-tuf/src/trusted.rs
@@ -260,6 +260,34 @@ impl TrustedMetadataSet {
         self.targets.get(name).map(|m| &m.signed)
     }
 
+    /// Verify that a cached delegated targets role is authorized by the
+    /// delegator through which it is currently being reached.
+    ///
+    /// Delegated metadata is cached by role name because the snapshot has a
+    /// single pin for that name. A role name can nevertheless be delegated by
+    /// multiple parents with different keys and thresholds, so callers must
+    /// perform this check on every delegating edge before using a cached role.
+    pub fn verify_delegated_targets(
+        &self,
+        role_name: &str,
+        delegator_name: &str,
+        now: jiff::Timestamp,
+    ) -> Result<&Targets> {
+        if is_top_level_role(role_name) {
+            return Err(Error::Malformed(format!(
+                "delegated role must not reuse top-level role name {role_name:?}"
+            )));
+        }
+        let (keys, role_keys) = self.delegation_authority(delegator_name, role_name)?;
+        let metadata = self
+            .targets
+            .get(role_name)
+            .ok_or_else(|| Error::UnknownRole(role_name.to_string()))?;
+        metadata.verify_threshold(&keys, &role_keys, role_name)?;
+        ensure_not_expired(&metadata.signed, role_name, now)?;
+        Ok(&metadata.signed)
+    }
+
     /// Incorporate the top-level `targets` metadata file.
     ///
     /// Requires a trusted snapshot first; checks length/hash/version against the

--- a/crates/sigstore-tuf/tests/end_to_end.rs
+++ b/crates/sigstore-tuf/tests/end_to_end.rs
@@ -195,6 +195,154 @@ fn build_repo_with_timestamp_expiry(timestamp_expires: &str) -> (MemRepo, Vec<u8
     (repo, root_bytes)
 }
 
+/// Build a repository where two parents delegate the same role name using
+/// different keys. The shared metadata is signed only by parent A's key.
+fn build_shared_role_repo() -> (MemRepo, Vec<u8>) {
+    let root_kp = KeyPair::generate_ecdsa_p256().unwrap();
+    let parent_a_kp = KeyPair::generate_ecdsa_p256().unwrap();
+    let parent_b_kp = KeyPair::generate_ecdsa_p256().unwrap();
+    let (root_kid, root_key) = key_entry(&root_kp);
+    let (a_kid, a_key) = key_entry(&parent_a_kp);
+    let (b_kid, b_key) = key_entry(&parent_b_kp);
+
+    let shared_signed = json!({
+        "_type": "targets", "spec_version": "1.0.0", "version": 1,
+        "expires": FAR_FUTURE,
+        "targets": {
+            "team-a/trusted_root.json": { "length": 1, "hashes": {} },
+            "team-b/trusted_root.json": { "length": 1, "hashes": {} },
+        },
+    });
+    let shared_bytes = envelope(
+        shared_signed.clone(),
+        vec![signature(&shared_signed, &a_kid, &parent_a_kp)],
+    );
+
+    let parent_a_signed = json!({
+        "_type": "targets", "spec_version": "1.0.0", "version": 1,
+        "expires": FAR_FUTURE, "targets": {},
+        "delegations": {
+            "keys": { a_kid.clone(): a_key.clone() },
+            "roles": [{
+                "name": "release", "keyids": [a_kid.clone()], "threshold": 1,
+                "paths": ["team-a/*"], "terminating": false,
+            }],
+        },
+    });
+    let parent_a_bytes = envelope(
+        parent_a_signed.clone(),
+        vec![signature(&parent_a_signed, &a_kid, &parent_a_kp)],
+    );
+
+    let parent_b_signed = json!({
+        "_type": "targets", "spec_version": "1.0.0", "version": 1,
+        "expires": FAR_FUTURE, "targets": {},
+        "delegations": {
+            "keys": { b_kid.clone(): b_key.clone() },
+            "roles": [{
+                "name": "release", "keyids": [b_kid.clone()], "threshold": 1,
+                "paths": ["team-b/*"], "terminating": false,
+            }],
+        },
+    });
+    let parent_b_bytes = envelope(
+        parent_b_signed.clone(),
+        vec![signature(&parent_b_signed, &b_kid, &parent_b_kp)],
+    );
+
+    let targets_signed = json!({
+        "_type": "targets", "spec_version": "1.0.0", "version": 1,
+        "expires": FAR_FUTURE, "targets": {},
+        "delegations": {
+            "keys": { a_kid.clone(): a_key, b_kid.clone(): b_key },
+            "roles": [
+                {
+                    "name": "parent-a", "keyids": [a_kid], "threshold": 1,
+                    "paths": ["team-a/*"], "terminating": false,
+                },
+                {
+                    "name": "parent-b", "keyids": [b_kid], "threshold": 1,
+                    "paths": ["team-b/*"], "terminating": false,
+                }
+            ],
+        },
+    });
+    let targets_bytes = envelope(
+        targets_signed.clone(),
+        vec![signature(&targets_signed, &root_kid, &root_kp)],
+    );
+
+    let snapshot_signed = json!({
+        "_type": "snapshot", "spec_version": "1.0.0", "version": 1,
+        "expires": FAR_FUTURE,
+        "meta": {
+            "targets.json": metafile(&targets_bytes, 1),
+            "parent-a.json": metafile(&parent_a_bytes, 1),
+            "parent-b.json": metafile(&parent_b_bytes, 1),
+            "release.json": metafile(&shared_bytes, 1),
+        },
+    });
+    let snapshot_bytes = envelope(
+        snapshot_signed.clone(),
+        vec![signature(&snapshot_signed, &root_kid, &root_kp)],
+    );
+    let timestamp_signed = json!({
+        "_type": "timestamp", "spec_version": "1.0.0", "version": 1,
+        "expires": FAR_FUTURE,
+        "meta": { "snapshot.json": metafile(&snapshot_bytes, 1) },
+    });
+    let timestamp_bytes = envelope(
+        timestamp_signed.clone(),
+        vec![signature(&timestamp_signed, &root_kid, &root_kp)],
+    );
+
+    let role = json!({ "keyids": [root_kid.clone()], "threshold": 1 });
+    let root_signed = json!({
+        "_type": "root", "spec_version": "1.0.0", "version": 1,
+        "expires": FAR_FUTURE, "consistent_snapshot": false,
+        "keys": { root_kid.clone(): root_key },
+        "roles": {
+            "root": role, "timestamp": role, "snapshot": role, "targets": role,
+        },
+    });
+    let root_bytes = envelope(
+        root_signed.clone(),
+        vec![signature(&root_signed, &root_kid, &root_kp)],
+    );
+
+    let mut repo = MemRepo::default();
+    repo.metadata
+        .insert("timestamp.json".into(), timestamp_bytes);
+    repo.metadata.insert("snapshot.json".into(), snapshot_bytes);
+    repo.metadata.insert("targets.json".into(), targets_bytes);
+    repo.metadata.insert("parent-a.json".into(), parent_a_bytes);
+    repo.metadata.insert("parent-b.json".into(), parent_b_bytes);
+    repo.metadata.insert("release.json".into(), shared_bytes);
+    (repo, root_bytes)
+}
+
+#[tokio::test]
+async fn cached_role_is_reverified_against_each_delegator() {
+    let (repo, root_bytes) = build_shared_role_repo();
+    let mut updater = Updater::new(repo, &root_bytes).unwrap();
+    updater.refresh(now()).await.unwrap();
+
+    updater
+        .get_targetinfo("team-a/trusted_root.json", now())
+        .await
+        .unwrap()
+        .expect("parent A authorizes its release metadata");
+
+    let err = updater
+        .get_targetinfo("team-b/trusted_root.json", now())
+        .await
+        .expect_err("parent A's cached signature must not satisfy parent B");
+    assert!(
+        matches!(err, sigstore_tuf::Error::ThresholdNotMet { .. }),
+        "got: {err}"
+    );
+}
+
 #[tokio::test]
 async fn get_target_serves_a_cached_target_without_re_downloading() {
     // Regression: an online updater with a store must reuse a previously cached


### PR DESCRIPTION
## Summary

- reverify cached delegated metadata against the keys and threshold of the parent used by the current traversal
- retain role-name caching without allowing a previously verified delegating edge to authorize a different edge
- add an end-to-end regression test with two parents delegating the same role name under different keys

This addresses TOB-SIGSTORE-14.

## Testing

- `cargo test -p sigstore-tuf`
- confirmed the new regression test fails before the client-side revalidation and passes with the fix
- `cargo fmt --all -- --check`
- `git diff --check`