### PR TITLE
refactor(artifact)!: make artifact digests typed

### DIFF
--- a/crates/sigstore-crypto/src/signing.rs
+++ b/crates/sigstore-crypto/src/signing.rs
@@ -3,12 +3,13 @@
 use crate::error::{Error, Result};
 use crate::hash::Sha256Hasher;
 use aws_lc_rs::{
+    digest::{Digest, SHA256},
     rand::SystemRandom,
     signature::{EcdsaKeyPair, KeyPair as AwsKeyPair, ECDSA_P256_SHA256_ASN1_SIGNING},
 };
 use const_oid::db::rfc5912::{ID_EC_PUBLIC_KEY, SECP_256_R_1};
 use der::{asn1::BitString, Encode as _};
-use sigstore_types::{DerPublicKey, Sha256Hash, SignatureBytes};
+use sigstore_types::{DerPublicKey, HashAlgorithm, Sha256Hash, SignatureBytes};
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 
 /// Supported signing schemes
@@ -77,6 +78,22 @@ impl SigningScheme {
                 | SigningScheme::MlDsa65
                 | SigningScheme::MlDsa87
         )
+    }
+
+    /// Hash algorithm used by prehashed variants of this scheme.
+    pub fn hash_algorithm(&self) -> Option<HashAlgorithm> {
+        match self {
+            Self::EcdsaP256Sha256
+            | Self::EcdsaP384Sha256
+            | Self::RsaPssSha256
+            | Self::RsaPkcs1Sha256 => Some(HashAlgorithm::Sha2256),
+            Self::EcdsaP256Sha384
+            | Self::EcdsaP384Sha384
+            | Self::RsaPssSha384
+            | Self::RsaPkcs1Sha384 => Some(HashAlgorithm::Sha2384),
+            Self::RsaPssSha512 | Self::RsaPkcs1Sha512 => Some(HashAlgorithm::Sha2512),
+            Self::Ed25519 | Self::MlDsa44 | Self::MlDsa65 | Self::MlDsa87 => None,
+        }
     }
 }
 
@@ -195,6 +212,21 @@ impl KeyPair {
         }
     }
 
