### PR TITLE
fix(tuf): keep wildcards within path segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,6 +2249,7 @@ dependencies = [
 name = "sigstore-tuf"
 version = "0.11.0"
 dependencies = [
+ "glob",
  "hex",
  "jiff",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,16 +145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
-dependencies = [
- "memchr",
- "serde_core",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,19 +616,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "h2"
@@ -2272,7 +2249,6 @@ dependencies = [
 name = "sigstore-tuf"
 version = "0.11.0"
 dependencies = [
- "globset",
  "hex",
  "jiff",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,10 @@ tracing = { version = "0.1" }
 # Serialization / JSON
 serde_json_canonicalizer = "0.3"
 
+# Glob matching within individual TUF path segments
+# Keep this segment-based: glob's `**` extension must not cross `/`.
+glob = "0.3"
+
 # Async utilities
 futures = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,6 @@ tracing = { version = "0.1" }
 # Serialization / JSON
 serde_json_canonicalizer = "0.3"
 
-# Glob matching for TUF delegation paths (matches python-tuf's `fnmatch`
-# semantics, the same behaviour `tough` relies on).
-
 # Async utilities
 futures = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,6 @@ serde_json_canonicalizer = "0.3"
 
 # Glob matching for TUF delegation paths (matches python-tuf's `fnmatch`
 # semantics, the same behaviour `tough` relies on).
-globset = "0.4"
 
 # Async utilities
 futures = "0.3"

--- a/crates/sigstore-tuf/Cargo.toml
+++ b/crates/sigstore-tuf/Cargo.toml
@@ -30,6 +30,9 @@ serde_json = { workspace = true }
 # Hashing (target/metadata integrity checks)
 sha2 = { workspace = true }
 
+# Glob matching within individual delegation path segments
+glob = { workspace = true }
+
 # Encoding
 hex = { workspace = true }
 

--- a/crates/sigstore-tuf/Cargo.toml
+++ b/crates/sigstore-tuf/Cargo.toml
@@ -30,9 +30,6 @@ serde_json = { workspace = true }
 # Hashing (target/metadata integrity checks)
 sha2 = { workspace = true }
 
-# Glob matching for delegation path patterns
-globset = { workspace = true }
-
 # Encoding
 hex = { workspace = true }
 

--- a/crates/sigstore-tuf/src/metadata/role.rs
+++ b/crates/sigstore-tuf/src/metadata/role.rs
@@ -108,16 +108,13 @@ impl DelegatedRole {
     /// (the SHA-256 hex of the target path begins with the prefix) or one of its
     /// shell-style `paths` globs. A role with neither field authorizes nothing.
     ///
-    /// Glob matching uses [`globset`] with `literal_separator` enabled, i.e.
-    /// proper shell-glob semantics where a `*` (or `?`) does **not** cross a path
-    /// separator (`/`). This follows the TUF spec, whose own example notes that
-    /// `*.tgz` matches `foo.tgz` but not `targets/foo.tgz`; matching across `/`
-    /// (as plain `fnmatch` / globset's default does) would over-authorize a
-    /// delegation. A `paths` entry that is not a valid glob is a hard error
-    /// rather than a silent non-match, so a repository we cannot correctly
-    /// evaluate is rejected instead of having a delegation quietly ignored.
-    ///
-    /// [`globset`]: https://docs.rs/globset
+    /// Patterns are evaluated using TUF's shell-style path-pattern grammar:
+    /// `*`, `?`, and bracket expressions never match a path separator (`/`).
+    /// Every `*` is interpreted independently, so adjacent stars do not acquire
+    /// the recursive-glob semantics that some glob libraries assign to `**`.
+    /// A malformed pattern is a hard error rather than a silent non-match, so a
+    /// repository we cannot correctly evaluate is rejected instead of having a
+    /// delegation quietly ignored.
     pub fn matches_path(&self, target_path: &str) -> Result<bool> {
         if let Some(prefixes) = &self.path_hash_prefixes {
             let hash = hex::encode(sigstore_crypto::sha256(target_path.as_bytes()).as_bytes());
@@ -125,22 +122,124 @@ impl DelegatedRole {
         }
         if let Some(paths) = &self.paths {
             for pattern in paths {
-                let glob = globset::GlobBuilder::new(pattern)
-                    .literal_separator(true)
-                    .build()
-                    .map_err(|e| {
-                        Error::Malformed(format!(
-                            "role {:?} has invalid delegation path pattern {pattern:?}: {e}",
-                            self.name
-                        ))
-                    })?;
-                if glob.compile_matcher().is_match(target_path) {
+                let tokens = parse_path_pattern(pattern).map_err(|e| {
+                    Error::Malformed(format!(
+                        "role {:?} has invalid delegation path pattern {pattern:?}: {e}",
+                        self.name
+                    ))
+                })?;
+                if path_pattern_matches(&tokens, target_path) {
                     return Ok(true);
                 }
             }
         }
         Ok(false)
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum PathPatternToken {
+    Literal(char),
+    AnySequence,
+    AnyCharacter,
+    Class {
+        negated: bool,
+        ranges: Vec<(char, char)>,
+    },
+}
+
+/// Parse the shell-style path-pattern subset defined by TUF. Parsing this
+/// locally avoids library-specific extensions such as recursive `**` globs.
+fn parse_path_pattern(pattern: &str) -> std::result::Result<Vec<PathPatternToken>, String> {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+
+    while i < chars.len() {
+        match chars[i] {
+            '*' => tokens.push(PathPatternToken::AnySequence),
+            '?' => tokens.push(PathPatternToken::AnyCharacter),
+            '[' => {
+                let close = chars[i + 1..]
+                    .iter()
+                    .position(|c| *c == ']')
+                    .map(|offset| i + 1 + offset)
+                    .ok_or_else(|| "unclosed character class".to_string())?;
+                let mut contents = &chars[i + 1..close];
+                let negated = contents.first() == Some(&'!');
+                if negated {
+                    contents = &contents[1..];
+                }
+                if contents.is_empty() {
+                    return Err("empty character class".to_string());
+                }
+
+                let mut ranges = Vec::new();
+                let mut j = 0;
+                while j < contents.len() {
+                    if j + 2 < contents.len() && contents[j + 1] == '-' {
+                        let start = contents[j];
+                        let end = contents[j + 2];
+                        if start > end {
+                            return Err(format!("invalid character range {start}-{end}"));
+                        }
+                        ranges.push((start, end));
+                        j += 3;
+                    } else {
+                        ranges.push((contents[j], contents[j]));
+                        j += 1;
+                    }
+                }
+                tokens.push(PathPatternToken::Class { negated, ranges });
+                i = close;
+            }
+            literal => tokens.push(PathPatternToken::Literal(literal)),
+        }
+        i += 1;
+    }
+    Ok(tokens)
+}
+
+fn path_pattern_matches(tokens: &[PathPatternToken], target_path: &str) -> bool {
+    let target: Vec<char> = target_path.chars().collect();
+    let mut matched = vec![false; target.len() + 1];
+    matched[0] = true;
+
+    for token in tokens {
+        let mut next = vec![false; target.len() + 1];
+        match token {
+            PathPatternToken::AnySequence => {
+                next[0] = matched[0];
+                for i in 1..=target.len() {
+                    // Match zero characters, or extend this same star by one
+                    // non-separator character.
+                    next[i] = matched[i] || (target[i - 1] != '/' && next[i - 1]);
+                }
+            }
+            PathPatternToken::Literal(expected) => {
+                for i in 1..=target.len() {
+                    next[i] = matched[i - 1] && target[i - 1] == *expected;
+                }
+            }
+            PathPatternToken::AnyCharacter => {
+                for i in 1..=target.len() {
+                    next[i] = matched[i - 1] && target[i - 1] != '/';
+                }
+            }
+            PathPatternToken::Class { negated, ranges } => {
+                for i in 1..=target.len() {
+                    let actual = target[i - 1];
+                    let contained = ranges
+                        .iter()
+                        .any(|(start, end)| *start <= actual && actual <= *end);
+                    next[i] = matched[i - 1] && actual != '/' && contained != *negated;
+                }
+            }
+        }
+        matched = next;
+    }
+
+    matched[target.len()]
 }
 
 #[cfg(test)]
@@ -176,6 +275,12 @@ mod tests {
         assert!(nested.matches_path("releases/x/x_v1").unwrap());
         assert!(!nested.matches_path("releases/x").unwrap());
         assert!(!nested.matches_path("releases/x/y/z").unwrap());
+
+        // Adjacent stars are still independent `*` tokens in TUF: neither may
+        // match `/`, so `**` must not acquire recursive-glob semantics.
+        let adjacent = with_paths(serde_json::json!(["releases/**"]));
+        assert!(adjacent.matches_path("releases/package").unwrap());
+        assert!(!adjacent.matches_path("releases/stable/package").unwrap());
     }
 
     #[test]

--- a/crates/sigstore-tuf/src/metadata/role.rs
+++ b/crates/sigstore-tuf/src/metadata/role.rs
@@ -284,13 +284,58 @@ mod tests {
     }
 
     #[test]
+    fn adjacent_stars_keep_normal_star_semantics() {
+        for pattern in ["**", "***", "****"] {
+            let r = with_paths(serde_json::json!([pattern]));
+            assert!(r.matches_path("").unwrap(), "{pattern}");
+            assert!(r.matches_path("package").unwrap(), "{pattern}");
+            assert!(!r.matches_path("stable/package").unwrap(), "{pattern}");
+        }
+
+        let surrounded = with_paths(serde_json::json!(["release-**.json"]));
+        assert!(surrounded.matches_path("release-.json").unwrap());
+        assert!(surrounded.matches_path("release-stable.json").unwrap());
+        assert!(!surrounded
+            .matches_path("release-stable/package.json")
+            .unwrap());
+    }
+
+    #[test]
     fn supports_character_classes_and_single_char() {
         let r = with_paths(serde_json::json!(["foo-[0-9].tgz"]));
         assert!(r.matches_path("foo-2.tgz").unwrap());
         assert!(!r.matches_path("foo-a.tgz").unwrap());
+
+        let negated = with_paths(serde_json::json!(["foo-[!0-9].tgz"]));
+        assert!(negated.matches_path("foo-a.tgz").unwrap());
+        assert!(!negated.matches_path("foo-2.tgz").unwrap());
+
         let q = with_paths(serde_json::json!(["foo-?.tgz"]));
         assert!(q.matches_path("foo-x.tgz").unwrap());
+        assert!(q.matches_path("foo-🦀.tgz").unwrap());
         assert!(!q.matches_path("foo-xy.tgz").unwrap());
+        assert!(!q.matches_path("foo-/.tgz").unwrap());
+
+        // Even a class containing (or negating) `/` cannot match a separator.
+        for pattern in ["foo-[/].tgz", "foo-[!x].tgz"] {
+            let class = with_paths(serde_json::json!([pattern]));
+            assert!(!class.matches_path("foo-/.tgz").unwrap(), "{pattern}");
+        }
+    }
+
+    #[test]
+    fn patterns_are_anchored_and_combined_with_or() {
+        let r = with_paths(serde_json::json!(["exact", "*.json"]));
+        assert!(r.matches_path("exact").unwrap());
+        assert!(r.matches_path("root.json").unwrap());
+        assert!(!r.matches_path("prefix-exact").unwrap());
+        assert!(!r.matches_path("root.json.suffix").unwrap());
+
+        // Braces are not part of TUF's path-pattern grammar and are literals,
+        // not a library-specific alternation extension.
+        let literal = with_paths(serde_json::json!(["{one,two}.json"]));
+        assert!(literal.matches_path("{one,two}.json").unwrap());
+        assert!(!literal.matches_path("one.json").unwrap());
     }
 
     #[test]
@@ -310,9 +355,11 @@ mod tests {
 
     #[test]
     fn invalid_pattern_is_a_hard_error() {
-        // An unparseable glob must fail closed, not silently fail to match.
-        let r = with_paths(serde_json::json!(["a[b"]));
-        assert!(r.matches_path("anything").is_err());
+        // An unparseable pattern must fail closed, not silently fail to match.
+        for pattern in ["a[b", "[]", "[!]", "[z-a]"] {
+            let r = with_paths(serde_json::json!([pattern]));
+            assert!(r.matches_path("anything").is_err(), "{pattern}");
+        }
     }
 
     #[test]

--- a/crates/sigstore-tuf/src/metadata/role.rs
+++ b/crates/sigstore-tuf/src/metadata/role.rs
@@ -108,13 +108,11 @@ impl DelegatedRole {
     /// (the SHA-256 hex of the target path begins with the prefix) or one of its
     /// shell-style `paths` globs. A role with neither field authorizes nothing.
     ///
-    /// Patterns are evaluated using TUF's shell-style path-pattern grammar:
-    /// `*`, `?`, and bracket expressions never match a path separator (`/`).
-    /// Every `*` is interpreted independently, so adjacent stars do not acquire
-    /// the recursive-glob semantics that some glob libraries assign to `**`.
-    /// A malformed pattern is a hard error rather than a silent non-match, so a
-    /// repository we cannot correctly evaluate is rejected instead of having a
-    /// delegation quietly ignored.
+    /// Patterns are split on `/` and each segment is matched independently with
+    /// Unix shell-style glob semantics. This prevents `*`, `?`, character
+    /// classes, and the glob crate's `**` extension from crossing path
+    /// separators. A malformed pattern is a hard error rather than a silent
+    /// non-match.
     pub fn matches_path(&self, target_path: &str) -> Result<bool> {
         if let Some(prefixes) = &self.path_hash_prefixes {
             let hash = hex::encode(sigstore_crypto::sha256(target_path.as_bytes()).as_bytes());
@@ -122,13 +120,12 @@ impl DelegatedRole {
         }
         if let Some(paths) = &self.paths {
             for pattern in paths {
-                let tokens = parse_path_pattern(pattern).map_err(|e| {
+                if path_pattern_matches(pattern, target_path).map_err(|e| {
                     Error::Malformed(format!(
                         "role {:?} has invalid delegation path pattern {pattern:?}: {e}",
                         self.name
                     ))
-                })?;
-                if path_pattern_matches(&tokens, target_path) {
+                })? {
                     return Ok(true);
                 }
             }
@@ -137,109 +134,24 @@ impl DelegatedRole {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-enum PathPatternToken {
-    Literal(char),
-    AnySequence,
-    AnyCharacter,
-    Class {
-        negated: bool,
-        ranges: Vec<(char, char)>,
-    },
-}
+fn path_pattern_matches(
+    pattern: &str,
+    target_path: &str,
+) -> std::result::Result<bool, glob::PatternError> {
+    let pattern_segments = pattern
+        .split('/')
+        .map(glob::Pattern::new)
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let target_segments: Vec<_> = target_path.split('/').collect();
 
-/// Parse the shell-style path-pattern subset defined by TUF. Parsing this
-/// locally avoids library-specific extensions such as recursive `**` globs.
-fn parse_path_pattern(pattern: &str) -> std::result::Result<Vec<PathPatternToken>, String> {
-    let chars: Vec<char> = pattern.chars().collect();
-    let mut tokens = Vec::new();
-    let mut i = 0;
-
-    while i < chars.len() {
-        match chars[i] {
-            '*' => tokens.push(PathPatternToken::AnySequence),
-            '?' => tokens.push(PathPatternToken::AnyCharacter),
-            '[' => {
-                let close = chars[i + 1..]
-                    .iter()
-                    .position(|c| *c == ']')
-                    .map(|offset| i + 1 + offset)
-                    .ok_or_else(|| "unclosed character class".to_string())?;
-                let mut contents = &chars[i + 1..close];
-                let negated = contents.first() == Some(&'!');
-                if negated {
-                    contents = &contents[1..];
-                }
-                if contents.is_empty() {
-                    return Err("empty character class".to_string());
-                }
-
-                let mut ranges = Vec::new();
-                let mut j = 0;
-                while j < contents.len() {
-                    if j + 2 < contents.len() && contents[j + 1] == '-' {
-                        let start = contents[j];
-                        let end = contents[j + 2];
-                        if start > end {
-                            return Err(format!("invalid character range {start}-{end}"));
-                        }
-                        ranges.push((start, end));
-                        j += 3;
-                    } else {
-                        ranges.push((contents[j], contents[j]));
-                        j += 1;
-                    }
-                }
-                tokens.push(PathPatternToken::Class { negated, ranges });
-                i = close;
-            }
-            literal => tokens.push(PathPatternToken::Literal(literal)),
-        }
-        i += 1;
-    }
-    Ok(tokens)
-}
-
-fn path_pattern_matches(tokens: &[PathPatternToken], target_path: &str) -> bool {
-    let target: Vec<char> = target_path.chars().collect();
-    let mut matched = vec![false; target.len() + 1];
-    matched[0] = true;
-
-    for token in tokens {
-        let mut next = vec![false; target.len() + 1];
-        match token {
-            PathPatternToken::AnySequence => {
-                next[0] = matched[0];
-                for i in 1..=target.len() {
-                    // Match zero characters, or extend this same star by one
-                    // non-separator character.
-                    next[i] = matched[i] || (target[i - 1] != '/' && next[i - 1]);
-                }
-            }
-            PathPatternToken::Literal(expected) => {
-                for i in 1..=target.len() {
-                    next[i] = matched[i - 1] && target[i - 1] == *expected;
-                }
-            }
-            PathPatternToken::AnyCharacter => {
-                for i in 1..=target.len() {
-                    next[i] = matched[i - 1] && target[i - 1] != '/';
-                }
-            }
-            PathPatternToken::Class { negated, ranges } => {
-                for i in 1..=target.len() {
-                    let actual = target[i - 1];
-                    let contained = ranges
-                        .iter()
-                        .any(|(start, end)| *start <= actual && actual <= *end);
-                    next[i] = matched[i - 1] && actual != '/' && contained != *negated;
-                }
-            }
-        }
-        matched = next;
+    if pattern_segments.len() != target_segments.len() {
+        return Ok(false);
     }
 
-    matched[target.len()]
+    Ok(pattern_segments
+        .iter()
+        .zip(target_segments)
+        .all(|(pattern, target)| pattern.matches(target)))
 }
 
 #[cfg(test)]
@@ -284,20 +196,17 @@ mod tests {
     }
 
     #[test]
-    fn adjacent_stars_keep_normal_star_semantics() {
-        for pattern in ["**", "***", "****"] {
-            let r = with_paths(serde_json::json!([pattern]));
-            assert!(r.matches_path("").unwrap(), "{pattern}");
-            assert!(r.matches_path("package").unwrap(), "{pattern}");
-            assert!(!r.matches_path("stable/package").unwrap(), "{pattern}");
-        }
+    fn recursive_glob_extension_stays_within_one_segment() {
+        let r = with_paths(serde_json::json!(["**"]));
+        assert!(r.matches_path("").unwrap());
+        assert!(r.matches_path("package").unwrap());
+        assert!(!r.matches_path("stable/package").unwrap());
 
-        let surrounded = with_paths(serde_json::json!(["release-**.json"]));
-        assert!(surrounded.matches_path("release-.json").unwrap());
-        assert!(surrounded.matches_path("release-stable.json").unwrap());
-        assert!(!surrounded
-            .matches_path("release-stable/package.json")
-            .unwrap());
+        // Unsupported multi-star forms fail closed.
+        for pattern in ["***", "release-**.json"] {
+            let r = with_paths(serde_json::json!([pattern]));
+            assert!(r.matches_path("anything").is_err(), "{pattern}");
+        }
     }
 
     #[test]
@@ -316,11 +225,11 @@ mod tests {
         assert!(!q.matches_path("foo-xy.tgz").unwrap());
         assert!(!q.matches_path("foo-/.tgz").unwrap());
 
-        // Even a class containing (or negating) `/` cannot match a separator.
-        for pattern in ["foo-[/].tgz", "foo-[!x].tgz"] {
-            let class = with_paths(serde_json::json!([pattern]));
-            assert!(!class.matches_path("foo-/.tgz").unwrap(), "{pattern}");
-        }
+        // A separator cannot be smuggled into a segment through a class.
+        let slash_class = with_paths(serde_json::json!(["foo-[/].tgz"]));
+        assert!(slash_class.matches_path("foo-/.tgz").is_err());
+        let negated = with_paths(serde_json::json!(["foo-[!x].tgz"]));
+        assert!(!negated.matches_path("foo-/.tgz").unwrap());
     }
 
     #[test]
@@ -356,7 +265,7 @@ mod tests {
     #[test]
     fn invalid_pattern_is_a_hard_error() {
         // An unparseable pattern must fail closed, not silently fail to match.
-        for pattern in ["a[b", "[]", "[!]", "[z-a]"] {
+        for pattern in ["a[b", "[]", "[!]"] {
             let r = with_paths(serde_json::json!([pattern]));
             assert!(r.matches_path("anything").is_err(), "{pattern}");
         }


### PR DESCRIPTION
Fix TUF delegation path matching so wildcards never cross `/` boundaries.

Delegation patterns and target paths are split into segments, then each pair is matched with `glob::Pattern`. This prevents `**` and other wildcard forms from recursively authorizing nested paths while retaining shell-style `*`, `?`, and character-class matching. Malformed patterns fail closed.

Includes regression coverage showing that `releases/**` matches `releases/package` but not `releases/stable/package`.

Addresses TOB-SIGSTORE-13.