+    /// Sign a caller-supplied SHA-256 digest.
+    ///
+    /// This attests to the digest supplied by the caller; the original message
+    /// is not available for the library to hash or otherwise inspect.
+    pub fn sign_digest(&self, digest: &Sha256Hash) -> Result<SignatureBytes> {
+        let digest = Digest::import_less_safe(digest.as_bytes(), &SHA256)
+            .map_err(|_| Error::Signing("invalid SHA-256 digest".to_string()))?;
+        match self {
+            KeyPair::EcdsaP256(kp) => {
+                let sig = kp.sign_digest(&digest)?;
+                Ok(SignatureBytes::new(sig.as_ref().to_vec()))
+            }
+        }
+    }
+
     /// Get the signing scheme for this key pair
     pub fn default_scheme(&self) -> SigningScheme {
         match self {
@@ -248,6 +280,22 @@ mod tests {
         let data = b"test data to sign";
         let sig = kp.sign(data).unwrap();
         assert!(!sig.is_empty());
+    }
+
+    #[test]
+    fn test_sign_digest_verifies_as_signature_over_message() {
+        use crate::verification::VerificationKey;
+
+        let kp = KeyPair::generate_ecdsa_p256().unwrap();
+        let message = b"caller supplied digest";
+        let digest = crate::hash::sha256(message);
+        let sig = kp.sign_digest(&digest).unwrap();
+        let vk = VerificationKey::from_spki(
+            &kp.public_key_der().unwrap(),
+            SigningScheme::EcdsaP256Sha256,
+        )
+        .unwrap();
+        vk.verify(message, &sig).unwrap();
     }
 
     #[test]

--- a/crates/sigstore-crypto/src/signing.rs
+++ b/crates/sigstore-crypto/src/signing.rs
@@ -290,7 +290,7 @@ mod tests {
         let message = b"caller supplied digest";
         let digest = crate::hash::sha256(message);
         let sig = kp.sign_digest(&digest).unwrap();
-        let vk = VerificationKey::from_spki(
+        let vk = VerificationKey::from_spki_with_scheme(
             &kp.public_key_der().unwrap(),
             SigningScheme::EcdsaP256Sha256,
         )

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -14,8 +14,8 @@ use sigstore_trust_root::{
 };
 use sigstore_tsa::TimestampClient;
 use sigstore_types::{
-    Artifact, Bundle, DerCertificate, DsseEnvelope, DsseSignature, KeyId, PayloadBytes, Sha256Hash,
-    SignatureBytes, Statement, Subject, TimestampToken,
+    Artifact, Bundle, DerCertificate, DsseEnvelope, DsseSignature, HashAlgorithm, KeyId,
+    PayloadBytes, Sha256Hash, SignatureBytes, Statement, Subject, TimestampToken,
 };
 
 /// Number of bytes hashed between yields to the async executor.
@@ -292,10 +292,9 @@ impl Signer {
     /// This creates a hashedrekord bundle that includes a signature over the artifact.
     /// The artifact can be provided as raw bytes or as an `Artifact` enum.
     ///
-    /// **Note:** For hashedrekord bundles, the raw artifact bytes are required to create
-    /// the signature. If you only have a pre-computed digest and don't need to sign the
-    /// raw bytes, use [`sign_attestation`](Self::sign_attestation) instead to create a
-    /// DSSE/in-toto attestation bundle.
+    /// A pre-computed digest is trusted as the identity of the artifact and
+    /// signed directly in prehashed mode; the library cannot check it against
+    /// bytes it was not given.
     ///
     /// # Executor behavior
     ///
@@ -325,31 +324,32 @@ impl Signer {
     pub async fn sign<'a>(&self, artifact: impl Into<Artifact<'a>>) -> Result<Bundle> {
         let artifact = artifact.into();
 
-        // For hashedrekord bundles, we need the raw bytes to sign
-        let bytes = match &artifact {
-            Artifact::Bytes(b) => *b,
-            Artifact::Digest(_) => {
-                return Err(Error::Signing(
-                    "Cannot create hashedrekord bundle with only a digest. \
-                     The raw artifact bytes are required to create the signature. \
-                     Use sign_attestation() to create a DSSE bundle with just a digest."
-                        .to_string(),
-                ));
-            }
-        };
-
         // 1. Generate ephemeral key pair
         let key_pair = self.generate_ephemeral_keypair()?;
 
         // 2. Get signing certificate from Fulcio
         let leaf_cert_der = self.request_certificate(&key_pair).await?;
 
-        // 3. + 4. Hash the artifact cooperatively (yielding to the executor
-        // between chunks so unbounded input cannot starve other tasks) and
-        // sign the digest. Signing the precomputed digest is equivalent to
-        // ECDSA-SHA256 over the raw bytes but is O(1) in the artifact size.
-        let hasher = sha256_yielding(bytes).await;
-        let (artifact_hash, signature) = key_pair.sign_prehashed(hasher)?;
+        // 3. + 4. Hash blobs cooperatively, or explicitly attest to the typed
+        // digest supplied by the caller, then sign in prehashed mode.
+        let (artifact_hash, signature) = match artifact {
+            Artifact::Blob(blob) => {
+                let hasher = sha256_yielding(blob).await;
+                key_pair.sign_prehashed(hasher)?
+            }
+            Artifact::Digest(digest) => {
+                if digest.algorithm() != HashAlgorithm::Sha2256 {
+                    return Err(Error::Signing(format!(
+                        "hashedrekord signing requires a SHA-256 artifact digest, got {}",
+                        digest.algorithm()
+                    )));
+                }
+                let hash = Sha256Hash::try_from_slice(digest.as_bytes())
+                    .map_err(|e| Error::Signing(e.to_string()))?;
+                let signature = key_pair.sign_digest(&hash)?;
+                (hash, signature)
+            }
+        };
 
         // 5. Create Rekor entry (with certificate, not just public key)
         let tlog_entry = self

--- a/crates/sigstore-types/README.md
+++ b/crates/sigstore-types/README.md
@@ -30,7 +30,7 @@ let bundle: Bundle = serde_json::from_str(bundle_json)?;
 let checkpoint = Checkpoint::from_text(checkpoint_text)?;
 
 // Create an artifact from bytes
-let artifact = Artifact::Bytes(b"hello world");
+let artifact = Artifact::Blob(b"hello world");
 
 // Create an artifact from a pre-computed SHA-256 digest
 // (useful for large files where you don't want to load the entire file into memory)

--- a/crates/sigstore-types/src/artifact.rs
+++ b/crates/sigstore-types/src/artifact.rs
@@ -1,118 +1,131 @@
-//! Artifact types for signing and verification
-//!
-//! This module provides types for representing artifacts to be signed or verified.
-//! Artifacts can be provided as raw bytes or as pre-computed digests, allowing
-//! for efficient handling of large files without loading them entirely into memory.
+//! Artifact inputs for signing and verification.
 
-use crate::{DigestBytes, Sha256Hash};
-use std::borrow::Cow;
+use crate::{DigestBytes, Error, HashAlgorithm, Sha256Hash};
 
-/// An artifact to be signed or verified
+/// A typed, pre-computed artifact digest.
 ///
-/// This enum allows flexible input for signing and verification operations:
-/// - `Bytes`: Raw artifact bytes (hash will be computed internally)
-/// - `Digest`: Pre-computed digest (no raw bytes needed)
-///
-/// The digest is stored as a [`Cow`] so it can either borrow from the caller
-/// (zero-copy, the common case) or own its bytes when an owned value is
-/// converted into an `Artifact` (e.g. `Artifact::from(some_sha256_hash)`).
-///
-/// # Example
-///
-/// ```
-/// use sigstore_types::{Artifact, Sha256Hash};
-///
-/// // From raw bytes
-/// let artifact = Artifact::from(b"hello world".as_slice());
-///
-/// // From a pre-computed digest (borrowed, zero-copy)
-/// let digest = Sha256Hash::from_hex(
-///     "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
-/// ).unwrap();
-/// let artifact = Artifact::from(&digest);
-/// ```
-#[derive(Debug, Clone)]
-pub enum Artifact<'a> {
-    /// Raw artifact bytes (hash will be computed)
-    Bytes(&'a [u8]),
-    /// Pre-computed digest bytes
-    Digest(Cow<'a, [u8]>),
+/// Carrying the algorithm with the bytes prevents a SHA-384 or SHA-512 value
+/// from being silently interpreted as SHA-256 (or vice versa).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactDigest {
+    algorithm: HashAlgorithm,
+    value: DigestBytes,
 }
 
-impl<'a> Artifact<'a> {
-    /// Create an artifact from raw bytes
-    pub fn from_bytes(bytes: &'a [u8]) -> Self {
-        Artifact::Bytes(bytes)
+impl ArtifactDigest {
+    /// Construct a digest and validate that its length matches `algorithm`.
+    pub fn new(algorithm: HashAlgorithm, value: impl Into<DigestBytes>) -> Result<Self, Error> {
+        let value = value.into();
+        if value.as_bytes().len() != algorithm.digest_size() {
+            return Err(Error::Validation(format!(
+                "{} digest must be {} bytes, got {}",
+                algorithm,
+                algorithm.digest_size(),
+                value.as_bytes().len()
+            )));
+        }
+        Ok(Self { algorithm, value })
     }
 
-    /// Create an artifact from a pre-computed digest (borrowed, zero-copy)
-    pub fn from_digest(digest: &'a [u8]) -> Self {
-        Artifact::Digest(Cow::Borrowed(digest))
-    }
-
-    /// Check if this artifact has raw bytes available
-    pub fn has_bytes(&self) -> bool {
-        matches!(self, Artifact::Bytes(_))
-    }
-
-    /// Get the raw bytes if available
-    pub fn bytes(&self) -> Option<&[u8]> {
-        match self {
-            Artifact::Bytes(bytes) => Some(bytes),
-            Artifact::Digest(_) => None,
+    /// Construct a SHA-256 artifact digest.
+    pub fn sha256(value: Sha256Hash) -> Self {
+        Self {
+            algorithm: HashAlgorithm::Sha2256,
+            value: value.into(),
         }
     }
 
-    /// Get the pre-computed digest bytes if available
-    pub fn pre_computed_digest(&self) -> Option<&[u8]> {
+    pub fn algorithm(&self) -> HashAlgorithm {
+        self.algorithm
+    }
+
+    pub fn value(&self) -> &DigestBytes {
+        &self.value
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.value.as_bytes()
+    }
+}
+
+impl From<Sha256Hash> for ArtifactDigest {
+    fn from(value: Sha256Hash) -> Self {
+        Self::sha256(value)
+    }
+}
+
+impl From<&Sha256Hash> for ArtifactDigest {
+    fn from(value: &Sha256Hash) -> Self {
+        Self::sha256(*value)
+    }
+}
+
+/// Material supplied as the subject of signing or verification.
+#[derive(Debug, Clone)]
+pub enum Artifact<'a> {
+    /// Complete artifact bytes.
+    Blob(&'a [u8]),
+    /// A typed pre-computed digest. The original bytes are unavailable.
+    Digest(ArtifactDigest),
+}
+
+impl<'a> Artifact<'a> {
+    pub fn from_blob(blob: &'a [u8]) -> Self {
+        Self::Blob(blob)
+    }
+
+    pub fn from_digest(digest: impl Into<ArtifactDigest>) -> Self {
+        Self::Digest(digest.into())
+    }
+
+    pub fn blob(&self) -> Option<&[u8]> {
         match self {
-            Artifact::Bytes(_) => None,
-            Artifact::Digest(hash) => Some(hash.as_ref()),
+            Self::Blob(blob) => Some(blob),
+            Self::Digest(_) => None,
+        }
+    }
+
+    pub fn digest(&self) -> Option<&ArtifactDigest> {
+        match self {
+            Self::Blob(_) => None,
+            Self::Digest(digest) => Some(digest),
         }
     }
 }
 
 impl<'a> From<&'a [u8]> for Artifact<'a> {
-    fn from(bytes: &'a [u8]) -> Self {
-        Artifact::Bytes(bytes)
+    fn from(value: &'a [u8]) -> Self {
+        Self::Blob(value)
     }
 }
 
 impl<'a> From<&'a Vec<u8>> for Artifact<'a> {
-    fn from(bytes: &'a Vec<u8>) -> Self {
-        Artifact::Bytes(bytes.as_slice())
+    fn from(value: &'a Vec<u8>) -> Self {
+        Self::Blob(value)
     }
 }
 
 impl<'a, const N: usize> From<&'a [u8; N]> for Artifact<'a> {
-    fn from(bytes: &'a [u8; N]) -> Self {
-        Artifact::Bytes(bytes.as_slice())
+    fn from(value: &'a [u8; N]) -> Self {
+        Self::Blob(value)
     }
 }
 
-impl<'a> From<&'a Sha256Hash> for Artifact<'a> {
-    fn from(hash: &'a Sha256Hash) -> Self {
-        Artifact::Digest(Cow::Borrowed(hash.as_bytes()))
-    }
-}
-
-impl<'a> From<&'a DigestBytes> for Artifact<'a> {
-    fn from(digest: &'a DigestBytes) -> Self {
-        Artifact::Digest(Cow::Borrowed(digest.as_bytes()))
+impl From<ArtifactDigest> for Artifact<'static> {
+    fn from(value: ArtifactDigest) -> Self {
+        Self::Digest(value)
     }
 }
 
 impl From<Sha256Hash> for Artifact<'static> {
-    fn from(hash: Sha256Hash) -> Self {
-        // Owned digest: copies the 32 bytes into the `Cow`. Prefer the
-        // borrowing `From<&Sha256Hash>` when the hash outlives the `Artifact`.
-        Artifact::Digest(Cow::Owned(hash.as_bytes().to_vec()))
+    fn from(value: Sha256Hash) -> Self {
+        Self::Digest(value.into())
     }
 }
 
-impl From<DigestBytes> for Artifact<'static> {
-    fn from(digest: DigestBytes) -> Self {
-        Artifact::Digest(Cow::Owned(digest.as_bytes().to_vec()))
+impl From<&Sha256Hash> for Artifact<'static> {
+    fn from(value: &Sha256Hash) -> Self {
+        Self::Digest(value.into())
     }
 }
 
@@ -121,35 +134,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_artifact_from_bytes() {
-        let bytes = b"hello world";
-        let artifact = Artifact::from(bytes.as_slice());
-        assert!(artifact.has_bytes());
-        assert_eq!(artifact.bytes(), Some(bytes.as_slice()));
+    fn digest_rejects_wrong_length() {
+        assert!(ArtifactDigest::new(HashAlgorithm::Sha2384, &[0_u8; 32][..]).is_err());
     }
 
     #[test]
-    fn test_artifact_from_digest() {
-        let digest = Sha256Hash::from_hex(
-            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
-        )
-        .unwrap();
-        let artifact = Artifact::from(digest);
-        assert!(!artifact.has_bytes());
-        assert_eq!(artifact.bytes(), None);
-        assert_eq!(
-            artifact.pre_computed_digest(),
-            Some(digest.as_bytes().as_slice())
-        );
-    }
-
-    #[test]
-    fn test_artifact_from_digest_bytes() {
-        let raw_bytes = vec![5u8; 32];
-        let digest = DigestBytes::from_bytes(raw_bytes.clone());
-        let artifact = Artifact::from(&digest);
-        assert!(!artifact.has_bytes());
-        assert_eq!(artifact.bytes(), None);
-        assert_eq!(artifact.pre_computed_digest(), Some(raw_bytes.as_slice()));
+    fn sha256_conversion_is_typed() {
+        let hash = Sha256Hash::from_bytes([7; 32]);
+        let artifact = Artifact::from(hash);
+        let digest = artifact.digest().unwrap();
+        assert_eq!(digest.algorithm(), HashAlgorithm::Sha2256);
+        assert_eq!(digest.as_bytes(), hash.as_bytes());
     }
 }

--- a/crates/sigstore-types/src/lib.rs
+++ b/crates/sigstore-types/src/lib.rs
@@ -13,7 +13,7 @@ pub mod hash;
 pub mod intoto;
 pub mod time_range;
 
-pub use artifact::Artifact;
+pub use artifact::{Artifact, ArtifactDigest};
 pub use bundle::{
     Bundle, BundleVersion, CheckpointData, InclusionPromise, InclusionProof, KindVersion, LogId,
     MediaType, MessageDigest, MessageSignature, SignatureContent, TransparencyLogEntry,

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -436,22 +436,19 @@ impl Verifier {
 
 fn compute_artifact_digest_algo(artifact: &Artifact<'_>, algo: HashAlgorithm) -> Result<Vec<u8>> {
     match artifact {
-        Artifact::Bytes(bytes) => match algo {
+        Artifact::Blob(bytes) => match algo {
             HashAlgorithm::Sha2256 => Ok(sigstore_crypto::sha256(bytes).as_bytes().to_vec()),
             HashAlgorithm::Sha2384 => Ok(sigstore_crypto::sha384(bytes)),
             HashAlgorithm::Sha2512 => Ok(sigstore_crypto::sha512(bytes)),
         },
-        Artifact::Digest(hash) => {
-            let expected_len = algo.digest_size();
-            if hash.len() != expected_len {
+        Artifact::Digest(digest) => {
+            if digest.algorithm() != algo {
                 return Err(Error::Verification(format!(
-                    "expected digest length {} for {:?}, got {}",
-                    expected_len,
-                    algo,
-                    hash.len()
+                    "verification requires an {algo} artifact digest, got {}",
+                    digest.algorithm()
                 )));
             }
-            Ok(hash.to_vec())
+            Ok(digest.as_bytes().to_vec())
         }
     }
 }
@@ -527,17 +524,36 @@ fn verify_signature_over_artifact(
     artifact: &Artifact<'_>,
 ) -> Result<()> {
     let result = match artifact {
-        Artifact::Bytes(bytes) => {
+        Artifact::Blob(bytes) => {
             sigstore_crypto::verify_signature(public_key, bytes, signature, scheme)
         }
-        Artifact::Digest(hash) => {
+        Artifact::Digest(digest) => {
             if !scheme.supports_prehashed() {
                 return Err(Error::Verification(format!(
                     "cannot verify signature with digest-only - scheme {} does not support prehashed mode",
                     scheme.name()
                 )));
             }
-            sigstore_crypto::verify_signature_prehashed(public_key, hash, signature, scheme)
+            let expected = scheme.hash_algorithm().ok_or_else(|| {
+                Error::Verification(format!(
+                    "cannot verify signature with digest-only - scheme {} has no external digest algorithm",
+                    scheme.name()
+                ))
+            })?;
+            if digest.algorithm() != expected {
+                return Err(Error::Verification(format!(
+                    "signature scheme {} requires an {} artifact digest, got {}",
+                    scheme.name(),
+                    expected,
+                    digest.algorithm()
+                )));
+            }
+            sigstore_crypto::verify_signature_prehashed(
+                public_key,
+                digest.as_bytes(),
+                signature,
+                scheme,
+            )
         }
     };
     result.map_err(|e| Error::Verification(format!("signature verification failed: {}", e)))

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -76,12 +76,20 @@ pub(crate) fn verify_hashedrekord_entry(
 /// Compute the SHA-256 digest from an artifact for Rekor inclusion proof
 fn compute_artifact_digest(artifact: &Artifact<'_>) -> Result<Sha256Hash> {
     match artifact {
-        Artifact::Bytes(bytes) => Ok(sigstore_crypto::sha256(bytes)),
-        Artifact::Digest(hash) => Sha256Hash::try_from_slice(hash).map_err(|_| {
-            Error::Verification(
-                "Rekor entry verification requires a 32-byte SHA-256 digest".to_string(),
-            )
-        }),
+        Artifact::Blob(bytes) => Ok(sigstore_crypto::sha256(bytes)),
+        Artifact::Digest(digest) => {
+            if digest.algorithm() != sigstore_types::HashAlgorithm::Sha2256 {
+                return Err(Error::Verification(format!(
+                    "Rekor entry verification requires SHA-256, got {}",
+                    digest.algorithm()
+                )));
+            }
+            Sha256Hash::try_from_slice(digest.as_bytes()).map_err(|_| {
+                Error::Verification(
+                    "Rekor entry verification requires a 32-byte SHA-256 digest".to_string(),
+                )
+            })
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Makes artifact inputs explicit and type-safe before 1.0:

```rust
pub enum Artifact<'a> {
    Blob(&'a [u8]),
    Digest(ArtifactDigest),
}
```

`ArtifactDigest` carries its `HashAlgorithm` and validates the digest length at construction. Verification therefore rejects algorithm mismatches instead of interpreting arbitrary bytes according to whichever bundle field is inspected later.

Signing now accepts SHA-256 digest input as documented, signs it directly in prehashed mode, and uses the same value in the hashedrekord entry. Supplying a digest explicitly means the caller—not the library—is asserting the artifact identity.

## Stack

1. #183: incremental/prehashed signing foundation
2. **This PR:** typed blob and digest inputs
3. #185: synchronous and asynchronous reader APIs

BREAKING CHANGE: digest inputs must use `ArtifactDigest`; untyped `DigestBytes` conversions are removed and `Artifact::Bytes` is renamed `Artifact::Blob`.

Signed-off-by: Wolf Vollprecht <w.vollprecht@gmail.com>
