### PR TITLE
feat(artifact)!: stream artifacts from sync and async readers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,7 @@ dependencies = [
  "base64",
  "const-oid",
  "der",
+ "futures-io",
  "hex",
  "jiff",
  "pem",
@@ -2227,6 +2228,7 @@ version = "0.11.0"
 dependencies = [
  "base64",
  "futures",
+ "futures-io",
  "hex",
  "jiff",
  "serde",
@@ -2333,6 +2335,7 @@ dependencies = [
  "cms",
  "const-oid",
  "futures",
+ "futures-io",
  "hex",
  "jiff",
  "pem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,12 +524,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -537,6 +553,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -556,8 +600,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -2177,6 +2226,7 @@ name = "sigstore-sign"
 version = "0.11.0"
 dependencies = [
  "base64",
+ "futures",
  "hex",
  "jiff",
  "serde",
@@ -2282,6 +2332,7 @@ dependencies = [
  "base64",
  "cms",
  "const-oid",
+ "futures",
  "hex",
  "jiff",
  "pem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,7 @@ dependencies = [
  "base64",
  "const-oid",
  "der",
+ "futures",
  "futures-io",
  "hex",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ glob = "0.3"
 
 # Async utilities
 futures = "0.3"
+futures-io = "0.3"
 
 # Directory utilities
 directories = "6.0"

--- a/crates/sigstore-crypto/Cargo.toml
+++ b/crates/sigstore-crypto/Cargo.toml
@@ -18,6 +18,7 @@ base64 = { workspace = true }
 pem = { workspace = true }
 x509-cert = { workspace = true }
 jiff = { workspace = true }
+futures-io = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/crates/sigstore-crypto/Cargo.toml
+++ b/crates/sigstore-crypto/Cargo.toml
@@ -21,4 +21,5 @@ jiff = { workspace = true }
 futures-io = { workspace = true }
 
 [dev-dependencies]
+futures = { workspace = true }
 hex = { workspace = true }

--- a/crates/sigstore-crypto/src/hash.rs
+++ b/crates/sigstore-crypto/src/hash.rs
@@ -51,7 +51,7 @@ impl ArtifactHasher {
 
     pub fn finalize(self) -> ArtifactDigest {
         ArtifactDigest::new(self.algorithm, self.context.finish().as_ref())
-            .expect("cryptographic backend returned the algorithm's documented digest length")
+            .expect("backend digest length does not match the algorithm's documented length")
     }
 }
 

--- a/crates/sigstore-crypto/src/hash.rs
+++ b/crates/sigstore-crypto/src/hash.rs
@@ -149,7 +149,7 @@ pub fn sha256_reader(reader: impl Read) -> io::Result<Sha256Hash> {
 pub fn hash_reader<H: HashUpdate>(mut reader: impl Read, hashers: &mut [H]) -> io::Result<()> {
     let mut buffer = [0_u8; HASH_CHUNK_SIZE];
     loop {
-        let read = reader.read(&mut buffer)?;
+        let read = read_retry(&mut reader, &mut buffer)?;
         if read == 0 {
             return Ok(());
         }
@@ -202,6 +202,15 @@ pub async fn hash_async_reader<H: HashUpdate>(
     }
 }
 
+fn read_retry(reader: &mut impl Read, buf: &mut [u8]) -> io::Result<usize> {
+    loop {
+        match reader.read(buf) {
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            result => return result,
+        }
+    }
+}
+
 /// Adapter presenting a blocking [`Read`] as an always-ready [`AsyncRead`].
 struct BlockingReader<R>(R);
 
@@ -215,7 +224,7 @@ impl<R: Read> AsyncRead for BlockingReader<R> {
         _cx: &mut TaskContext<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        Poll::Ready(self.0.read(buf))
+        Poll::Ready(read_retry(&mut self.0, buf))
     }
 }
 
@@ -224,25 +233,16 @@ impl<R: Read> AsyncRead for BlockingReader<R> {
 /// Runtime-agnostic equivalent of `tokio::task::yield_now()`: the future
 /// wakes its own waker and returns `Pending` on the first poll, then `Ready`.
 fn yield_now() -> impl Future<Output = ()> {
-    struct YieldNow {
-        yielded: bool,
-    }
-
-    impl Future for YieldNow {
-        type Output = ();
-
-        fn poll(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<()> {
-            if self.yielded {
-                Poll::Ready(())
-            } else {
-                self.yielded = true;
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
+    let mut yielded = false;
+    std::future::poll_fn(move |cx| {
+        if yielded {
+            Poll::Ready(())
+        } else {
+            yielded = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
         }
-    }
-
-    YieldNow { yielded: false }
+    })
 }
 
 #[cfg(test)]
@@ -326,14 +326,11 @@ mod tests {
     }
 
     fn futures_task_noop_waker() -> std::task::Waker {
-        use std::task::{RawWaker, RawWakerVTable, Waker};
-        fn noop(_: *const ()) {}
-        fn clone(p: *const ()) -> RawWaker {
-            RawWaker::new(p, &VTABLE)
+        struct Noop;
+        impl std::task::Wake for Noop {
+            fn wake(self: std::sync::Arc<Self>) {}
         }
-        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
-        // SAFETY: the vtable functions ignore the data pointer entirely.
-        unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+        std::sync::Arc::new(Noop).into()
     }
 
     #[test]
@@ -387,6 +384,56 @@ mod tests {
         let waker = futures_task_noop_waker();
         let mut cx = TaskContext::from_waker(&waker);
         assert!(future.as_mut().poll(&mut cx).is_pending());
+    }
+
+    #[test]
+    fn short_interrupted_and_pending_reads() {
+        struct Reader {
+            remaining: &'static [u8],
+            interrupted: bool,
+            pending: bool,
+        }
+        impl Read for Reader {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                if !self.interrupted {
+                    self.interrupted = true;
+                    return Err(io::ErrorKind::Interrupted.into());
+                }
+                let len = buf.len().min(2);
+                self.remaining.read(&mut buf[..len])
+            }
+        }
+        impl AsyncRead for Reader {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                cx: &mut TaskContext<'_>,
+                buf: &mut [u8],
+            ) -> Poll<io::Result<usize>> {
+                if !self.pending {
+                    self.pending = true;
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                self.pending = false;
+                Poll::Ready(read_retry(&mut *self, buf))
+            }
+        }
+        let reader = || Reader {
+            remaining: b"hello",
+            interrupted: false,
+            pending: false,
+        };
+        assert_eq!(sha256_reader(reader()).unwrap(), sha256(b"hello"));
+        for asynchronous in [false, true] {
+            let mut hasher = Sha256Hasher::new();
+            let hashers = std::slice::from_mut(&mut hasher);
+            if asynchronous {
+                block_on(hash_async_reader(reader(), hashers)).unwrap();
+            } else {
+                block_on(hash_reader_yielding(reader(), hashers)).unwrap();
+            }
+            assert_eq!(hasher.finalize(), sha256(b"hello"));
+        }
     }
 
     #[test]

--- a/crates/sigstore-crypto/src/hash.rs
+++ b/crates/sigstore-crypto/src/hash.rs
@@ -1,7 +1,7 @@
 //! Hashing utilities using aws-lc-rs
 
 use aws_lc_rs::digest::{self, Context, SHA256, SHA384, SHA512};
-use sigstore_types::Sha256Hash;
+use sigstore_types::{ArtifactDigest, HashAlgorithm, Sha256Hash};
 use std::io::{self, Read};
 
 /// Hash data using SHA-256, returning a typed hash
@@ -22,6 +22,35 @@ pub fn sha384(data: &[u8]) -> Vec<u8> {
 pub fn sha512(data: &[u8]) -> Vec<u8> {
     let digest = digest::digest(&SHA512, data);
     digest.as_ref().to_vec()
+}
+
+/// Incremental hasher for a typed artifact digest.
+pub struct ArtifactHasher {
+    algorithm: HashAlgorithm,
+    context: Context,
+}
+
+impl ArtifactHasher {
+    pub fn new(algorithm: HashAlgorithm) -> Self {
+        let backend = match algorithm {
+            HashAlgorithm::Sha2256 => &SHA256,
+            HashAlgorithm::Sha2384 => &SHA384,
+            HashAlgorithm::Sha2512 => &SHA512,
+        };
+        Self {
+            algorithm,
+            context: Context::new(backend),
+        }
+    }
+
+    pub fn update(&mut self, data: &[u8]) {
+        self.context.update(data);
+    }
+
+    pub fn finalize(self) -> ArtifactDigest {
+        ArtifactDigest::new(self.algorithm, self.context.finish().as_ref())
+            .expect("cryptographic backend returned the algorithm's documented digest length")
+    }
 }
 
 /// Incremental SHA-256 hasher

--- a/crates/sigstore-crypto/src/hash.rs
+++ b/crates/sigstore-crypto/src/hash.rs
@@ -1,8 +1,15 @@
 //! Hashing utilities using aws-lc-rs
 
 use aws_lc_rs::digest::{self, Context, SHA256, SHA384, SHA512};
+use futures_io::AsyncRead;
 use sigstore_types::{ArtifactDigest, HashAlgorithm, Sha256Hash, Sha512Hash};
+use std::future::Future;
 use std::io::{self, Read};
+use std::pin::Pin;
+use std::task::{Context as TaskContext, Poll};
+
+/// Bytes read and hashed between yields to the async executor.
+const HASH_CHUNK_SIZE: usize = 64 * 1024;
 
 /// Hash data using SHA-256, returning a typed hash
 pub fn sha256(data: &[u8]) -> Sha256Hash {
@@ -52,6 +59,27 @@ impl ArtifactHasher {
     pub fn finalize(self) -> ArtifactDigest {
         ArtifactDigest::new(self.algorithm, self.context.finish().as_ref())
             .expect("backend digest length does not match the algorithm's documented length")
+    }
+}
+
+/// An incremental hasher that can absorb more input.
+///
+/// Implemented by every hasher in this module so the reader helpers below can
+/// feed one pass over the input into any combination of them.
+pub trait HashUpdate {
+    /// Absorb `data`.
+    fn update(&mut self, data: &[u8]);
+}
+
+impl HashUpdate for ArtifactHasher {
+    fn update(&mut self, data: &[u8]) {
+        ArtifactHasher::update(self, data);
+    }
+}
+
+impl HashUpdate for Sha256Hasher {
+    fn update(&mut self, data: &[u8]) {
+        Sha256Hasher::update(self, data);
     }
 }
 
@@ -108,17 +136,113 @@ impl Default for Sha256Hasher {
 /// let file = File::open("large-file.tar.gz").unwrap();
 /// let hash = sha256_reader(file).unwrap();
 /// ```
-pub fn sha256_reader(mut reader: impl Read) -> io::Result<Sha256Hash> {
+pub fn sha256_reader(reader: impl Read) -> io::Result<Sha256Hash> {
     let mut hasher = Sha256Hasher::new();
-    let mut buf = [0u8; 8192];
-    loop {
-        let n = reader.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
+    hash_reader(reader, std::slice::from_mut(&mut hasher))?;
     Ok(hasher.finalize())
+}
+
+/// Feed `reader` to EOF into every hasher in constant memory.
+///
+/// Reads block the calling thread. Inside an async task use
+/// [`hash_reader_yielding`] or [`hash_async_reader`] instead.
+pub fn hash_reader<H: HashUpdate>(mut reader: impl Read, hashers: &mut [H]) -> io::Result<()> {
+    let mut buffer = [0_u8; HASH_CHUNK_SIZE];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(());
+        }
+        for hasher in hashers.iter_mut() {
+            hasher.update(&buffer[..read]);
+        }
+    }
+}
+
+/// Feed a blocking `reader` to EOF into every hasher, yielding to the async
+/// executor after each chunk.
+///
+/// Hashing is CPU-bound: doing it in one shot over unbounded caller input
+/// would occupy the executor thread for the whole duration and starve other
+/// tasks (TOB-SIGSTORE-8). Reading and hashing in 64 KiB chunks
+/// keeps each non-yielding stretch short. In-memory input works too, since
+/// `&[u8]` implements [`Read`].
+///
+/// The reads themselves still block the executor thread; prefer
+/// [`hash_async_reader`] when the input has an async source.
+pub async fn hash_reader_yielding<H: HashUpdate>(
+    reader: impl Read,
+    hashers: &mut [H],
+) -> io::Result<()> {
+    hash_async_reader(BlockingReader(reader), hashers).await
+}
+
+/// Feed an async `reader` to EOF into every hasher, yielding to the executor
+/// after each chunk.
+///
+/// `AsyncRead` implementations may return `Ready` indefinitely (an in-memory
+/// cursor, for example), so awaiting a read is not by itself a scheduling
+/// point. Yielding explicitly after each hashed chunk keeps large inputs from
+/// monopolizing the executor thread (TOB-SIGSTORE-8).
+pub async fn hash_async_reader<H: HashUpdate>(
+    mut reader: impl AsyncRead + Unpin,
+    hashers: &mut [H],
+) -> io::Result<()> {
+    let mut buffer = [0_u8; HASH_CHUNK_SIZE];
+    loop {
+        let read =
+            std::future::poll_fn(|cx| Pin::new(&mut reader).poll_read(cx, &mut buffer)).await?;
+        if read == 0 {
+            return Ok(());
+        }
+        for hasher in hashers.iter_mut() {
+            hasher.update(&buffer[..read]);
+        }
+        yield_now().await;
+    }
+}
+
+/// Adapter presenting a blocking [`Read`] as an always-ready [`AsyncRead`].
+struct BlockingReader<R>(R);
+
+// The wrapped reader is only ever used through `&mut`, never pinned, so the
+// adapter can move freely regardless of `R`.
+impl<R> Unpin for BlockingReader<R> {}
+
+impl<R: Read> AsyncRead for BlockingReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut TaskContext<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(self.0.read(buf))
+    }
+}
+
+/// Yield control back to the async executor once.
+///
+/// Runtime-agnostic equivalent of `tokio::task::yield_now()`: the future
+/// wakes its own waker and returns `Pending` on the first poll, then `Ready`.
+fn yield_now() -> impl Future<Output = ()> {
+    struct YieldNow {
+        yielded: bool,
+    }
+
+    impl Future for YieldNow {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<()> {
+            if self.yielded {
+                Poll::Ready(())
+            } else {
+                self.yielded = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    YieldNow { yielded: false }
 }
 
 #[cfg(test)]
@@ -171,5 +295,110 @@ mod tests {
 
         let direct = sha256(data);
         assert_eq!(hash, direct);
+    }
+
+    fn chunk_boundary_sizes() -> [usize; 6] {
+        [
+            0,
+            1,
+            HASH_CHUNK_SIZE - 1,
+            HASH_CHUNK_SIZE,
+            HASH_CHUNK_SIZE + 1,
+            3 * HASH_CHUNK_SIZE + 17,
+        ]
+    }
+
+    fn patterned(size: usize) -> Vec<u8> {
+        (0..size).map(|i| (i % 251) as u8).collect()
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        // Every future here only ever yields once per chunk and re-wakes
+        // itself, so a spin loop with a no-op waker is a sufficient executor.
+        let waker = futures_task_noop_waker();
+        let mut cx = TaskContext::from_waker(&waker);
+        let mut future = Box::pin(future);
+        loop {
+            if let Poll::Ready(output) = future.as_mut().poll(&mut cx) {
+                return output;
+            }
+        }
+    }
+
+    fn futures_task_noop_waker() -> std::task::Waker {
+        use std::task::{RawWaker, RawWakerVTable, Waker};
+        fn noop(_: *const ()) {}
+        fn clone(p: *const ()) -> RawWaker {
+            RawWaker::new(p, &VTABLE)
+        }
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+        // SAFETY: the vtable functions ignore the data pointer entirely.
+        unsafe { Waker::from_raw(RawWaker::new(std::ptr::null(), &VTABLE)) }
+    }
+
+    #[test]
+    fn reader_helpers_match_one_shot_hashing_across_chunk_boundaries() {
+        for size in chunk_boundary_sizes() {
+            let data = patterned(size);
+            let expected = sha256(&data);
+
+            let mut hashers = [
+                ArtifactHasher::new(HashAlgorithm::Sha2256),
+                ArtifactHasher::new(HashAlgorithm::Sha2512),
+            ];
+            hash_reader(data.as_slice(), &mut hashers).unwrap();
+            let [h256, h512] = hashers;
+            assert_eq!(
+                h256.finalize().as_bytes(),
+                expected.as_bytes(),
+                "size {size}"
+            );
+            assert_eq!(
+                h512.finalize().as_bytes(),
+                sha512(&data).as_bytes(),
+                "size {size}"
+            );
+
+            let mut hasher = Sha256Hasher::new();
+            block_on(hash_reader_yielding(
+                data.as_slice(),
+                std::slice::from_mut(&mut hasher),
+            ))
+            .unwrap();
+            assert_eq!(hasher.finalize(), expected, "size {size}");
+
+            let mut hasher = Sha256Hasher::new();
+            block_on(hash_async_reader(
+                BlockingReader(data.as_slice()),
+                std::slice::from_mut(&mut hasher),
+            ))
+            .unwrap();
+            assert_eq!(hasher.finalize(), expected, "size {size}");
+        }
+    }
+
+    #[test]
+    fn async_hashing_yields_even_when_reads_are_ready() {
+        let mut hasher = Sha256Hasher::new();
+        let mut future = Box::pin(hash_async_reader(
+            BlockingReader(&[42_u8][..]),
+            std::slice::from_mut(&mut hasher),
+        ));
+        let waker = futures_task_noop_waker();
+        let mut cx = TaskContext::from_waker(&waker);
+        assert!(future.as_mut().poll(&mut cx).is_pending());
+    }
+
+    #[test]
+    fn reader_errors_are_propagated() {
+        struct Failing;
+        impl Read for Failing {
+            fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::Other, "disk on fire"))
+            }
+        }
+        let mut hasher = Sha256Hasher::new();
+        let err = hash_reader(Failing, std::slice::from_mut(&mut hasher)).unwrap_err();
+        assert_eq!(err.to_string(), "disk on fire");
     }
 }

--- a/crates/sigstore-crypto/src/hash.rs
+++ b/crates/sigstore-crypto/src/hash.rs
@@ -142,6 +142,18 @@ pub fn sha256_reader(reader: impl Read) -> io::Result<Sha256Hash> {
     Ok(hasher.finalize())
 }
 
+/// Hash in-memory data directly, yielding to the executor after each 64 KiB
+/// chunk so unbounded input cannot starve other tasks (TOB-SIGSTORE-8).
+/// Unlike [`hash_reader_yielding`], this does not copy through a reader buffer.
+pub async fn hash_yielding<H: HashUpdate>(data: &[u8], hashers: &mut [H]) {
+    for chunk in data.chunks(HASH_CHUNK_SIZE) {
+        for hasher in hashers.iter_mut() {
+            hasher.update(chunk);
+        }
+        yield_now().await;
+    }
+}
+
 /// Feed `reader` to EOF into every hasher in constant memory.
 ///
 /// Reads block the calling thread. Inside an async task use
@@ -165,8 +177,8 @@ pub fn hash_reader<H: HashUpdate>(mut reader: impl Read, hashers: &mut [H]) -> i
 /// Hashing is CPU-bound: doing it in one shot over unbounded caller input
 /// would occupy the executor thread for the whole duration and starve other
 /// tasks (TOB-SIGSTORE-8). Reading and hashing in 64 KiB chunks
-/// keeps each non-yielding stretch short. In-memory input works too, since
-/// `&[u8]` implements [`Read`].
+/// keeps each non-yielding stretch short. For in-memory slices, prefer
+/// [`hash_yielding`] to avoid copying through a reader buffer.
 ///
 /// The reads themselves still block the executor thread; prefer
 /// [`hash_async_reader`] when the input has an async source.
@@ -248,6 +260,7 @@ fn yield_now() -> impl Future<Output = ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::{executor::block_on, task::noop_waker_ref};
 
     #[test]
     fn test_sha256() {
@@ -312,27 +325,6 @@ mod tests {
         (0..size).map(|i| (i % 251) as u8).collect()
     }
 
-    fn block_on<F: Future>(future: F) -> F::Output {
-        // Every future here only ever yields once per chunk and re-wakes
-        // itself, so a spin loop with a no-op waker is a sufficient executor.
-        let waker = futures_task_noop_waker();
-        let mut cx = TaskContext::from_waker(&waker);
-        let mut future = Box::pin(future);
-        loop {
-            if let Poll::Ready(output) = future.as_mut().poll(&mut cx) {
-                return output;
-            }
-        }
-    }
-
-    fn futures_task_noop_waker() -> std::task::Waker {
-        struct Noop;
-        impl std::task::Wake for Noop {
-            fn wake(self: std::sync::Arc<Self>) {}
-        }
-        std::sync::Arc::new(Noop).into()
-    }
-
     #[test]
     fn reader_helpers_match_one_shot_hashing_across_chunk_boundaries() {
         for size in chunk_boundary_sizes() {
@@ -375,14 +367,46 @@ mod tests {
     }
 
     #[test]
+    fn slice_hashing_uses_source_chunks_and_yields() {
+        struct CheckSource<'a> {
+            remaining: &'a [u8],
+            hasher: Sha256Hasher,
+        }
+        impl HashUpdate for CheckSource<'_> {
+            fn update(&mut self, data: &[u8]) {
+                // Catch accidental copies through a reader buffer.
+                assert_eq!(data.as_ptr(), self.remaining.as_ptr());
+                assert!(data.len() <= HASH_CHUNK_SIZE);
+                self.remaining = &self.remaining[data.len()..];
+                self.hasher.update(data);
+            }
+        }
+        for size in chunk_boundary_sizes() {
+            let data = patterned(size);
+            let mut checked = CheckSource {
+                remaining: &data,
+                hasher: Sha256Hasher::new(),
+            };
+            let mut future = Box::pin(hash_yielding(&data, std::slice::from_mut(&mut checked)));
+            let mut cx = TaskContext::from_waker(noop_waker_ref());
+            for _ in data.chunks(HASH_CHUNK_SIZE) {
+                assert!(future.as_mut().poll(&mut cx).is_pending());
+            }
+            assert!(future.as_mut().poll(&mut cx).is_ready());
+            drop(future);
+            assert!(checked.remaining.is_empty());
+            assert_eq!(checked.hasher.finalize(), sha256(&data));
+        }
+    }
+
+    #[test]
     fn async_hashing_yields_even_when_reads_are_ready() {
         let mut hasher = Sha256Hasher::new();
         let mut future = Box::pin(hash_async_reader(
             BlockingReader(&[42_u8][..]),
             std::slice::from_mut(&mut hasher),
         ));
-        let waker = futures_task_noop_waker();
-        let mut cx = TaskContext::from_waker(&waker);
+        let mut cx = TaskContext::from_waker(noop_waker_ref());
         assert!(future.as_mut().poll(&mut cx).is_pending());
     }
 

--- a/crates/sigstore-crypto/src/lib.rs
+++ b/crates/sigstore-crypto/src/lib.rs
@@ -13,7 +13,7 @@ pub mod x509;
 
 pub use checkpoint::{compute_key_hint, Checkpoint, CheckpointSignature, CheckpointVerifyExt};
 pub use error::{Error, Result};
-pub use hash::{sha256, sha256_reader, sha384, sha512, Sha256Hasher};
+pub use hash::{sha256, sha256_reader, sha384, sha512, ArtifactHasher, Sha256Hasher};
 pub use keyring::Keyring;
 pub use signing::{KeyAlgorithm, KeyPair, SigningScheme};
 pub use verification::{verify_signature, verify_signature_prehashed, VerificationKey};

--- a/crates/sigstore-crypto/src/lib.rs
+++ b/crates/sigstore-crypto/src/lib.rs
@@ -13,7 +13,10 @@ pub mod x509;
 
 pub use checkpoint::{compute_key_hint, Checkpoint, CheckpointSignature, CheckpointVerifyExt};
 pub use error::{Error, Result};
-pub use hash::{sha256, sha256_reader, sha384, sha512, ArtifactHasher, Sha256Hasher};
+pub use hash::{
+    hash_async_reader, hash_reader, hash_reader_yielding, sha256, sha256_reader, sha384, sha512,
+    ArtifactHasher, HashUpdate, Sha256Hasher,
+};
 pub use keyring::Keyring;
 pub use signing::{KeyAlgorithm, KeyPair, SigningScheme};
 pub use verification::{verify_signature, verify_signature_prehashed, VerificationKey};

--- a/crates/sigstore-crypto/src/lib.rs
+++ b/crates/sigstore-crypto/src/lib.rs
@@ -14,8 +14,8 @@ pub mod x509;
 pub use checkpoint::{compute_key_hint, Checkpoint, CheckpointSignature, CheckpointVerifyExt};
 pub use error::{Error, Result};
 pub use hash::{
-    hash_async_reader, hash_reader, hash_reader_yielding, sha256, sha256_reader, sha384, sha512,
-    ArtifactHasher, HashUpdate, Sha256Hasher,
+    hash_async_reader, hash_reader, hash_reader_yielding, hash_yielding, sha256, sha256_reader,
+    sha384, sha512, ArtifactHasher, HashUpdate, Sha256Hasher,
 };
 pub use keyring::Keyring;
 pub use signing::{KeyAlgorithm, KeyPair, SigningScheme};

--- a/crates/sigstore-sign/Cargo.toml
+++ b/crates/sigstore-sign/Cargo.toml
@@ -20,10 +20,11 @@ thiserror = { workspace = true }
 base64 = { workspace = true }
 x509-cert = { workspace = true }
 serde_json = { workspace = true }
-futures = { workspace = true }
+futures-io = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+futures = { workspace = true }
 jiff = { workspace = true }
 serde = { workspace = true }
 hex = { workspace = true }

--- a/crates/sigstore-sign/Cargo.toml
+++ b/crates/sigstore-sign/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { workspace = true }
 base64 = { workspace = true }
 x509-cert = { workspace = true }
 serde_json = { workspace = true }
+futures = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/sigstore-sign/README.md
+++ b/crates/sigstore-sign/README.md
@@ -48,6 +48,13 @@ let bundle = signer.sign(artifact).await?;
 let digest = Sha256Hash::from_hex("b94d27b9...")?;
 let bundle = signer.sign(digest).await?;
 
+// Or stream without loading the artifact into memory
+let file = std::fs::File::open("large-artifact.tar.gz")?;
+let bundle = signer.sign_reader(file).await?;
+
+// Runtime-independent async readers are supported as well
+let bundle = signer.sign_async_reader(async_reader).await?;
+
 // Sign an in-toto attestation (DSSE envelope)
 let subject = AttestationSubject::new("artifact.tar.gz", digest);
 let attestation = Attestation::new("https://slsa.dev/provenance/v1")

--- a/crates/sigstore-sign/README.md
+++ b/crates/sigstore-sign/README.md
@@ -78,6 +78,9 @@ let context = SigningContext::production();
 let context = SigningContext::staging();
 ```
 
+For Tokio files/streams, enable `tokio-util`'s `compat` feature and call
+`TokioAsyncReadCompatExt::compat()` before passing the reader to the async API.
+
 ## Related Crates
 
 - [`sigstore-verify`](../sigstore-verify) - Verify signatures created by this crate

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -114,17 +114,19 @@ async fn main() {
     let artifact_path = &positional[0];
     let output_path = output.unwrap_or_else(|| format!("{}.sigstore.json", artifact_path));
 
-    // Read artifact
-    let artifact = match fs::read(artifact_path) {
-        Ok(data) => data,
+    // Stream the artifact instead of loading it into memory.
+    let artifact = match fs::File::open(artifact_path) {
+        Ok(file) => file,
         Err(e) => {
-            eprintln!("Error reading artifact '{}': {}", artifact_path, e);
+            eprintln!("Error opening artifact '{}': {}", artifact_path, e);
             process::exit(1);
         }
     };
 
     println!("Signing artifact: {}", artifact_path);
-    println!("  Size: {} bytes", artifact.len());
+    if let Ok(metadata) = artifact.metadata() {
+        println!("  Size: {} bytes", metadata.len());
+    }
 
     // Create signing context with appropriate API version
     let tuf_config = if let Some(ref url) = instance {
@@ -189,7 +191,7 @@ async fn main() {
     let signer = context.signer(identity_token);
 
     println!("\nSigning...");
-    let bundle = match signer.sign(&artifact).await {
+    let bundle = match signer.sign_reader(artifact).await {
         Ok(b) => b,
         Err(e) => {
             eprintln!("Error signing artifact: {}", e);

--- a/crates/sigstore-sign/src/error.rs
+++ b/crates/sigstore-sign/src/error.rs
@@ -36,6 +36,10 @@ pub enum Error {
     /// OIDC error
     #[error("OIDC error: {0}")]
     Oidc(#[from] sigstore_oidc::Error),
+
+    /// Failed to read artifact input.
+    #[error("failed to read artifact: {0}")]
+    ArtifactRead(#[source] std::io::Error),
 }
 
 /// Result type for signing operations

--- a/crates/sigstore-sign/src/lib.rs
+++ b/crates/sigstore-sign/src/lib.rs
@@ -36,6 +36,5 @@ pub use sigstore_types as types;
 
 pub use error::{Error, Result};
 pub use sign::{
-    async_reader, reader, sign_context, ArtifactSource, AsyncArtifactSource, Attestation,
-    AttestationSubject, Signer, SigningConfig, SigningContext,
+    sign_context, Attestation, AttestationSubject, Signer, SigningConfig, SigningContext,
 };

--- a/crates/sigstore-sign/src/lib.rs
+++ b/crates/sigstore-sign/src/lib.rs
@@ -36,5 +36,6 @@ pub use sigstore_types as types;
 
 pub use error::{Error, Result};
 pub use sign::{
-    sign_context, Attestation, AttestationSubject, Signer, SigningConfig, SigningContext,
+    async_reader, reader, sign_context, ArtifactSource, AsyncArtifactSource, Attestation,
+    AttestationSubject, Signer, SigningConfig, SigningContext,
 };

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -23,72 +23,6 @@ use sigstore_types::{
     TransparencyLogEntry,
 };
 
-/// Artifact input for signing.
-#[derive(Debug)]
-pub enum ArtifactSource<'a, R = std::io::Empty> {
-    /// Raw artifact bytes or a pre-computed digest.
-    Artifact(Artifact<'a>),
-    /// Artifact bytes streamed from a reader.
-    Reader(R),
-}
-
-/// Reader input for [`ArtifactSource`].
-#[derive(Debug)]
-pub struct Reader<R>(R);
-
-/// Wrap a reader so it can be passed to `sign(...).`
-pub fn reader<R>(reader: R) -> Reader<R> {
-    Reader(reader)
-}
-
-impl<'a, A> From<A> for ArtifactSource<'a>
-where
-    A: Into<Artifact<'a>>,
-{
-    fn from(artifact: A) -> Self {
-        Self::Artifact(artifact.into())
-    }
-}
-
-impl<'a, R> From<Reader<R>> for ArtifactSource<'a, R> {
-    fn from(reader: Reader<R>) -> Self {
-        Self::Reader(reader.0)
-    }
-}
-
-/// Artifact input for async signing.
-#[derive(Debug)]
-pub enum AsyncArtifactSource<'a, R = futures::io::Empty> {
-    /// Raw artifact bytes or a pre-computed digest.
-    Artifact(Artifact<'a>),
-    /// Artifact bytes streamed from an async reader.
-    Reader(R),
-}
-
-/// Async reader input for [`AsyncArtifactSource`].
-#[derive(Debug)]
-pub struct AsyncReader<R>(R);
-
-/// Wrap an async reader so it can be passed to `sign_async(...).`
-pub fn async_reader<R>(reader: R) -> AsyncReader<R> {
-    AsyncReader(reader)
-}
-
-impl<'a, A> From<A> for AsyncArtifactSource<'a>
-where
-    A: Into<Artifact<'a>>,
-{
-    fn from(artifact: A) -> Self {
-        Self::Artifact(artifact.into())
-    }
-}
-
-impl<'a, R> From<AsyncReader<R>> for AsyncArtifactSource<'a, R> {
-    fn from(reader: AsyncReader<R>) -> Self {
-        Self::Reader(reader.0)
-    }
-}
-
 /// Number of bytes hashed between yields to the async executor.
 const HASH_YIELD_CHUNK_SIZE: usize = 64 * 1024;
 
@@ -437,13 +371,19 @@ impl Signer {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn sign<'a, R: std::io::Read>(
-        &self,
-        artifact: impl Into<ArtifactSource<'a, R>>,
-    ) -> Result<Bundle> {
+    pub async fn sign<'a>(&self, artifact: impl Into<Artifact<'a>>) -> Result<Bundle> {
         let artifact_hash = match artifact.into() {
-            ArtifactSource::Artifact(artifact) => self.sha256_artifact(artifact).await?,
-            ArtifactSource::Reader(reader) => sha256_reader_yielding(reader).await?,
+            Artifact::Blob(blob) => sha256_yielding(blob).await.finalize(),
+            Artifact::Digest(digest) => {
+                if digest.algorithm() != HashAlgorithm::Sha2256 {
+                    return Err(Error::Signing(format!(
+                        "hashedrekord signing requires a SHA-256 artifact digest, got {}",
+                        digest.algorithm()
+                    )));
+                }
+                Sha256Hash::try_from_slice(digest.as_bytes())
+                    .map_err(|e| Error::Signing(e.to_string()))?
+            }
         };
         self.sign_sha256(artifact_hash).await
     }
@@ -453,40 +393,13 @@ impl Signer {
     /// Reads happen while this future is polled and may block its executor
     /// thread. Async applications should prefer [`Signer::sign_async_reader`].
     pub async fn sign_reader(&self, reader: impl std::io::Read) -> Result<Bundle> {
-        self.sign(crate::sign::reader(reader)).await
+        self.sign_sha256(sha256_reader_yielding(reader).await?)
+            .await
     }
 
     /// Sign an artifact read asynchronously to EOF in constant memory.
     pub async fn sign_async_reader(&self, reader: impl AsyncRead + Unpin) -> Result<Bundle> {
-        self.sign_async(crate::sign::async_reader(reader)).await
-    }
-
-    /// Sign an artifact or async reader.
-    pub async fn sign_async<'a, R: AsyncRead + Unpin>(
-        &self,
-        artifact: impl Into<AsyncArtifactSource<'a, R>>,
-    ) -> Result<Bundle> {
-        let artifact_hash = match artifact.into() {
-            AsyncArtifactSource::Artifact(artifact) => self.sha256_artifact(artifact).await?,
-            AsyncArtifactSource::Reader(reader) => sha256_async_reader(reader).await?,
-        };
-        self.sign_sha256(artifact_hash).await
-    }
-
-    async fn sha256_artifact(&self, artifact: Artifact<'_>) -> Result<Sha256Hash> {
-        match artifact {
-            Artifact::Blob(blob) => Ok(sha256_yielding(blob).await.finalize()),
-            Artifact::Digest(digest) => {
-                if digest.algorithm() != HashAlgorithm::Sha2256 {
-                    return Err(Error::Signing(format!(
-                        "hashedrekord signing requires a SHA-256 artifact digest, got {}",
-                        digest.algorithm()
-                    )));
-                }
-                Sha256Hash::try_from_slice(digest.as_bytes())
-                    .map_err(|e| Error::Signing(e.to_string()))
-            }
-        }
+        self.sign_sha256(sha256_async_reader(reader).await?).await
     }
 
     async fn sign_sha256(&self, artifact_hash: Sha256Hash) -> Result<Bundle> {

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -80,8 +80,24 @@ async fn prepare_dsse_payload_yielding(
     payload_type: &str,
     data: &[u8],
 ) -> (PayloadBytes, Sha256Hasher) {
-    let hasher = sha256_pae_yielding(payload_type, data).await;
-    (PayloadBytes::new(data.to_vec()), hasher)
+    struct CopyAndHash {
+        payload: Vec<u8>,
+        hasher: Sha256Hasher,
+    }
+    impl sigstore_crypto::HashUpdate for CopyAndHash {
+        fn update(&mut self, data: &[u8]) {
+            self.payload.extend_from_slice(data);
+            self.hasher.update(data);
+        }
+    }
+    let mut prepared = CopyAndHash {
+        payload: Vec::with_capacity(data.len()),
+        hasher: dsse_pae_hasher(payload_type, data.len()),
+    };
+    hash_reader_yielding(data, std::slice::from_mut(&mut prepared))
+        .await
+        .expect("reading from an in-memory slice cannot fail");
+    (PayloadBytes::new(prepared.payload), prepared.hasher)
 }
 
 /// Configuration for signing operations
@@ -201,13 +217,31 @@ impl SigningConfig {
 
     /// Validate that the configured services can produce a verifiable bundle.
     pub fn validate(&self) -> Result<()> {
-        if self.rekor_api_version == RekorApiVersion::V2 && self.tsa_url.is_none() {
-            return Err(Error::Config(
-                "Rekor v2 requires an RFC 3161 timestamp authority".to_string(),
-            ));
-        }
-        Ok(())
+        validate_configuration(
+            self.signing_scheme,
+            self.rekor_api_version,
+            self.tsa_url.as_deref(),
+        )
     }
+}
+
+fn validate_configuration(
+    scheme: SigningScheme,
+    rekor: RekorApiVersion,
+    tsa: Option<&str>,
+) -> Result<()> {
+    if scheme != SigningScheme::EcdsaP256Sha256 {
+        return Err(Error::Config(format!(
+            "signing scheme {} is not supported",
+            scheme.name()
+        )));
+    }
+    if rekor == RekorApiVersion::V2 && tsa.is_none() {
+        return Err(Error::Config(
+            "Rekor v2 requires an RFC 3161 timestamp authority".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Context for signing operations
@@ -597,12 +631,11 @@ impl Signer {
     }
 
     fn validate_configuration(&self) -> Result<()> {
-        if self.rekor_api_version == RekorApiVersion::V2 && self.tsa_url.is_none() {
-            return Err(Error::Config(
-                "Rekor v2 requires an RFC 3161 timestamp authority".to_string(),
-            ));
-        }
-        Ok(())
+        validate_configuration(
+            self.signing_scheme,
+            self.rekor_api_version,
+            self.tsa_url.as_deref(),
+        )
     }
 
     fn rekor_v2_key_details(&self) -> Result<RekorV2KeyDetails> {
@@ -739,6 +772,30 @@ mod tests {
 
         config.tsa_url = Some("https://timestamp.example".to_string());
         config.validate().unwrap();
+    }
+
+    #[tokio::test]
+    async fn unsupported_scheme_does_not_consume_reader() {
+        use base64::Engine;
+        let jwt = format!(
+            "header.{}.signature",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(br#"{"iss":"test","sub":"test","exp":9999999999}"#)
+        );
+        let config = SigningConfig {
+            signing_scheme: SigningScheme::Ed25519,
+            ..Default::default()
+        };
+        let signer =
+            SigningContext::with_config(config).signer(IdentityToken::from_jwt(&jwt).unwrap());
+        let mut reader = std::io::Cursor::new(b"do not read");
+        assert!(signer
+            .sign_reader(&mut reader)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("not supported"));
+        assert_eq!(reader.position(), 0);
     }
 
     #[test]

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -3,9 +3,11 @@
 //! This module provides the main entry point for signing artifacts with Sigstore.
 
 use crate::error::{Error, Result};
-use futures::io::{AsyncRead, AsyncReadExt};
+use futures_io::AsyncRead;
 use sigstore_bundle::{BundleV03, TlogEntryBuilder};
-use sigstore_crypto::{KeyPair, Sha256Hasher, SigningScheme};
+use sigstore_crypto::{
+    hash_async_reader, hash_reader_yielding, KeyPair, Sha256Hasher, SigningScheme,
+};
 use sigstore_fulcio::FulcioClient;
 use sigstore_oidc::IdentityToken;
 use sigstore_rekor::{
@@ -23,93 +25,32 @@ use sigstore_types::{
     TransparencyLogEntry,
 };
 
-/// Number of bytes hashed between yields to the async executor.
-const HASH_YIELD_CHUNK_SIZE: usize = 64 * 1024;
-
-/// Yield control back to the async executor once.
-///
-/// Runtime-agnostic equivalent of `tokio::task::yield_now()`: the future
-/// wakes its own waker and returns `Pending` on the first poll, then `Ready`.
-fn yield_now() -> impl std::future::Future<Output = ()> {
-    struct YieldNow {
-        yielded: bool,
-    }
-
-    impl std::future::Future for YieldNow {
-        type Output = ();
-
-        fn poll(
-            mut self: std::pin::Pin<&mut Self>,
-            cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<()> {
-            if self.yielded {
-                std::task::Poll::Ready(())
-            } else {
-                self.yielded = true;
-                cx.waker().wake_by_ref();
-                std::task::Poll::Pending
-            }
-        }
-    }
-
-    YieldNow { yielded: false }
+/// Hash in-memory `data` into `hasher`, yielding to the executor between
+/// chunks so unbounded caller input cannot starve other tasks (TOB-SIGSTORE-8).
+async fn update_yielding(hasher: &mut Sha256Hasher, data: &[u8]) {
+    hash_reader_yielding(data, std::slice::from_mut(hasher))
+        .await
+        .expect("reading from an in-memory slice cannot fail");
 }
 
-async fn update_sha256_yielding(hasher: &mut Sha256Hasher, data: &[u8]) {
-    for chunk in data.chunks(HASH_YIELD_CHUNK_SIZE) {
-        hasher.update(chunk);
-        yield_now().await;
-    }
-}
-
-/// Compute a SHA-256 digest over `data` in chunks, yielding to the async
-/// executor between chunks.
+/// SHA-256 a blocking reader to EOF, yielding to the executor between chunks.
 ///
-/// Hashing is CPU-bound: doing it in one shot over unbounded caller input
-/// would occupy the executor thread for the whole duration and starve other
-/// tasks (TOB-SIGSTORE-8). Hashing in [`HASH_YIELD_CHUNK_SIZE`] chunks keeps
-/// each non-yielding stretch short so other tasks can make progress.
-///
-/// Returns the hasher so callers can either [`Sha256Hasher::finalize`] it or
-/// sign the digest directly via [`KeyPair::sign_prehashed`].
-async fn sha256_yielding(data: &[u8]) -> Sha256Hasher {
+/// The reads themselves run on the executor thread; see
+/// [`sigstore_crypto::hash_reader_yielding`].
+async fn sha256_yielding(reader: impl std::io::Read) -> Result<Sha256Hash> {
     let mut hasher = Sha256Hasher::new();
-    update_sha256_yielding(&mut hasher, data).await;
-    hasher
-}
-
-async fn sha256_reader_yielding(mut reader: impl std::io::Read) -> Result<Sha256Hash> {
-    let mut hasher = Sha256Hasher::new();
-    let mut buffer = [0_u8; HASH_YIELD_CHUNK_SIZE];
-    loop {
-        let read = std::io::Read::read(&mut reader, &mut buffer).map_err(Error::ArtifactRead)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-        yield_now().await;
-    }
+    hash_reader_yielding(reader, std::slice::from_mut(&mut hasher))
+        .await
+        .map_err(Error::ArtifactRead)?;
     Ok(hasher.finalize())
 }
 
-async fn sha256_async_reader(mut reader: impl AsyncRead + Unpin) -> Result<Sha256Hash> {
+/// SHA-256 an async reader to EOF, yielding to the executor between chunks.
+async fn sha256_async(reader: impl AsyncRead + Unpin) -> Result<Sha256Hash> {
     let mut hasher = Sha256Hasher::new();
-    let mut buffer = [0_u8; HASH_YIELD_CHUNK_SIZE];
-    loop {
-        let read = reader
-            .read(&mut buffer)
-            .await
-            .map_err(Error::ArtifactRead)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-        // AsyncRead is allowed to remain ready indefinitely (for example,
-        // futures::io::Cursor), so the read itself is not necessarily a
-        // scheduling point. Yield explicitly to keep large inputs from
-        // monopolizing the executor thread.
-        yield_now().await;
-    }
+    hash_async_reader(reader, std::slice::from_mut(&mut hasher))
+        .await
+        .map_err(Error::ArtifactRead)?;
     Ok(hasher.finalize())
 }
 
@@ -129,24 +70,18 @@ fn dsse_pae_hasher(payload_type: &str, payload_len: usize) -> Sha256Hasher {
 /// Hash a DSSE PAE in chunks without first allocating a full PAE copy.
 async fn sha256_pae_yielding(payload_type: &str, payload: &[u8]) -> Sha256Hasher {
     let mut hasher = dsse_pae_hasher(payload_type, payload.len());
-    update_sha256_yielding(&mut hasher, payload).await;
+    update_yielding(&mut hasher, payload).await;
     hasher
 }
 
-/// Copy a DSSE payload into its owned envelope representation while hashing
-/// its PAE in the same yielding pass.
+/// Copy a DSSE payload into its owned envelope representation and hash its
+/// PAE cooperatively, without allocating a full PAE copy.
 async fn prepare_dsse_payload_yielding(
     payload_type: &str,
     data: &[u8],
 ) -> (PayloadBytes, Sha256Hasher) {
-    let mut payload = Vec::with_capacity(data.len());
-    let mut hasher = dsse_pae_hasher(payload_type, data.len());
-    for chunk in data.chunks(HASH_YIELD_CHUNK_SIZE) {
-        payload.extend_from_slice(chunk);
-        hasher.update(chunk);
-        yield_now().await;
-    }
-    (PayloadBytes::new(payload), hasher)
+    let hasher = sha256_pae_yielding(payload_type, data).await;
+    (PayloadBytes::new(data.to_vec()), hasher)
 }
 
 /// Configuration for signing operations
@@ -373,7 +308,7 @@ impl Signer {
     /// ```
     pub async fn sign<'a>(&self, artifact: impl Into<Artifact<'a>>) -> Result<Bundle> {
         let artifact_hash = match artifact.into() {
-            Artifact::Blob(blob) => sha256_yielding(blob).await.finalize(),
+            Artifact::Blob(blob) => sha256_yielding(blob).await?,
             Artifact::Digest(digest) => {
                 if digest.algorithm() != HashAlgorithm::Sha2256 {
                     return Err(Error::Signing(format!(
@@ -393,13 +328,12 @@ impl Signer {
     /// Reads happen while this future is polled and may block its executor
     /// thread. Async applications should prefer [`Signer::sign_async_reader`].
     pub async fn sign_reader(&self, reader: impl std::io::Read) -> Result<Bundle> {
-        self.sign_sha256(sha256_reader_yielding(reader).await?)
-            .await
+        self.sign_sha256(sha256_yielding(reader).await?).await
     }
 
     /// Sign an artifact read asynchronously to EOF in constant memory.
     pub async fn sign_async_reader(&self, reader: impl AsyncRead + Unpin) -> Result<Bundle> {
-        self.sign_sha256(sha256_async_reader(reader).await?).await
+        self.sign_sha256(sha256_async(reader).await?).await
     }
 
     async fn sign_sha256(&self, artifact_hash: Sha256Hash) -> Result<Bundle> {
@@ -810,54 +744,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sha256_yielding_matches_one_shot() {
-        for size in [
-            0,
-            1,
-            HASH_YIELD_CHUNK_SIZE - 1,
-            HASH_YIELD_CHUNK_SIZE,
-            HASH_YIELD_CHUNK_SIZE + 1,
-            3 * HASH_YIELD_CHUNK_SIZE + 17,
-        ] {
-            let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-            let chunked = sha256_yielding(&data).await.finalize();
-            assert_eq!(chunked, sigstore_crypto::sha256(&data), "size {size}");
-        }
-    }
-
-    #[tokio::test]
-    async fn reader_hashing_matches_blob_hashing() {
-        let data = vec![42_u8; HASH_YIELD_CHUNK_SIZE * 2 + 7];
-        let expected = sigstore_crypto::sha256(&data);
-        assert_eq!(
-            sha256_reader_yielding(std::io::Cursor::new(&data))
-                .await
-                .unwrap(),
-            expected
-        );
-        assert_eq!(
-            sha256_async_reader(futures::io::Cursor::new(&data))
-                .await
-                .unwrap(),
-            expected
-        );
-    }
-
-    #[test]
-    fn async_reader_hashing_yields_even_when_reads_are_ready() {
-        let mut future = Box::pin(sha256_async_reader(futures::io::Cursor::new(vec![42_u8])));
-        let waker = futures::task::noop_waker();
-        let mut context = std::task::Context::from_waker(&waker);
-        assert!(matches!(
-            std::future::Future::poll(future.as_mut(), &mut context),
-            std::task::Poll::Pending
-        ));
-    }
-
-    #[tokio::test]
     async fn test_dsse_pae_yielding_matches_materialized_pae() {
         let payload_type = "application/vnd.in-toto+json";
-        for size in [0, 1, HASH_YIELD_CHUNK_SIZE, HASH_YIELD_CHUNK_SIZE + 1] {
+        // Straddle the 64 KiB chunk boundary used by the yielding hasher.
+        for size in [0, 1, 64 * 1024, 64 * 1024 + 1] {
             let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
             let (payload, hasher) = prepare_dsse_payload_yielding(payload_type, &data).await;
             assert_eq!(payload.as_bytes(), data);

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -307,6 +307,7 @@ impl Signer {
     /// # }
     /// ```
     pub async fn sign<'a>(&self, artifact: impl Into<Artifact<'a>>) -> Result<Bundle> {
+        self.validate_configuration()?;
         let artifact_hash = match artifact.into() {
             Artifact::Blob(blob) => sha256_yielding(blob).await?,
             Artifact::Digest(digest) => {
@@ -328,17 +329,21 @@ impl Signer {
     /// Reads happen while this future is polled and may block its executor
     /// thread. Async applications should prefer [`Signer::sign_async_reader`].
     pub async fn sign_reader(&self, reader: impl std::io::Read) -> Result<Bundle> {
+        self.validate_configuration()?;
         self.sign_sha256(sha256_yielding(reader).await?).await
     }
 
     /// Sign an artifact read asynchronously to EOF in constant memory.
     pub async fn sign_async_reader(&self, reader: impl AsyncRead + Unpin) -> Result<Bundle> {
+        self.validate_configuration()?;
         self.sign_sha256(sha256_async(reader).await?).await
     }
 
+    /// Sign an already hashed artifact.
+    ///
+    /// Callers validate the configuration before hashing so a misconfigured
+    /// signer fails immediately rather than after streaming a large artifact.
     async fn sign_sha256(&self, artifact_hash: Sha256Hash) -> Result<Bundle> {
-        self.validate_configuration()?;
-
         // 1. Generate ephemeral key pair
         let key_pair = self.generate_ephemeral_keypair()?;
 

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -3,6 +3,7 @@
 //! This module provides the main entry point for signing artifacts with Sigstore.
 
 use crate::error::{Error, Result};
+use futures::io::{AsyncRead, AsyncReadExt};
 use sigstore_bundle::{BundleV03, TlogEntryBuilder};
 use sigstore_crypto::{KeyPair, Sha256Hasher, SigningScheme};
 use sigstore_fulcio::FulcioClient;
@@ -21,6 +22,72 @@ use sigstore_types::{
     PayloadBytes, Sha256Hash, SignatureBytes, Statement, Subject, TimestampToken,
     TransparencyLogEntry,
 };
+
+/// Artifact input for signing.
+#[derive(Debug)]
+pub enum ArtifactSource<'a, R = std::io::Empty> {
+    /// Raw artifact bytes or a pre-computed digest.
+    Artifact(Artifact<'a>),
+    /// Artifact bytes streamed from a reader.
+    Reader(R),
+}
+
+/// Reader input for [`ArtifactSource`].
+#[derive(Debug)]
+pub struct Reader<R>(R);
+
+/// Wrap a reader so it can be passed to `sign(...).`
+pub fn reader<R>(reader: R) -> Reader<R> {
+    Reader(reader)
+}
+
+impl<'a, A> From<A> for ArtifactSource<'a>
+where
+    A: Into<Artifact<'a>>,
+{
+    fn from(artifact: A) -> Self {
+        Self::Artifact(artifact.into())
+    }
+}
+
+impl<'a, R> From<Reader<R>> for ArtifactSource<'a, R> {
+    fn from(reader: Reader<R>) -> Self {
+        Self::Reader(reader.0)
+    }
+}
+
+/// Artifact input for async signing.
+#[derive(Debug)]
+pub enum AsyncArtifactSource<'a, R = futures::io::Empty> {
+    /// Raw artifact bytes or a pre-computed digest.
+    Artifact(Artifact<'a>),
+    /// Artifact bytes streamed from an async reader.
+    Reader(R),
+}
+
+/// Async reader input for [`AsyncArtifactSource`].
+#[derive(Debug)]
+pub struct AsyncReader<R>(R);
+
+/// Wrap an async reader so it can be passed to `sign_async(...).`
+pub fn async_reader<R>(reader: R) -> AsyncReader<R> {
+    AsyncReader(reader)
+}
+
+impl<'a, A> From<A> for AsyncArtifactSource<'a>
+where
+    A: Into<Artifact<'a>>,
+{
+    fn from(artifact: A) -> Self {
+        Self::Artifact(artifact.into())
+    }
+}
+
+impl<'a, R> From<AsyncReader<R>> for AsyncArtifactSource<'a, R> {
+    fn from(reader: AsyncReader<R>) -> Self {
+        Self::Reader(reader.0)
+    }
+}
 
 /// Number of bytes hashed between yields to the async executor.
 const HASH_YIELD_CHUNK_SIZE: usize = 64 * 1024;
@@ -75,6 +142,41 @@ async fn sha256_yielding(data: &[u8]) -> Sha256Hasher {
     let mut hasher = Sha256Hasher::new();
     update_sha256_yielding(&mut hasher, data).await;
     hasher
+}
+
+async fn sha256_reader_yielding(mut reader: impl std::io::Read) -> Result<Sha256Hash> {
+    let mut hasher = Sha256Hasher::new();
+    let mut buffer = [0_u8; HASH_YIELD_CHUNK_SIZE];
+    loop {
+        let read = std::io::Read::read(&mut reader, &mut buffer).map_err(Error::ArtifactRead)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        yield_now().await;
+    }
+    Ok(hasher.finalize())
+}
+
+async fn sha256_async_reader(mut reader: impl AsyncRead + Unpin) -> Result<Sha256Hash> {
+    let mut hasher = Sha256Hasher::new();
+    let mut buffer = [0_u8; HASH_YIELD_CHUNK_SIZE];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .await
+            .map_err(Error::ArtifactRead)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        // AsyncRead is allowed to remain ready indefinitely (for example,
+        // futures::io::Cursor), so the read itself is not necessarily a
+        // scheduling point. Yield explicitly to keep large inputs from
+        // monopolizing the executor thread.
+        yield_now().await;
+    }
+    Ok(hasher.finalize())
 }
 
 /// Start hashing a DSSE PAE without materializing the PAE in memory.
@@ -335,23 +437,45 @@ impl Signer {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn sign<'a>(&self, artifact: impl Into<Artifact<'a>>) -> Result<Bundle> {
-        self.validate_configuration()?;
-        let artifact = artifact.into();
+    pub async fn sign<'a, R: std::io::Read>(
+        &self,
+        artifact: impl Into<ArtifactSource<'a, R>>,
+    ) -> Result<Bundle> {
+        let artifact_hash = match artifact.into() {
+            ArtifactSource::Artifact(artifact) => self.sha256_artifact(artifact).await?,
+            ArtifactSource::Reader(reader) => sha256_reader_yielding(reader).await?,
+        };
+        self.sign_sha256(artifact_hash).await
+    }
 
-        // 1. Generate ephemeral key pair
-        let key_pair = self.generate_ephemeral_keypair()?;
+    /// Sign an artifact read synchronously to EOF in constant memory.
+    ///
+    /// Reads happen while this future is polled and may block its executor
+    /// thread. Async applications should prefer [`Signer::sign_async_reader`].
+    pub async fn sign_reader(&self, reader: impl std::io::Read) -> Result<Bundle> {
+        self.sign(crate::sign::reader(reader)).await
+    }
 
-        // 2. Get signing certificate from Fulcio
-        let leaf_cert_der = self.request_certificate(&key_pair).await?;
+    /// Sign an artifact read asynchronously to EOF in constant memory.
+    pub async fn sign_async_reader(&self, reader: impl AsyncRead + Unpin) -> Result<Bundle> {
+        self.sign_async(crate::sign::async_reader(reader)).await
+    }
 
-        // 3. + 4. Hash blobs cooperatively, or explicitly attest to the typed
-        // digest supplied by the caller, then sign in prehashed mode.
-        let (artifact_hash, signature) = match artifact {
-            Artifact::Blob(blob) => {
-                let hasher = sha256_yielding(blob).await;
-                key_pair.sign_prehashed(hasher)?
-            }
+    /// Sign an artifact or async reader.
+    pub async fn sign_async<'a, R: AsyncRead + Unpin>(
+        &self,
+        artifact: impl Into<AsyncArtifactSource<'a, R>>,
+    ) -> Result<Bundle> {
+        let artifact_hash = match artifact.into() {
+            AsyncArtifactSource::Artifact(artifact) => self.sha256_artifact(artifact).await?,
+            AsyncArtifactSource::Reader(reader) => sha256_async_reader(reader).await?,
+        };
+        self.sign_sha256(artifact_hash).await
+    }
+
+    async fn sha256_artifact(&self, artifact: Artifact<'_>) -> Result<Sha256Hash> {
+        match artifact {
+            Artifact::Blob(blob) => Ok(sha256_yielding(blob).await.finalize()),
             Artifact::Digest(digest) => {
                 if digest.algorithm() != HashAlgorithm::Sha2256 {
                     return Err(Error::Signing(format!(
@@ -359,14 +483,25 @@ impl Signer {
                         digest.algorithm()
                     )));
                 }
-                let hash = Sha256Hash::try_from_slice(digest.as_bytes())
-                    .map_err(|e| Error::Signing(e.to_string()))?;
-                let signature = key_pair.sign_digest(&hash)?;
-                (hash, signature)
+                Sha256Hash::try_from_slice(digest.as_bytes())
+                    .map_err(|e| Error::Signing(e.to_string()))
             }
-        };
+        }
+    }
 
-        // 5. Create Rekor entry (with certificate, not just public key)
+    async fn sign_sha256(&self, artifact_hash: Sha256Hash) -> Result<Bundle> {
+        self.validate_configuration()?;
+
+        // 1. Generate ephemeral key pair
+        let key_pair = self.generate_ephemeral_keypair()?;
+
+        // 2. Get signing certificate from Fulcio
+        let leaf_cert_der = self.request_certificate(&key_pair).await?;
+
+        // 3. Sign the already prepared digest.
+        let signature = key_pair.sign_digest(&artifact_hash)?;
+
+        // 4. Create Rekor entry (with certificate, not just public key)
         let tlog_entry = self
             .create_rekor_entry(&artifact_hash, &signature, &leaf_cert_der)
             .await?;
@@ -766,6 +901,35 @@ mod tests {
             let chunked = sha256_yielding(&data).await.finalize();
             assert_eq!(chunked, sigstore_crypto::sha256(&data), "size {size}");
         }
+    }
+
+    #[tokio::test]
+    async fn reader_hashing_matches_blob_hashing() {
+        let data = vec![42_u8; HASH_YIELD_CHUNK_SIZE * 2 + 7];
+        let expected = sigstore_crypto::sha256(&data);
+        assert_eq!(
+            sha256_reader_yielding(std::io::Cursor::new(&data))
+                .await
+                .unwrap(),
+            expected
+        );
+        assert_eq!(
+            sha256_async_reader(futures::io::Cursor::new(&data))
+                .await
+                .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn async_reader_hashing_yields_even_when_reads_are_ready() {
+        let mut future = Box::pin(sha256_async_reader(futures::io::Cursor::new(vec![42_u8])));
+        let waker = futures::task::noop_waker();
+        let mut context = std::task::Context::from_waker(&waker);
+        assert!(matches!(
+            std::future::Future::poll(future.as_mut(), &mut context),
+            std::task::Poll::Pending
+        ));
     }
 
     #[tokio::test]

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, Result};
 use futures_io::AsyncRead;
 use sigstore_bundle::{BundleV03, TlogEntryBuilder};
 use sigstore_crypto::{
-    hash_async_reader, hash_reader_yielding, KeyPair, Sha256Hasher, SigningScheme,
+    hash_async_reader, hash_reader_yielding, hash_yielding, KeyPair, Sha256Hasher, SigningScheme,
 };
 use sigstore_fulcio::FulcioClient;
 use sigstore_oidc::IdentityToken;
@@ -25,35 +25,6 @@ use sigstore_types::{
     TransparencyLogEntry,
 };
 
-/// Hash in-memory `data` into `hasher`, yielding to the executor between
-/// chunks so unbounded caller input cannot starve other tasks (TOB-SIGSTORE-8).
-async fn update_yielding(hasher: &mut Sha256Hasher, data: &[u8]) {
-    hash_reader_yielding(data, std::slice::from_mut(hasher))
-        .await
-        .expect("reading from an in-memory slice cannot fail");
-}
-
-/// SHA-256 a blocking reader to EOF, yielding to the executor between chunks.
-///
-/// The reads themselves run on the executor thread; see
-/// [`sigstore_crypto::hash_reader_yielding`].
-async fn sha256_yielding(reader: impl std::io::Read) -> Result<Sha256Hash> {
-    let mut hasher = Sha256Hasher::new();
-    hash_reader_yielding(reader, std::slice::from_mut(&mut hasher))
-        .await
-        .map_err(Error::ArtifactRead)?;
-    Ok(hasher.finalize())
-}
-
-/// SHA-256 an async reader to EOF, yielding to the executor between chunks.
-async fn sha256_async(reader: impl AsyncRead + Unpin) -> Result<Sha256Hash> {
-    let mut hasher = Sha256Hasher::new();
-    hash_async_reader(reader, std::slice::from_mut(&mut hasher))
-        .await
-        .map_err(Error::ArtifactRead)?;
-    Ok(hasher.finalize())
-}
-
 /// Start hashing a DSSE PAE without materializing the PAE in memory.
 fn dsse_pae_hasher(payload_type: &str, payload_len: usize) -> Sha256Hasher {
     let mut hasher = Sha256Hasher::new();
@@ -70,7 +41,7 @@ fn dsse_pae_hasher(payload_type: &str, payload_len: usize) -> Sha256Hasher {
 /// Hash a DSSE PAE in chunks without first allocating a full PAE copy.
 async fn sha256_pae_yielding(payload_type: &str, payload: &[u8]) -> Sha256Hasher {
     let mut hasher = dsse_pae_hasher(payload_type, payload.len());
-    update_yielding(&mut hasher, payload).await;
+    hash_yielding(payload, std::slice::from_mut(&mut hasher)).await;
     hasher
 }
 
@@ -94,9 +65,7 @@ async fn prepare_dsse_payload_yielding(
         payload: Vec::with_capacity(data.len()),
         hasher: dsse_pae_hasher(payload_type, data.len()),
     };
-    hash_reader_yielding(data, std::slice::from_mut(&mut prepared))
-        .await
-        .expect("reading from an in-memory slice cannot fail");
+    hash_yielding(data, std::slice::from_mut(&mut prepared)).await;
     (PayloadBytes::new(prepared.payload), prepared.hasher)
 }
 
@@ -343,7 +312,11 @@ impl Signer {
     pub async fn sign<'a>(&self, artifact: impl Into<Artifact<'a>>) -> Result<Bundle> {
         self.validate_configuration()?;
         let artifact_hash = match artifact.into() {
-            Artifact::Blob(blob) => sha256_yielding(blob).await?,
+            Artifact::Blob(blob) => {
+                let mut hasher = Sha256Hasher::new();
+                hash_yielding(blob, std::slice::from_mut(&mut hasher)).await;
+                hasher.finalize()
+            }
             Artifact::Digest(digest) => {
                 if digest.algorithm() != HashAlgorithm::Sha2256 {
                     return Err(Error::Signing(format!(
@@ -364,13 +337,21 @@ impl Signer {
     /// thread. Async applications should prefer [`Signer::sign_async_reader`].
     pub async fn sign_reader(&self, reader: impl std::io::Read) -> Result<Bundle> {
         self.validate_configuration()?;
-        self.sign_sha256(sha256_yielding(reader).await?).await
+        let mut hasher = Sha256Hasher::new();
+        hash_reader_yielding(reader, std::slice::from_mut(&mut hasher))
+            .await
+            .map_err(Error::ArtifactRead)?;
+        self.sign_sha256(hasher.finalize()).await
     }
 
     /// Sign an artifact read asynchronously to EOF in constant memory.
     pub async fn sign_async_reader(&self, reader: impl AsyncRead + Unpin) -> Result<Bundle> {
         self.validate_configuration()?;
-        self.sign_sha256(sha256_async(reader).await?).await
+        let mut hasher = Sha256Hasher::new();
+        hash_async_reader(reader, std::slice::from_mut(&mut hasher))
+            .await
+            .map_err(Error::ArtifactRead)?;
+        self.sign_sha256(hasher.finalize()).await
     }
 
     /// Sign an already hashed artifact.

--- a/crates/sigstore-types/src/intoto.rs
+++ b/crates/sigstore-types/src/intoto.rs
@@ -6,7 +6,7 @@
 //!
 //! Specification: <https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md>
 
-use crate::{Sha256Hash, Sha512Hash};
+use crate::{HashAlgorithm, Sha256Hash, Sha512Hash};
 use serde::{Deserialize, Serialize};
 
 /// In-toto Statement v1
@@ -101,6 +101,21 @@ impl<'de> Deserialize<'de> for Digest {
 }
 
 impl Statement {
+    /// The digest algorithms used by at least one subject.
+    ///
+    /// Verifiers use this to hash an artifact only with the algorithms that
+    /// can actually bind it to this statement.
+    pub fn subject_algorithms(&self) -> Vec<HashAlgorithm> {
+        let mut algorithms = Vec::new();
+        if self.subject.iter().any(|s| s.digest.sha256.is_some()) {
+            algorithms.push(HashAlgorithm::Sha2256);
+        }
+        if self.subject.iter().any(|s| s.digest.sha512.is_some()) {
+            algorithms.push(HashAlgorithm::Sha2512);
+        }
+        algorithms
+    }
+
     /// Check if any subject in the statement matches the given SHA-256 hash
     pub fn matches_sha256(&self, hash: &Sha256Hash) -> bool {
         self.subject
@@ -147,6 +162,25 @@ option_hex_digest!(option_hex_sha512, Sha512Hash);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn subject_algorithms_lists_each_used_algorithm_once() {
+        let statement: Statement = serde_json::from_str(
+            r#"{"_type":"https://in-toto.io/Statement/v1","predicateType":"p","predicate":{},
+                "subject":[
+                    {"name":"a","digest":{"sha256":"b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"}},
+                    {"name":"b","digest":{"sha256":"b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"}}
+                ]}"#,
+        )
+        .unwrap();
+        assert_eq!(statement.subject_algorithms(), vec![HashAlgorithm::Sha2256]);
+
+        let none: Statement = serde_json::from_str(
+            r#"{"_type":"https://in-toto.io/Statement/v1","predicateType":"p","predicate":{},"subject":[]}"#,
+        )
+        .unwrap();
+        assert!(none.subject_algorithms().is_empty());
+    }
 
     #[test]
     fn test_statement_deserialization() {

--- a/crates/sigstore-verify/Cargo.toml
+++ b/crates/sigstore-verify/Cargo.toml
@@ -30,10 +30,11 @@ pem = { workspace = true }
 rustls-webpki = { workspace = true }
 rustls-pki-types = { workspace = true }
 tracing = { workspace = true }
-futures = { workspace = true }
+futures-io = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+futures = { workspace = true }
 hex = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/sigstore-verify/Cargo.toml
+++ b/crates/sigstore-verify/Cargo.toml
@@ -30,6 +30,7 @@ pem = { workspace = true }
 rustls-webpki = { workspace = true }
 rustls-pki-types = { workspace = true }
 tracing = { workspace = true }
+futures = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/sigstore-verify/README.md
+++ b/crates/sigstore-verify/README.md
@@ -44,16 +44,20 @@ let result = verify(artifact_bytes.as_slice(), &bundle, &policy, &root)?;
 let digest = Sha256Hash::from_hex("b94d27b9...")?;
 let result = verify(digest, &bundle, &policy, &root)?;
 
-// Or stream a large artifact in constant memory
-let file = std::fs::File::open("large-artifact.tar.gz")?;
-let result = sigstore_verify::verify_reader(file, &bundle, &policy, &root)?;
-
-// Runtime-independent futures_io::AsyncRead is also supported
-let result = sigstore_verify::verify_async_reader(async_reader, &bundle, &policy, &root).await?;
-
-// Using the Verifier struct directly
+// Or use a Verifier directly; it also offers the same inputs
 let verifier = Verifier::new(&root);
 let result = verifier.verify(artifact_bytes.as_slice(), &bundle, &policy)?;
+
+// Stream a large artifact in constant memory
+let file = std::fs::File::open("large-artifact.tar.gz")?;
+let result = verifier.verify_reader(file, &bundle, &policy)?;
+
+// Runtime-independent futures_io::AsyncRead is also supported
+let result = verifier.verify_async_reader(async_reader, &bundle, &policy).await?;
+
+// Managed-key bundles use the `verify_with_key*` family with the same
+// three input shapes: `verify_with_key`, `verify_with_key_reader`,
+// `verify_with_key_async_reader`.
 ```
 
 For GitHub artifact attestations, choose GitHub's Sigstore instance explicitly

--- a/crates/sigstore-verify/README.md
+++ b/crates/sigstore-verify/README.md
@@ -60,6 +60,11 @@ let result = verifier.verify_async_reader(async_reader, &bundle, &policy).await?
 // `verify_with_key_async_reader`.
 ```
 
+For Tokio readers, enable `tokio-util`'s `compat` feature and use
+`tokio_util::compat::TokioAsyncReadCompatExt::compat()` on the file or stream.
+Reader verification rejects message-signature schemes that require the original
+bytes (such as Ed25519) before consuming input; use the byte API for those schemes.
+
 For GitHub artifact attestations, choose GitHub's Sigstore instance explicitly
 and use the GitHub verification profile:
 

--- a/crates/sigstore-verify/README.md
+++ b/crates/sigstore-verify/README.md
@@ -44,6 +44,13 @@ let result = verify(artifact_bytes.as_slice(), &bundle, &policy, &root)?;
 let digest = Sha256Hash::from_hex("b94d27b9...")?;
 let result = verify(digest, &bundle, &policy, &root)?;
 
+// Or stream a large artifact in constant memory
+let file = std::fs::File::open("large-artifact.tar.gz")?;
+let result = sigstore_verify::verify_reader(file, &bundle, &policy, &root)?;
+
+// Runtime-independent futures_io::AsyncRead is also supported
+let result = sigstore_verify::verify_async_reader(async_reader, &bundle, &policy, &root).await?;
+
 // Using the Verifier struct directly
 let verifier = Verifier::new(&root);
 let result = verifier.verify(artifact_bytes.as_slice(), &bundle, &policy)?;

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -47,7 +47,7 @@
 use regex::Regex;
 use sigstore_trust_root::TrustedRoot;
 use sigstore_types::{Artifact, Bundle, Sha256Hash};
-use sigstore_verify::{verify, VerificationPolicy};
+use sigstore_verify::{verify, verify_reader, VerificationPolicy};
 
 use std::env;
 use std::fs;
@@ -228,15 +228,15 @@ async fn main() {
         let artifact = Artifact::from(&digest);
         verify(artifact, &bundle, &policy, &trusted_root)
     } else {
-        // Read artifact file
-        let artifact_bytes = match fs::read(artifact_or_digest) {
-            Ok(data) => data,
+        // Stream artifact file in constant memory.
+        let artifact = match fs::File::open(artifact_or_digest) {
+            Ok(file) => file,
             Err(e) => {
-                eprintln!("Error reading artifact '{}': {}", artifact_or_digest, e);
+                eprintln!("Error opening artifact '{}': {}", artifact_or_digest, e);
                 process::exit(1);
             }
         };
-        verify(&artifact_bytes, &bundle, &policy, &trusted_root)
+        verify_reader(artifact, &bundle, &policy, &trusted_root)
     };
 
     match result {

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -46,8 +46,8 @@
 
 use regex::Regex;
 use sigstore_trust_root::TrustedRoot;
-use sigstore_types::{Artifact, Bundle, Sha256Hash};
-use sigstore_verify::{verify, verify_reader, VerificationPolicy};
+use sigstore_types::{Bundle, Sha256Hash};
+use sigstore_verify::{VerificationPolicy, Verifier};
 
 use std::env;
 use std::fs;
@@ -213,6 +213,7 @@ async fn main() {
     }
 
     // Verify
+    let verifier = Verifier::new(&trusted_root);
     let result = if is_digest {
         // Parse digest (sha256:hex...)
         let hex_digest = artifact_or_digest.strip_prefix("sha256:").unwrap();
@@ -223,8 +224,7 @@ async fn main() {
                 process::exit(1);
             }
         };
-        let artifact = Artifact::from(&digest);
-        verify(artifact, &bundle, &policy, &trusted_root)
+        verifier.verify(digest, &bundle, &policy)
     } else {
         // Stream artifact file in constant memory.
         let artifact = match fs::File::open(artifact_or_digest) {
@@ -234,7 +234,7 @@ async fn main() {
                 process::exit(1);
             }
         };
-        verify_reader(artifact, &bundle, &policy, &trusted_root)
+        verifier.verify_reader(artifact, &bundle, &policy)
     };
 
     match result {

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -1,6 +1,8 @@
 //! Example: Verify a Sigstore bundle
 //!
 //! This example demonstrates how to verify a Sigstore bundle against an artifact.
+//! Files are streamed unless the message-signature scheme requires the original
+//! bytes (e.g. Ed25519), in which case the file is loaded into memory.
 //!
 //! # Usage
 //!
@@ -46,8 +48,8 @@
 
 use regex::Regex;
 use sigstore_trust_root::TrustedRoot;
-use sigstore_types::{Bundle, Sha256Hash};
-use sigstore_verify::{VerificationPolicy, Verifier};
+use sigstore_types::{Bundle, Sha256Hash, SignatureContent};
+use sigstore_verify::{Error, VerificationPolicy, VerificationResult, Verifier};
 
 use std::env;
 use std::fs;
@@ -226,15 +228,7 @@ async fn main() {
         };
         verifier.verify(digest, &bundle, &policy)
     } else {
-        // Stream artifact file in constant memory.
-        let artifact = match fs::File::open(artifact_or_digest) {
-            Ok(file) => file,
-            Err(e) => {
-                eprintln!("Error opening artifact '{}': {}", artifact_or_digest, e);
-                process::exit(1);
-            }
-        };
-        verifier.verify_reader(artifact, &bundle, &policy)
+        verify_file(artifact_or_digest, &verifier, &bundle, &policy)
     };
 
     match result {
@@ -280,6 +274,73 @@ async fn main() {
             eprintln!("\nVerification error: {}", e);
             process::exit(1);
         }
+    }
+}
+
+fn requires_blob(bundle: &Bundle) -> Result<bool, Error> {
+    if !matches!(bundle.content, SignatureContent::MessageSignature(_)) {
+        // DSSE signatures cover the envelope, not the streamed artifact.
+        return Ok(false);
+    }
+    let cert = bundle
+        .signing_certificate()
+        .ok_or_else(|| Error::Verification("bundle has no signing certificate".into()))?;
+    Ok(!sigstore_crypto::parse_certificate_info(cert.as_bytes())?
+        .key_algorithm
+        .default_signing_scheme()
+        .supports_prehashed())
+}
+
+fn verify_file(
+    path: &str,
+    verifier: &Verifier,
+    bundle: &Bundle,
+    policy: &VerificationPolicy,
+) -> Result<VerificationResult, Error> {
+    if requires_blob(bundle)? {
+        let artifact = fs::read(path).map_err(Error::ArtifactRead)?;
+        verifier.verify(&artifact, bundle, policy)
+    } else {
+        let artifact = fs::File::open(path).map_err(Error::ArtifactRead)?;
+        verifier.verify_reader(artifact, bundle, policy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigstore_types::{bundle::VerificationMaterialContent, DerCertificate};
+    use x509_cert::der::{asn1::BitString, Decode, Encode};
+
+    #[test]
+    fn only_non_prehashed_message_signatures_require_blob_input() {
+        let mut bundle = Bundle::from_json(include_str!(
+            "../../sigstore-bundle/tests/fixtures/bundle_v3.json"
+        ))
+        .unwrap();
+        assert!(!requires_blob(&bundle).unwrap());
+
+        // Synthetic Ed25519 certificate: only key parsing is exercised here,
+        // not certificate-chain or signature verification.
+        let mut cert =
+            x509_cert::Certificate::from_der(bundle.signing_certificate().unwrap().as_bytes())
+                .unwrap();
+        let spki = &mut cert.tbs_certificate.subject_public_key_info;
+        spki.algorithm.oid = "1.3.101.112".parse().unwrap();
+        spki.algorithm.parameters = None;
+        spki.subject_public_key = BitString::from_bytes(&[0; 32]).unwrap();
+        bundle.verification_material.content =
+            VerificationMaterialContent::Certificate(sigstore_types::bundle::CertificateContent {
+                raw_bytes: DerCertificate::new(cert.to_der().unwrap()),
+            });
+        assert!(requires_blob(&bundle).unwrap());
+
+        let dsse = Bundle::from_json(include_str!(
+            "../../sigstore-bundle/tests/fixtures/happy-path.json"
+        ))
+        .unwrap();
+        bundle.content = dsse.content;
+        assert!(!requires_blob(&bundle).unwrap());
     }
 }
 

--- a/crates/sigstore-verify/src/artifact.rs
+++ b/crates/sigstore-verify/src/artifact.rs
@@ -1,37 +1,10 @@
 use crate::error::{Error, Result};
-use futures::io::{AsyncRead, AsyncReadExt};
-use sigstore_crypto::ArtifactHasher;
+use futures_io::AsyncRead;
+use sigstore_crypto::{hash_async_reader, hash_reader, ArtifactHasher};
 use sigstore_types::{
     Artifact, ArtifactDigest, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent, Statement,
 };
 use std::io::Read;
-
-/// Yield control back to the async executor once.
-///
-/// `AsyncRead` implementations may return `Ready` indefinitely, so awaiting a
-/// read is not by itself a reliable scheduling point.
-fn yield_now() -> impl std::future::Future<Output = ()> {
-    struct YieldNow(bool);
-
-    impl std::future::Future for YieldNow {
-        type Output = ();
-
-        fn poll(
-            mut self: std::pin::Pin<&mut Self>,
-            cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<()> {
-            if self.0 {
-                std::task::Poll::Ready(())
-            } else {
-                self.0 = true;
-                cx.waker().wake_by_ref();
-                std::task::Poll::Pending
-            }
-        }
-    }
-
-    YieldNow(false)
-}
 
 /// Artifact data normalized for the verification core.
 ///
@@ -100,44 +73,22 @@ impl<'a> PreparedArtifact<'a> {
     }
 
     pub(crate) fn from_reader(
-        mut reader: impl Read,
+        reader: impl Read,
         content: &SignatureContent,
     ) -> Result<PreparedArtifact<'static>> {
         let mut hashers = required_hashers(content);
-        let mut buffer = [0_u8; 64 * 1024];
-        loop {
-            let read = reader.read(&mut buffer).map_err(Error::ArtifactRead)?;
-            if read == 0 {
-                break;
-            }
-            for hasher in &mut hashers {
-                hasher.update(&buffer[..read]);
-            }
-        }
+        hash_reader(reader, &mut hashers).map_err(Error::ArtifactRead)?;
         Ok(Self::from_digests(Self::finalize(hashers)))
     }
 
     pub(crate) async fn from_async_reader(
-        mut reader: impl AsyncRead + Unpin,
+        reader: impl AsyncRead + Unpin,
         content: &SignatureContent,
     ) -> Result<PreparedArtifact<'static>> {
         let mut hashers = required_hashers(content);
-        let mut buffer = [0_u8; 64 * 1024];
-        loop {
-            let read = reader
-                .read(&mut buffer)
-                .await
-                .map_err(Error::ArtifactRead)?;
-            if read == 0 {
-                break;
-            }
-            for hasher in &mut hashers {
-                hasher.update(&buffer[..read]);
-            }
-            // Always-ready readers (including in-memory cursors) do not yield
-            // when awaited. Cooperate explicitly after each hashing chunk.
-            yield_now().await;
-        }
+        hash_async_reader(reader, &mut hashers)
+            .await
+            .map_err(Error::ArtifactRead)?;
         Ok(Self::from_digests(Self::finalize(hashers)))
     }
 

--- a/crates/sigstore-verify/src/artifact.rs
+++ b/crates/sigstore-verify/src/artifact.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use futures_io::AsyncRead;
-use sigstore_crypto::{hash_async_reader, hash_reader, ArtifactHasher};
+use sigstore_crypto::{hash_async_reader, hash_reader, ArtifactHasher, SigningScheme};
 use sigstore_types::{
     Artifact, ArtifactDigest, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent, Statement,
 };
@@ -17,16 +17,55 @@ pub(crate) struct PreparedArtifact<'a> {
     digests: Vec<ArtifactDigest>,
 }
 
+/// How the signature over a `MessageSignature` artifact will be checked.
+///
+/// Blob input keeps its bytes, so the signature is verified over them directly
+/// and only the digests that bind the artifact to the bundle are needed.
+/// Streamed input keeps nothing but digests, so the signature must be verified
+/// prehashed and the single pass over the reader has to produce the digest the
+/// signing scheme consumes.
+#[derive(Clone, Copy)]
+enum SignatureInput {
+    Bytes,
+    Prehashed(Option<SigningScheme>),
+}
+
+fn require(algorithms: &mut Vec<HashAlgorithm>, algorithm: HashAlgorithm) {
+    if !algorithms.contains(&algorithm) {
+        algorithms.push(algorithm);
+    }
+}
+
 /// The digest algorithms verification can request for this bundle content.
-fn required_algorithms(content: &SignatureContent) -> Vec<HashAlgorithm> {
+fn required_algorithms(content: &SignatureContent, input: SignatureInput) -> Vec<HashAlgorithm> {
     match content {
-        // hashedrekord binds SHA-256; the signature itself may be over the
-        // declared messageDigest algorithm (SHA-384 for ECDSA-P256-SHA384).
         SignatureContent::MessageSignature(signature) => {
+            // hashedrekord binds SHA-256; the declared messageDigest may use
+            // another algorithm and is compared against the artifact as well.
             let mut algorithms = vec![HashAlgorithm::Sha2256];
             if let Some(digest) = &signature.message_digest {
-                if !algorithms.contains(&digest.algorithm) {
-                    algorithms.push(digest.algorithm);
+                require(&mut algorithms, digest.algorithm);
+            }
+            match input {
+                SignatureInput::Bytes => {}
+                // Schemes without an external digest (Ed25519) cannot be
+                // verified prehashed at all; verification reports that later.
+                SignatureInput::Prehashed(Some(scheme)) => {
+                    if let Some(algorithm) = scheme.hash_algorithm() {
+                        require(&mut algorithms, algorithm);
+                    }
+                }
+                // The key could not be read before the artifact, so the
+                // scheme's digest is unknown. Hash with every algorithm so
+                // verification can still proceed and report the real problem.
+                SignatureInput::Prehashed(None) => {
+                    for algorithm in [
+                        HashAlgorithm::Sha2256,
+                        HashAlgorithm::Sha2384,
+                        HashAlgorithm::Sha2512,
+                    ] {
+                        require(&mut algorithms, algorithm);
+                    }
                 }
             }
             algorithms
@@ -45,8 +84,8 @@ fn required_algorithms(content: &SignatureContent) -> Vec<HashAlgorithm> {
     }
 }
 
-fn required_hashers(content: &SignatureContent) -> Vec<ArtifactHasher> {
-    required_algorithms(content)
+fn required_hashers(content: &SignatureContent, input: SignatureInput) -> Vec<ArtifactHasher> {
+    required_algorithms(content, input)
         .into_iter()
         .map(ArtifactHasher::new)
         .collect()
@@ -56,7 +95,7 @@ impl<'a> PreparedArtifact<'a> {
     pub(crate) fn from_artifact(artifact: Artifact<'a>, content: &SignatureContent) -> Self {
         match artifact {
             Artifact::Blob(blob) => {
-                let mut hashers = required_hashers(content);
+                let mut hashers = required_hashers(content, SignatureInput::Bytes);
                 for hasher in &mut hashers {
                     hasher.update(blob);
                 }
@@ -72,20 +111,30 @@ impl<'a> PreparedArtifact<'a> {
         }
     }
 
+    /// Hash a blocking reader to EOF.
+    ///
+    /// `scheme` is the signing scheme the signature will be verified with, if
+    /// it could be determined from the bundle's key material up front. It only
+    /// matters for `MessageSignature` bundles: streamed input can only be
+    /// verified prehashed, so this pass must produce the scheme's digest.
     pub(crate) fn from_reader(
         reader: impl Read,
         content: &SignatureContent,
+        scheme: Option<SigningScheme>,
     ) -> Result<PreparedArtifact<'static>> {
-        let mut hashers = required_hashers(content);
+        let mut hashers = required_hashers(content, SignatureInput::Prehashed(scheme));
         hash_reader(reader, &mut hashers).map_err(Error::ArtifactRead)?;
         Ok(Self::from_digests(Self::finalize(hashers)))
     }
 
+    /// Hash an async reader to EOF. See [`PreparedArtifact::from_reader`] for
+    /// the role of `scheme`.
     pub(crate) async fn from_async_reader(
         reader: impl AsyncRead + Unpin,
         content: &SignatureContent,
+        scheme: Option<SigningScheme>,
     ) -> Result<PreparedArtifact<'static>> {
-        let mut hashers = required_hashers(content);
+        let mut hashers = required_hashers(content, SignatureInput::Prehashed(scheme));
         hash_async_reader(reader, &mut hashers)
             .await
             .map_err(Error::ArtifactRead)?;

--- a/crates/sigstore-verify/src/artifact.rs
+++ b/crates/sigstore-verify/src/artifact.rs
@@ -1,7 +1,9 @@
 use crate::error::{Error, Result};
 use futures::io::{AsyncRead, AsyncReadExt};
 use sigstore_crypto::ArtifactHasher;
-use sigstore_types::{Artifact, ArtifactDigest, Bundle, HashAlgorithm, SignatureContent};
+use sigstore_types::{
+    Artifact, ArtifactDigest, Bundle, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent,
+};
 use std::io::Read;
 
 /// Yield control back to the async executor once.
@@ -122,19 +124,22 @@ impl<'a> PreparedArtifact<'a> {
         self.blob
     }
 
-    pub(crate) fn digest(&self, algorithm: HashAlgorithm) -> Result<Vec<u8>> {
+    /// The artifact digest for `algorithm`.
+    ///
+    /// Blob input is hashed on demand. Digest and reader input can only
+    /// supply the algorithms they were prepared with, so any other request is
+    /// an error that names what was supplied.
+    pub(crate) fn digest(&self, algorithm: HashAlgorithm) -> Result<ArtifactDigest> {
         if let Some(blob) = self.blob {
-            return Ok(match algorithm {
-                HashAlgorithm::Sha2256 => sigstore_crypto::sha256(blob).as_bytes().to_vec(),
-                HashAlgorithm::Sha2384 => sigstore_crypto::sha384(blob),
-                HashAlgorithm::Sha2512 => sigstore_crypto::sha512(blob).as_bytes().to_vec(),
-            });
+            let mut hasher = ArtifactHasher::new(algorithm);
+            hasher.update(blob);
+            return Ok(hasher.finalize());
         }
 
         self.digests
             .iter()
             .find(|digest| digest.algorithm() == algorithm)
-            .map(|digest| digest.as_bytes().to_vec())
+            .cloned()
             .ok_or_else(|| {
                 let supplied = self
                     .digests
@@ -146,5 +151,17 @@ impl<'a> PreparedArtifact<'a> {
                     "verification requires an {algorithm} artifact digest; supplied: {supplied}"
                 ))
             })
+    }
+
+    pub(crate) fn sha256(&self) -> Result<Sha256Hash> {
+        let digest = self.digest(HashAlgorithm::Sha2256)?;
+        Sha256Hash::try_from_slice(digest.as_bytes())
+            .map_err(|e| Error::Verification(e.to_string()))
+    }
+
+    pub(crate) fn sha512(&self) -> Result<Sha512Hash> {
+        let digest = self.digest(HashAlgorithm::Sha2512)?;
+        Sha512Hash::try_from_slice(digest.as_bytes())
+            .map_err(|e| Error::Verification(e.to_string()))
     }
 }

--- a/crates/sigstore-verify/src/artifact.rs
+++ b/crates/sigstore-verify/src/artifact.rs
@@ -2,7 +2,7 @@ use crate::error::{Error, Result};
 use futures::io::{AsyncRead, AsyncReadExt};
 use sigstore_crypto::ArtifactHasher;
 use sigstore_types::{
-    Artifact, ArtifactDigest, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent,
+    Artifact, ArtifactDigest, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent, Statement,
 };
 use std::io::Read;
 
@@ -45,22 +45,38 @@ pub(crate) struct PreparedArtifact<'a> {
 }
 
 /// The digest algorithms verification can request for this bundle content.
-fn required_hashers(content: &SignatureContent) -> Vec<ArtifactHasher> {
-    let mut algorithms = vec![HashAlgorithm::Sha2256];
+fn required_algorithms(content: &SignatureContent) -> Vec<HashAlgorithm> {
     match content {
         // hashedrekord binds SHA-256; the signature itself may be over the
         // declared messageDigest algorithm (SHA-384 for ECDSA-P256-SHA384).
         SignatureContent::MessageSignature(signature) => {
+            let mut algorithms = vec![HashAlgorithm::Sha2256];
             if let Some(digest) = &signature.message_digest {
                 if !algorithms.contains(&digest.algorithm) {
                     algorithms.push(digest.algorithm);
                 }
             }
+            algorithms
         }
-        // in-toto subjects may be bound by SHA-256 or SHA-512.
-        SignatureContent::DsseEnvelope(_) => algorithms.push(HashAlgorithm::Sha2512),
+        // Only the in-toto subjects bind the artifact, so hash with the
+        // algorithms they use. If the payload is not a readable statement,
+        // hash both so the binding check later reports the real problem.
+        SignatureContent::DsseEnvelope(envelope) => {
+            std::str::from_utf8(envelope.payload.as_bytes())
+                .ok()
+                .and_then(|payload| serde_json::from_str::<Statement>(payload).ok())
+                .map(|statement| statement.subject_algorithms())
+                .filter(|algorithms| !algorithms.is_empty())
+                .unwrap_or_else(|| vec![HashAlgorithm::Sha2256, HashAlgorithm::Sha2512])
+        }
     }
-    algorithms.into_iter().map(ArtifactHasher::new).collect()
+}
+
+fn required_hashers(content: &SignatureContent) -> Vec<ArtifactHasher> {
+    required_algorithms(content)
+        .into_iter()
+        .map(ArtifactHasher::new)
+        .collect()
 }
 
 impl<'a> PreparedArtifact<'a> {

--- a/crates/sigstore-verify/src/artifact.rs
+++ b/crates/sigstore-verify/src/artifact.rs
@@ -2,7 +2,7 @@ use crate::error::{Error, Result};
 use futures::io::{AsyncRead, AsyncReadExt};
 use sigstore_crypto::ArtifactHasher;
 use sigstore_types::{
-    Artifact, ArtifactDigest, Bundle, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent,
+    Artifact, ArtifactDigest, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent,
 };
 use std::io::Read;
 
@@ -35,35 +35,47 @@ fn yield_now() -> impl std::future::Future<Output = ()> {
 
 /// Artifact data normalized for the verification core.
 ///
-/// Blob callers retain their bytes for schemes that cannot verify prehashed
-/// input. Reader callers provide every digest computed during their single
-/// pass and never need to retain the artifact in memory.
+/// Every input is hashed at most once. Blob and reader input are run through
+/// all the digest algorithms the bundle content can ask for in a single pass;
+/// digest input supplies exactly one digest. Blob callers additionally retain
+/// their bytes for schemes that cannot verify prehashed input.
 pub(crate) struct PreparedArtifact<'a> {
     blob: Option<&'a [u8]>,
     digests: Vec<ArtifactDigest>,
 }
 
-fn required_hashers(bundle: &Bundle) -> Vec<ArtifactHasher> {
-    // SHA-256 binds hashedrekord entries, while in-toto subjects can use
-    // SHA-256 or SHA-512. MessageSignature may additionally select SHA-384.
-    let mut algorithms = vec![HashAlgorithm::Sha2256, HashAlgorithm::Sha2512];
-    if let SignatureContent::MessageSignature(signature) = &bundle.content {
-        if let Some(digest) = &signature.message_digest {
-            if !algorithms.contains(&digest.algorithm) {
-                algorithms.push(digest.algorithm);
+/// The digest algorithms verification can request for this bundle content.
+fn required_hashers(content: &SignatureContent) -> Vec<ArtifactHasher> {
+    let mut algorithms = vec![HashAlgorithm::Sha2256];
+    match content {
+        // hashedrekord binds SHA-256; the signature itself may be over the
+        // declared messageDigest algorithm (SHA-384 for ECDSA-P256-SHA384).
+        SignatureContent::MessageSignature(signature) => {
+            if let Some(digest) = &signature.message_digest {
+                if !algorithms.contains(&digest.algorithm) {
+                    algorithms.push(digest.algorithm);
+                }
             }
         }
+        // in-toto subjects may be bound by SHA-256 or SHA-512.
+        SignatureContent::DsseEnvelope(_) => algorithms.push(HashAlgorithm::Sha2512),
     }
     algorithms.into_iter().map(ArtifactHasher::new).collect()
 }
 
 impl<'a> PreparedArtifact<'a> {
-    pub(crate) fn from_artifact(artifact: Artifact<'a>) -> Self {
+    pub(crate) fn from_artifact(artifact: Artifact<'a>, content: &SignatureContent) -> Self {
         match artifact {
-            Artifact::Blob(blob) => Self {
-                blob: Some(blob),
-                digests: Vec::new(),
-            },
+            Artifact::Blob(blob) => {
+                let mut hashers = required_hashers(content);
+                for hasher in &mut hashers {
+                    hasher.update(blob);
+                }
+                Self {
+                    blob: Some(blob),
+                    digests: Self::finalize(hashers),
+                }
+            }
             Artifact::Digest(digest) => Self {
                 blob: None,
                 digests: vec![digest],
@@ -73,9 +85,9 @@ impl<'a> PreparedArtifact<'a> {
 
     pub(crate) fn from_reader(
         mut reader: impl Read,
-        bundle: &Bundle,
+        content: &SignatureContent,
     ) -> Result<PreparedArtifact<'static>> {
-        let mut hashers = required_hashers(bundle);
+        let mut hashers = required_hashers(content);
         let mut buffer = [0_u8; 64 * 1024];
         loop {
             let read = reader.read(&mut buffer).map_err(Error::ArtifactRead)?;
@@ -86,14 +98,14 @@ impl<'a> PreparedArtifact<'a> {
                 hasher.update(&buffer[..read]);
             }
         }
-        Ok(Self::from_hashers(hashers))
+        Ok(Self::from_digests(Self::finalize(hashers)))
     }
 
     pub(crate) async fn from_async_reader(
         mut reader: impl AsyncRead + Unpin,
-        bundle: &Bundle,
+        content: &SignatureContent,
     ) -> Result<PreparedArtifact<'static>> {
-        let mut hashers = required_hashers(bundle);
+        let mut hashers = required_hashers(content);
         let mut buffer = [0_u8; 64 * 1024];
         loop {
             let read = reader
@@ -110,13 +122,17 @@ impl<'a> PreparedArtifact<'a> {
             // when awaited. Cooperate explicitly after each hashing chunk.
             yield_now().await;
         }
-        Ok(Self::from_hashers(hashers))
+        Ok(Self::from_digests(Self::finalize(hashers)))
     }
 
-    fn from_hashers(hashers: Vec<ArtifactHasher>) -> PreparedArtifact<'static> {
+    fn finalize(hashers: Vec<ArtifactHasher>) -> Vec<ArtifactDigest> {
+        hashers.into_iter().map(ArtifactHasher::finalize).collect()
+    }
+
+    fn from_digests(digests: Vec<ArtifactDigest>) -> PreparedArtifact<'static> {
         PreparedArtifact {
             blob: None,
-            digests: hashers.into_iter().map(ArtifactHasher::finalize).collect(),
+            digests,
         }
     }
 
@@ -126,16 +142,10 @@ impl<'a> PreparedArtifact<'a> {
 
     /// The artifact digest for `algorithm`.
     ///
-    /// Blob input is hashed on demand. Digest and reader input can only
-    /// supply the algorithms they were prepared with, so any other request is
-    /// an error that names what was supplied.
+    /// Blob and reader input were hashed once with every algorithm the bundle
+    /// content can request; digest input supplies a single algorithm. Anything
+    /// else is an error naming what was supplied.
     pub(crate) fn digest(&self, algorithm: HashAlgorithm) -> Result<ArtifactDigest> {
-        if let Some(blob) = self.blob {
-            let mut hasher = ArtifactHasher::new(algorithm);
-            hasher.update(blob);
-            return Ok(hasher.finalize());
-        }
-
         self.digests
             .iter()
             .find(|digest| digest.algorithm() == algorithm)

--- a/crates/sigstore-verify/src/artifact.rs
+++ b/crates/sigstore-verify/src/artifact.rs
@@ -6,96 +6,118 @@ use sigstore_types::{
 };
 use std::io::Read;
 
-/// Artifact data normalized for the verification core.
-///
-/// Every input is hashed at most once. Blob and reader input are run through
-/// all the digest algorithms the bundle content can ask for in a single pass;
-/// digest input supplies exactly one digest. Blob callers additionally retain
-/// their bytes for schemes that cannot verify prehashed input.
+/// Parse binding requirements before consuming caller input. The statement is
+/// retained for the binding check, rather than parsed a second time after I/O.
+pub(crate) struct ArtifactRequirements {
+    algorithms: Vec<HashAlgorithm>,
+    statement: Option<Statement>,
+    message_scheme: Option<SigningScheme>,
+}
+
+impl ArtifactRequirements {
+    pub(crate) fn new(content: &SignatureContent, scheme: SigningScheme) -> Result<Self> {
+        match content {
+            SignatureContent::MessageSignature(signature) => {
+                let mut algorithms = vec![HashAlgorithm::Sha2256]; // hashedrekord
+                for algorithm in signature
+                    .message_digest
+                    .as_ref()
+                    .map(|d| d.algorithm)
+                    .into_iter()
+                    .chain(scheme.hash_algorithm())
+                {
+                    if !algorithms.contains(&algorithm) {
+                        algorithms.push(algorithm);
+                    }
+                }
+                Ok(Self {
+                    algorithms,
+                    statement: None,
+                    message_scheme: Some(scheme),
+                })
+            }
+            SignatureContent::DsseEnvelope(envelope) => {
+                if envelope.payload_type != "application/vnd.in-toto+json" {
+                    return Err(Error::Verification(format!(
+                        "unsupported DSSE payload type {:?}: cannot bind artifact to attestation",
+                        envelope.payload_type
+                    )));
+                }
+                let statement: Statement = serde_json::from_slice(envelope.payload.as_bytes())
+                    .map_err(|e| {
+                        Error::Verification(format!("failed to parse in-toto statement: {e}"))
+                    })?;
+                if statement.subject.is_empty() {
+                    return Err(Error::Verification(
+                        "in-toto statement has no subjects: cannot bind artifact to attestation"
+                            .into(),
+                    ));
+                }
+                let algorithms = statement.subject_algorithms();
+                if algorithms.is_empty() {
+                    return Err(Error::Verification(
+                        "in-toto statement has no supported subject digest algorithms".into(),
+                    ));
+                }
+                Ok(Self {
+                    algorithms,
+                    statement: Some(statement),
+                    message_scheme: None,
+                })
+            }
+        }
+    }
+
+    fn hashers(&self) -> Vec<ArtifactHasher> {
+        self.algorithms
+            .iter()
+            .copied()
+            .map(ArtifactHasher::new)
+            .collect()
+    }
+
+    fn check_reader(&self) -> Result<()> {
+        if let Some(scheme) = self.message_scheme {
+            if !scheme.supports_prehashed() {
+                return Err(Error::Verification(format!("cannot verify signature from a digest or reader - scheme {} does not support prehashed mode", scheme.name())));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn verify_binding(&self, artifact: &PreparedArtifact<'_>) -> Result<()> {
+        if let Some(statement) = &self.statement {
+            let matches = artifact
+                .sha256()
+                .is_ok_and(|digest| statement.matches_sha256(&digest))
+                || artifact
+                    .sha512()
+                    .is_ok_and(|digest| statement.matches_sha512(&digest));
+            if !matches {
+                return Err(Error::Verification(
+                    "artifact hash does not match any subject in attestation".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Digests computed in one pass. Bytes are retained only for schemes such as
+/// Ed25519 that cannot verify a prehashed message.
 pub(crate) struct PreparedArtifact<'a> {
     blob: Option<&'a [u8]>,
     digests: Vec<ArtifactDigest>,
 }
 
-/// How the signature over a `MessageSignature` artifact will be checked.
-///
-/// Blob input keeps its bytes, so the signature is verified over them directly
-/// and only the digests that bind the artifact to the bundle are needed.
-/// Streamed input keeps nothing but digests, so the signature must be verified
-/// prehashed and the single pass over the reader has to produce the digest the
-/// signing scheme consumes.
-#[derive(Clone, Copy)]
-enum SignatureInput {
-    Bytes,
-    Prehashed(Option<SigningScheme>),
-}
-
-fn require(algorithms: &mut Vec<HashAlgorithm>, algorithm: HashAlgorithm) {
-    if !algorithms.contains(&algorithm) {
-        algorithms.push(algorithm);
-    }
-}
-
-/// The digest algorithms verification can request for this bundle content.
-fn required_algorithms(content: &SignatureContent, input: SignatureInput) -> Vec<HashAlgorithm> {
-    match content {
-        SignatureContent::MessageSignature(signature) => {
-            // hashedrekord binds SHA-256; the declared messageDigest may use
-            // another algorithm and is compared against the artifact as well.
-            let mut algorithms = vec![HashAlgorithm::Sha2256];
-            if let Some(digest) = &signature.message_digest {
-                require(&mut algorithms, digest.algorithm);
-            }
-            match input {
-                SignatureInput::Bytes => {}
-                // Schemes without an external digest (Ed25519) cannot be
-                // verified prehashed at all; verification reports that later.
-                SignatureInput::Prehashed(Some(scheme)) => {
-                    if let Some(algorithm) = scheme.hash_algorithm() {
-                        require(&mut algorithms, algorithm);
-                    }
-                }
-                // The key could not be read before the artifact, so the
-                // scheme's digest is unknown. Hash with every algorithm so
-                // verification can still proceed and report the real problem.
-                SignatureInput::Prehashed(None) => {
-                    for algorithm in [
-                        HashAlgorithm::Sha2256,
-                        HashAlgorithm::Sha2384,
-                        HashAlgorithm::Sha2512,
-                    ] {
-                        require(&mut algorithms, algorithm);
-                    }
-                }
-            }
-            algorithms
-        }
-        // Only the in-toto subjects bind the artifact, so hash with the
-        // algorithms they use. If the payload is not a readable statement,
-        // hash both so the binding check later reports the real problem.
-        SignatureContent::DsseEnvelope(envelope) => {
-            std::str::from_utf8(envelope.payload.as_bytes())
-                .ok()
-                .and_then(|payload| serde_json::from_str::<Statement>(payload).ok())
-                .map(|statement| statement.subject_algorithms())
-                .filter(|algorithms| !algorithms.is_empty())
-                .unwrap_or_else(|| vec![HashAlgorithm::Sha2256, HashAlgorithm::Sha2512])
-        }
-    }
-}
-
-fn required_hashers(content: &SignatureContent, input: SignatureInput) -> Vec<ArtifactHasher> {
-    required_algorithms(content, input)
-        .into_iter()
-        .map(ArtifactHasher::new)
-        .collect()
-}
-
 impl<'a> PreparedArtifact<'a> {
-    pub(crate) fn from_artifact(artifact: Artifact<'a>, content: &SignatureContent) -> Self {
+    pub(crate) fn from_artifact(
+        artifact: Artifact<'a>,
+        requirements: &ArtifactRequirements,
+    ) -> Self {
         match artifact {
             Artifact::Blob(blob) => {
-                let mut hashers = required_hashers(content, SignatureInput::Bytes);
+                let mut hashers = requirements.hashers();
                 for hasher in &mut hashers {
                     hasher.update(blob);
                 }
@@ -111,30 +133,22 @@ impl<'a> PreparedArtifact<'a> {
         }
     }
 
-    /// Hash a blocking reader to EOF.
-    ///
-    /// `scheme` is the signing scheme the signature will be verified with, if
-    /// it could be determined from the bundle's key material up front. It only
-    /// matters for `MessageSignature` bundles: streamed input can only be
-    /// verified prehashed, so this pass must produce the scheme's digest.
     pub(crate) fn from_reader(
         reader: impl Read,
-        content: &SignatureContent,
-        scheme: Option<SigningScheme>,
+        requirements: &ArtifactRequirements,
     ) -> Result<PreparedArtifact<'static>> {
-        let mut hashers = required_hashers(content, SignatureInput::Prehashed(scheme));
+        requirements.check_reader()?;
+        let mut hashers = requirements.hashers();
         hash_reader(reader, &mut hashers).map_err(Error::ArtifactRead)?;
         Ok(Self::from_digests(Self::finalize(hashers)))
     }
 
-    /// Hash an async reader to EOF. See [`PreparedArtifact::from_reader`] for
-    /// the role of `scheme`.
     pub(crate) async fn from_async_reader(
         reader: impl AsyncRead + Unpin,
-        content: &SignatureContent,
-        scheme: Option<SigningScheme>,
+        requirements: &ArtifactRequirements,
     ) -> Result<PreparedArtifact<'static>> {
-        let mut hashers = required_hashers(content, SignatureInput::Prehashed(scheme));
+        requirements.check_reader()?;
+        let mut hashers = requirements.hashers();
         hash_async_reader(reader, &mut hashers)
             .await
             .map_err(Error::ArtifactRead)?;
@@ -156,11 +170,6 @@ impl<'a> PreparedArtifact<'a> {
         self.blob
     }
 
-    /// The artifact digest for `algorithm`.
-    ///
-    /// Blob and reader input were hashed once with every algorithm the bundle
-    /// content can request; digest input supplies a single algorithm. Anything
-    /// else is an error naming what was supplied.
     pub(crate) fn digest(&self, algorithm: HashAlgorithm) -> Result<ArtifactDigest> {
         self.digests
             .iter()
@@ -180,14 +189,45 @@ impl<'a> PreparedArtifact<'a> {
     }
 
     pub(crate) fn sha256(&self) -> Result<Sha256Hash> {
-        let digest = self.digest(HashAlgorithm::Sha2256)?;
-        Sha256Hash::try_from_slice(digest.as_bytes())
+        Sha256Hash::try_from_slice(self.digest(HashAlgorithm::Sha2256)?.as_bytes())
             .map_err(|e| Error::Verification(e.to_string()))
     }
 
     pub(crate) fn sha512(&self) -> Result<Sha512Hash> {
-        let digest = self.digest(HashAlgorithm::Sha2512)?;
-        Sha512Hash::try_from_slice(digest.as_bytes())
+        Sha512Hash::try_from_slice(self.digest(HashAlgorithm::Sha2512)?.as_bytes())
             .map_err(|e| Error::Verification(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigstore_types::{DsseEnvelope, DsseSignature, PayloadBytes, SignatureBytes};
+
+    #[test]
+    fn scheme_and_subjects_select_the_required_digests() {
+        let message = SignatureContent::MessageSignature(sigstore_types::MessageSignature {
+            message_digest: None,
+            signature: SignatureBytes::from_bytes(b"unused"),
+        });
+        let requirements =
+            ArtifactRequirements::new(&message, SigningScheme::EcdsaP384Sha384).unwrap();
+        let artifact = PreparedArtifact::from_reader(&b"hello"[..], &requirements).unwrap();
+        assert!(artifact.digest(HashAlgorithm::Sha2256).is_ok());
+        assert!(artifact.digest(HashAlgorithm::Sha2384).is_ok());
+        assert!(artifact.digest(HashAlgorithm::Sha2512).is_err());
+        let requirements = ArtifactRequirements::new(&message, SigningScheme::Ed25519).unwrap();
+        let mut reader = std::io::Cursor::new(b"do not read");
+        assert!(PreparedArtifact::from_reader(&mut reader, &requirements).is_err());
+        assert_eq!(reader.position(), 0);
+
+        let hash = sigstore_crypto::sha512(b"hello").to_hex();
+        let content = SignatureContent::DsseEnvelope(DsseEnvelope::new("application/vnd.in-toto+json".into(), PayloadBytes::new(format!(r#"{{"_type":"https://in-toto.io/Statement/v1","subject":[{{"digest":{{"sha512":"{hash}"}}}}],"predicateType":"p","predicate":{{}}}}"#).into_bytes()), DsseSignature { sig: SignatureBytes::from_bytes(b"unused"), keyid: Default::default() }));
+        let requirements = ArtifactRequirements::new(&content, SigningScheme::Ed25519).unwrap();
+        assert_eq!(requirements.algorithms, vec![HashAlgorithm::Sha2512]);
+        let artifact = PreparedArtifact::from_reader(&b"hello"[..], &requirements).unwrap();
+        requirements.verify_binding(&artifact).unwrap();
+        let wrong = PreparedArtifact::from_reader(&b"other"[..], &requirements).unwrap();
+        assert!(requirements.verify_binding(&wrong).is_err());
     }
 }

--- a/crates/sigstore-verify/src/artifact.rs
+++ b/crates/sigstore-verify/src/artifact.rs
@@ -1,0 +1,150 @@
+use crate::error::{Error, Result};
+use futures::io::{AsyncRead, AsyncReadExt};
+use sigstore_crypto::ArtifactHasher;
+use sigstore_types::{Artifact, ArtifactDigest, Bundle, HashAlgorithm, SignatureContent};
+use std::io::Read;
+
+/// Yield control back to the async executor once.
+///
+/// `AsyncRead` implementations may return `Ready` indefinitely, so awaiting a
+/// read is not by itself a reliable scheduling point.
+fn yield_now() -> impl std::future::Future<Output = ()> {
+    struct YieldNow(bool);
+
+    impl std::future::Future for YieldNow {
+        type Output = ();
+
+        fn poll(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<()> {
+            if self.0 {
+                std::task::Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                std::task::Poll::Pending
+            }
+        }
+    }
+
+    YieldNow(false)
+}
+
+/// Artifact data normalized for the verification core.
+///
+/// Blob callers retain their bytes for schemes that cannot verify prehashed
+/// input. Reader callers provide every digest computed during their single
+/// pass and never need to retain the artifact in memory.
+pub(crate) struct PreparedArtifact<'a> {
+    blob: Option<&'a [u8]>,
+    digests: Vec<ArtifactDigest>,
+}
+
+fn required_hashers(bundle: &Bundle) -> Vec<ArtifactHasher> {
+    // SHA-256 binds hashedrekord entries, while in-toto subjects can use
+    // SHA-256 or SHA-512. MessageSignature may additionally select SHA-384.
+    let mut algorithms = vec![HashAlgorithm::Sha2256, HashAlgorithm::Sha2512];
+    if let SignatureContent::MessageSignature(signature) = &bundle.content {
+        if let Some(digest) = &signature.message_digest {
+            if !algorithms.contains(&digest.algorithm) {
+                algorithms.push(digest.algorithm);
+            }
+        }
+    }
+    algorithms.into_iter().map(ArtifactHasher::new).collect()
+}
+
+impl<'a> PreparedArtifact<'a> {
+    pub(crate) fn from_artifact(artifact: Artifact<'a>) -> Self {
+        match artifact {
+            Artifact::Blob(blob) => Self {
+                blob: Some(blob),
+                digests: Vec::new(),
+            },
+            Artifact::Digest(digest) => Self {
+                blob: None,
+                digests: vec![digest],
+            },
+        }
+    }
+
+    pub(crate) fn from_reader(
+        mut reader: impl Read,
+        bundle: &Bundle,
+    ) -> Result<PreparedArtifact<'static>> {
+        let mut hashers = required_hashers(bundle);
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = reader.read(&mut buffer).map_err(Error::ArtifactRead)?;
+            if read == 0 {
+                break;
+            }
+            for hasher in &mut hashers {
+                hasher.update(&buffer[..read]);
+            }
+        }
+        Ok(Self::from_hashers(hashers))
+    }
+
+    pub(crate) async fn from_async_reader(
+        mut reader: impl AsyncRead + Unpin,
+        bundle: &Bundle,
+    ) -> Result<PreparedArtifact<'static>> {
+        let mut hashers = required_hashers(bundle);
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = reader
+                .read(&mut buffer)
+                .await
+                .map_err(Error::ArtifactRead)?;
+            if read == 0 {
+                break;
+            }
+            for hasher in &mut hashers {
+                hasher.update(&buffer[..read]);
+            }
+            // Always-ready readers (including in-memory cursors) do not yield
+            // when awaited. Cooperate explicitly after each hashing chunk.
+            yield_now().await;
+        }
+        Ok(Self::from_hashers(hashers))
+    }
+
+    fn from_hashers(hashers: Vec<ArtifactHasher>) -> PreparedArtifact<'static> {
+        PreparedArtifact {
+            blob: None,
+            digests: hashers.into_iter().map(ArtifactHasher::finalize).collect(),
+        }
+    }
+
+    pub(crate) fn blob(&self) -> Option<&[u8]> {
+        self.blob
+    }
+
+    pub(crate) fn digest(&self, algorithm: HashAlgorithm) -> Result<Vec<u8>> {
+        if let Some(blob) = self.blob {
+            return Ok(match algorithm {
+                HashAlgorithm::Sha2256 => sigstore_crypto::sha256(blob).as_bytes().to_vec(),
+                HashAlgorithm::Sha2384 => sigstore_crypto::sha384(blob),
+                HashAlgorithm::Sha2512 => sigstore_crypto::sha512(blob),
+            });
+        }
+
+        self.digests
+            .iter()
+            .find(|digest| digest.algorithm() == algorithm)
+            .map(|digest| digest.as_bytes().to_vec())
+            .ok_or_else(|| {
+                let supplied = self
+                    .digests
+                    .iter()
+                    .map(|digest| digest.algorithm().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Error::Verification(format!(
+                    "verification requires an {algorithm} artifact digest; supplied: {supplied}"
+                ))
+            })
+    }
+}

--- a/crates/sigstore-verify/src/error.rs
+++ b/crates/sigstore-verify/src/error.rs
@@ -20,6 +20,10 @@ pub enum Error {
     /// Bundle error
     #[error("Bundle error: {0}")]
     Bundle(#[from] sigstore_bundle::Error),
+
+    /// Failed to read artifact input.
+    #[error("failed to read artifact: {0}")]
+    ArtifactRead(#[source] std::io::Error),
 }
 
 /// Result type for verification operations

--- a/crates/sigstore-verify/src/lib.rs
+++ b/crates/sigstore-verify/src/lib.rs
@@ -24,6 +24,7 @@
 //! # }
 //! ```
 
+mod artifact;
 pub mod error;
 mod verify;
 
@@ -40,5 +41,8 @@ pub use sigstore_types as types;
 
 pub use error::{Error, Result};
 pub use verify::{
-    verify, verify_with_key, CertificatePolicy, VerificationPolicy, VerificationResult, Verifier,
+    async_reader, reader, verify, verify_async, verify_async_reader, verify_reader,
+    verify_with_key, verify_with_key_async, verify_with_key_async_reader, verify_with_key_reader,
+    ArtifactSource, AsyncArtifactSource, CertificatePolicy, VerificationPolicy, VerificationResult,
+    Verifier,
 };

--- a/crates/sigstore-verify/src/lib.rs
+++ b/crates/sigstore-verify/src/lib.rs
@@ -41,8 +41,6 @@ pub use sigstore_types as types;
 
 pub use error::{Error, Result};
 pub use verify::{
-    async_reader, reader, verify, verify_async, verify_async_reader, verify_reader,
-    verify_with_key, verify_with_key_async, verify_with_key_async_reader, verify_with_key_reader,
-    ArtifactSource, AsyncArtifactSource, CertificatePolicy, PublicKeyVerificationPolicy,
-    VerificationPolicy, VerificationResult, Verifier,
+    verify, verify_with_key, CertificatePolicy, PublicKeyVerificationPolicy, VerificationPolicy,
+    VerificationResult, Verifier,
 };

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides the main entry point for verifying Sigstore signatures.
 
-use crate::artifact::PreparedArtifact;
+use crate::artifact::{ArtifactRequirements, PreparedArtifact};
 use crate::error::{Error, Result};
 use sigstore_bundle::validate_bundle_with_options;
 use sigstore_bundle::ValidationOptions;
@@ -10,7 +10,7 @@ use sigstore_crypto::{parse_certificate_info, KeyAlgorithm, SigningScheme, Verif
 use sigstore_trust_root::TrustedRoot;
 
 use sigstore_types::bundle::VerificationMaterialContent;
-use sigstore_types::{Artifact, Bundle, KindVersion, SignatureContent, Statement};
+use sigstore_types::{Artifact, Bundle, KindVersion, SignatureContent};
 
 /// How the signing certificate is verified.
 ///
@@ -273,10 +273,17 @@ impl Verifier {
         bundle: &Bundle,
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
+        let cert_info = prepare_certificate(bundle, policy)?;
+        let requirements = ArtifactRequirements::new(
+            &bundle.content,
+            signing_scheme_for_content(cert_info.key_algorithm, &bundle.content)?,
+        )?;
         self.verify_prepared(
-            PreparedArtifact::from_artifact(artifact.into(), &bundle.content),
+            PreparedArtifact::from_artifact(artifact.into(), &requirements),
             bundle,
             policy,
+            &cert_info,
+            &requirements,
         )
     }
 
@@ -290,14 +297,17 @@ impl Verifier {
         bundle: &Bundle,
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
+        let cert_info = prepare_certificate(bundle, policy)?;
+        let requirements = ArtifactRequirements::new(
+            &bundle.content,
+            signing_scheme_for_content(cert_info.key_algorithm, &bundle.content)?,
+        )?;
         self.verify_prepared(
-            PreparedArtifact::from_reader(
-                reader,
-                &bundle.content,
-                certificate_signing_scheme(bundle),
-            )?,
+            PreparedArtifact::from_reader(reader, &requirements)?,
             bundle,
             policy,
+            &cert_info,
+            &requirements,
         )
     }
 
@@ -308,15 +318,17 @@ impl Verifier {
         bundle: &Bundle,
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
+        let cert_info = prepare_certificate(bundle, policy)?;
+        let requirements = ArtifactRequirements::new(
+            &bundle.content,
+            signing_scheme_for_content(cert_info.key_algorithm, &bundle.content)?,
+        )?;
         self.verify_prepared(
-            PreparedArtifact::from_async_reader(
-                reader,
-                &bundle.content,
-                certificate_signing_scheme(bundle),
-            )
-            .await?,
+            PreparedArtifact::from_async_reader(reader, &requirements).await?,
             bundle,
             policy,
+            &cert_info,
+            &requirements,
         )
     }
 
@@ -325,25 +337,13 @@ impl Verifier {
         artifact: PreparedArtifact<'_>,
         bundle: &Bundle,
         policy: &VerificationPolicy,
+        cert_info: &sigstore_crypto::CertificateInfo,
+        requirements: &ArtifactRequirements,
     ) -> Result<VerificationResult> {
         let mut result = VerificationResult::new();
-
-        // Validate bundle structure first. This is a purely structural
-        // (shape/required-fields) check; all cryptographic verification of
-        // the bundle's contents happens in the steps below.
-        let options = ValidationOptions {
-            require_inclusion_proof: policy.verify_tlog,
-            require_timestamp: false, // Don't require timestamps, but verify if present
-        };
-        validate_bundle_with_options(bundle, &options)
-            .map_err(|e| Error::Verification(format!("bundle validation failed: {}", e)))?;
-
-        // Extract certificate for verification
-        let cert = crate::verify_impl::helpers::extract_certificate(
-            &bundle.verification_material.content,
-        )?;
-        let cert_info = parse_certificate_info(cert.as_bytes())
-            .map_err(|e| Error::Verification(format!("failed to parse certificate: {}", e)))?;
+        let cert = bundle
+            .signing_certificate()
+            .ok_or_else(|| Error::Verification("bundle has no signing certificate".into()))?;
 
         // Store identity and issuer in result
         result.identity = cert_info.identity.clone();
@@ -383,10 +383,7 @@ impl Verifier {
                 )?);
 
                 // Also verify the certificate is within its validity period
-                crate::verify_impl::helpers::validate_certificate_time(
-                    validation_time,
-                    &cert_info,
-                )?;
+                crate::verify_impl::helpers::validate_certificate_time(validation_time, cert_info)?;
             }
             // determine_validation_times never yields an empty list, but fail
             // closed rather than panic if that ever stops holding: reaching
@@ -473,7 +470,7 @@ impl Verifier {
             )?;
 
             // Verify the payload binds the artifact
-            verify_dsse_artifact_binding(envelope, &artifact)?;
+            requirements.verify_binding(&artifact)?;
         }
 
         // For MessageSignature bundles, verify the messageDigest matches the artifact
@@ -484,7 +481,7 @@ impl Verifier {
             // regardless of `policy.verify_tlog` so the signature is always checked;
             // the transparency-log path (step 8) performs an equivalent check when
             // enabled, but must not be the only place verification happens.
-            verify_message_signature_crypto(&cert_info, msg_sig, &artifact)?;
+            verify_message_signature_crypto(cert_info, msg_sig, &artifact)?;
         }
 
         // (8): Verify the transparency log entry's consistency against the other
@@ -542,11 +539,15 @@ impl Verifier {
         public_key: &sigstore_types::DerPublicKey,
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
+        let scheme = prepare_public_key(bundle, public_key, policy)?;
+        let requirements = ArtifactRequirements::new(&bundle.content, scheme)?;
         self.verify_with_key_prepared(
-            PreparedArtifact::from_artifact(artifact.into(), &bundle.content),
+            PreparedArtifact::from_artifact(artifact.into(), &requirements),
             bundle,
             public_key,
             policy,
+            scheme,
+            &requirements,
         )
     }
 
@@ -563,15 +564,15 @@ impl Verifier {
         public_key: &sigstore_types::DerPublicKey,
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
+        let scheme = prepare_public_key(bundle, public_key, policy)?;
+        let requirements = ArtifactRequirements::new(&bundle.content, scheme)?;
         self.verify_with_key_prepared(
-            PreparedArtifact::from_reader(
-                reader,
-                &bundle.content,
-                public_key_signing_scheme(bundle, public_key),
-            )?,
+            PreparedArtifact::from_reader(reader, &requirements)?,
             bundle,
             public_key,
             policy,
+            scheme,
+            &requirements,
         )
     }
 
@@ -584,16 +585,15 @@ impl Verifier {
         public_key: &sigstore_types::DerPublicKey,
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
+        let scheme = prepare_public_key(bundle, public_key, policy)?;
+        let requirements = ArtifactRequirements::new(&bundle.content, scheme)?;
         self.verify_with_key_prepared(
-            PreparedArtifact::from_async_reader(
-                reader,
-                &bundle.content,
-                public_key_signing_scheme(bundle, public_key),
-            )
-            .await?,
+            PreparedArtifact::from_async_reader(reader, &requirements).await?,
             bundle,
             public_key,
             policy,
+            scheme,
+            &requirements,
         )
     }
 
@@ -603,30 +603,10 @@ impl Verifier {
         bundle: &Bundle,
         public_key: &sigstore_types::DerPublicKey,
         policy: &PublicKeyVerificationPolicy,
+        signing_scheme: SigningScheme,
+        requirements: &ArtifactRequirements,
     ) -> Result<VerificationResult> {
-        if !matches!(
-            &bundle.verification_material.content,
-            VerificationMaterialContent::PublicKey { .. }
-        ) {
-            return Err(Error::Verification(
-                "bundle contains a certificate but public-key verification was requested"
-                    .to_string(),
-            ));
-        }
-
         let mut result = VerificationResult::new();
-
-        // Validate bundle structure (structural only; the cryptographic checks
-        // follow below)
-        let options = ValidationOptions {
-            require_inclusion_proof: policy.verify_tlog,
-            require_timestamp: false,
-        };
-        validate_bundle_with_options(bundle, &options)
-            .map_err(|e| Error::Verification(format!("bundle validation failed: {}", e)))?;
-
-        let key_algorithm = public_key_algorithm(public_key)?;
-        let signing_scheme = signing_scheme_for_content(key_algorithm, &bundle.content)?;
 
         // Verify transparency log entries (Merkle inclusion proofs, checkpoints,
         // SETs) without certificate time validation.
@@ -667,7 +647,7 @@ impl Verifier {
                 verify_dsse_envelope_signature(envelope, public_key, signing_scheme)?;
 
                 // Verify the payload binds the artifact
-                verify_dsse_artifact_binding(envelope, &artifact)?;
+                requirements.verify_binding(&artifact)?;
             }
         }
 
@@ -709,55 +689,10 @@ fn verify_dsse_envelope_signature(
     scheme: SigningScheme,
 ) -> Result<()> {
     // Compute the PAE that was signed
-    let payload_bytes = envelope.decode_payload();
-    let pae = sigstore_types::pae(&envelope.payload_type, &payload_bytes);
+    let pae = envelope.pae();
 
     sigstore_crypto::verify_signature(public_key, &pae, &envelope.signature.sig, scheme)
         .map_err(|e| Error::Verification(format!("DSSE signature verification failed: {}", e)))
-}
-
-/// Verify that a DSSE envelope's payload binds the artifact being verified.
-///
-/// Only in-toto statements are supported: any other payload type has no
-/// defined relationship to the artifact, so verification fails closed rather
-/// than accepting an arbitrary artifact alongside a validly-signed envelope.
-/// A supported artifact digest (SHA-256 or SHA-512) must match at least one
-/// subject of the statement, and the statement must have at least one subject.
-fn verify_dsse_artifact_binding(
-    envelope: &sigstore_types::DsseEnvelope,
-    artifact: &PreparedArtifact<'_>,
-) -> Result<()> {
-    if envelope.payload_type != "application/vnd.in-toto+json" {
-        return Err(Error::Verification(format!(
-            "unsupported DSSE payload type {:?}: cannot bind artifact to attestation",
-            envelope.payload_type
-        )));
-    }
-
-    let payload_str = std::str::from_utf8(envelope.payload.as_bytes())
-        .map_err(|e| Error::Verification(format!("payload is not valid UTF-8: {}", e)))?;
-    let statement: Statement = serde_json::from_str(payload_str)
-        .map_err(|e| Error::Verification(format!("failed to parse in-toto statement: {}", e)))?;
-
-    if statement.subject.is_empty() {
-        return Err(Error::Verification(
-            "in-toto statement has no subjects: cannot bind artifact to attestation".to_string(),
-        ));
-    }
-    let matches = artifact
-        .sha256()
-        .is_ok_and(|digest| statement.matches_sha256(&digest))
-        || artifact
-            .sha512()
-            .is_ok_and(|digest| statement.matches_sha512(&digest));
-
-    if !matches {
-        return Err(Error::Verification(
-            "artifact hash does not match any subject in attestation".to_string(),
-        ));
-    }
-
-    Ok(())
 }
 
 /// Verify `signature` over `artifact` with an already-resolved signing scheme.
@@ -771,28 +706,18 @@ fn verify_signature_over_artifact(
     signature: &sigstore_types::SignatureBytes,
     artifact: &PreparedArtifact<'_>,
 ) -> Result<()> {
-    let result = if let Some(blob) = artifact.blob() {
-        sigstore_crypto::verify_signature(public_key, blob, signature, scheme)
-    } else {
-        if !scheme.supports_prehashed() {
-            return Err(Error::Verification(format!(
-                "cannot verify signature from a digest or reader - scheme {} does not support prehashed mode",
-                scheme.name()
-            )));
-        }
-        let expected = scheme.hash_algorithm().ok_or_else(|| {
-            Error::Verification(format!(
-                "scheme {} has no external digest algorithm",
-                scheme.name()
-            ))
-        })?;
-        let digest = artifact.digest(expected)?;
+    let result = if let Some(algorithm) = scheme.hash_algorithm() {
+        let digest = artifact.digest(algorithm)?;
         sigstore_crypto::verify_signature_prehashed(
             public_key,
             digest.as_bytes(),
             signature,
             scheme,
         )
+    } else if let Some(blob) = artifact.blob() {
+        sigstore_crypto::verify_signature(public_key, blob, signature, scheme)
+    } else {
+        return Err(Error::Verification(format!("cannot verify signature from a digest or reader - scheme {} does not support prehashed mode", scheme.name())));
     };
     result.map_err(|e| Error::Verification(format!("signature verification failed: {}", e)))
 }
@@ -828,28 +753,44 @@ fn signing_scheme_for_content(
     }
 }
 
-/// The scheme a certificate bundle's signature will be verified with, derived
-/// before the artifact is read so one streaming pass can produce the digest
-/// that scheme consumes.
-///
-/// `None` when the certificate cannot be read: streamed input then hashes with
-/// every algorithm and verification reports the certificate problem itself.
-fn certificate_signing_scheme(bundle: &Bundle) -> Option<SigningScheme> {
-    let cert =
-        crate::verify_impl::helpers::extract_certificate(&bundle.verification_material.content)
-            .ok()?;
-    let cert_info = parse_certificate_info(cert.as_bytes()).ok()?;
-    signing_scheme_for_content(cert_info.key_algorithm, &bundle.content).ok()
+fn validate_structure(bundle: &Bundle, verify_tlog: bool) -> Result<()> {
+    validate_bundle_with_options(
+        bundle,
+        &ValidationOptions {
+            require_inclusion_proof: verify_tlog,
+            require_timestamp: false,
+        },
+    )
+    .map_err(|e| Error::Verification(format!("bundle validation failed: {e}")))
 }
 
-/// [`certificate_signing_scheme`] for managed-key bundles, whose key is
-/// supplied by the caller.
-fn public_key_signing_scheme(
+fn prepare_certificate(
+    bundle: &Bundle,
+    policy: &VerificationPolicy,
+) -> Result<sigstore_crypto::CertificateInfo> {
+    validate_structure(bundle, policy.verify_tlog)?;
+    let cert = bundle
+        .signing_certificate()
+        .ok_or_else(|| Error::Verification("bundle has no signing certificate".into()))?;
+    parse_certificate_info(cert.as_bytes())
+        .map_err(|e| Error::Verification(format!("failed to parse certificate: {e}")))
+}
+
+fn prepare_public_key(
     bundle: &Bundle,
     public_key: &sigstore_types::DerPublicKey,
-) -> Option<SigningScheme> {
-    let key_algorithm = public_key_algorithm(public_key).ok()?;
-    signing_scheme_for_content(key_algorithm, &bundle.content).ok()
+    policy: &PublicKeyVerificationPolicy,
+) -> Result<SigningScheme> {
+    if !matches!(
+        bundle.verification_material.content,
+        VerificationMaterialContent::PublicKey { .. }
+    ) {
+        return Err(Error::Verification(
+            "bundle contains a certificate but public-key verification was requested".into(),
+        ));
+    }
+    validate_structure(bundle, policy.verify_tlog)?;
+    signing_scheme_for_content(public_key_algorithm(public_key)?, &bundle.content)
 }
 
 fn verify_message_signature_crypto(
@@ -1058,151 +999,31 @@ mod tests {
         )
     }
 
-    fn prepared_blob<'a>(
-        blob: &'a [u8],
-        envelope: &sigstore_types::DsseEnvelope,
-    ) -> PreparedArtifact<'a> {
-        PreparedArtifact::from_artifact(
-            Artifact::from(blob),
-            &SignatureContent::DsseEnvelope(envelope.clone()),
+    #[test]
+    fn statement_requirements_fail_closed_and_bind_blob() {
+        let content = SignatureContent::DsseEnvelope(in_toto_envelope(
+            &statement_with_subject_sha256(&sigstore_crypto::sha256(b"hello").to_hex()),
+        ));
+        let requirements =
+            ArtifactRequirements::new(&content, SigningScheme::EcdsaP256Sha256).unwrap();
+        for (bytes, matches) in [(b"hello".as_slice(), true), (b"wrong".as_slice(), false)] {
+            let artifact = PreparedArtifact::from_artifact(bytes.into(), &requirements);
+            assert_eq!(requirements.verify_binding(&artifact).is_ok(), matches);
+        }
+        for payload in [
+            "not json",
+            r#"{"_type":"https://in-toto.io/Statement/v1","subject":[],"predicateType":"p","predicate":{}}"#,
+        ] {
+            let content = SignatureContent::DsseEnvelope(in_toto_envelope(payload));
+            assert!(ArtifactRequirements::new(&content, SigningScheme::EcdsaP256Sha256).is_err());
+        }
+        let mut envelope = in_toto_envelope("{}");
+        envelope.payload_type = "unknown".into();
+        assert!(ArtifactRequirements::new(
+            &SignatureContent::DsseEnvelope(envelope),
+            SigningScheme::EcdsaP256Sha256
         )
-    }
-
-    fn message_signature_content(message_digest: Option<HashAlgorithm>) -> SignatureContent {
-        SignatureContent::MessageSignature(sigstore_types::bundle::MessageSignature {
-            message_digest: message_digest.map(|algorithm| sigstore_types::bundle::MessageDigest {
-                algorithm,
-                digest: sigstore_types::DigestBytes::from_bytes(vec![0; 32]),
-            }),
-            signature: sigstore_types::SignatureBytes::from_bytes(b"sig"),
-        })
-    }
-
-    fn has_digest(artifact: &PreparedArtifact<'_>, algorithm: HashAlgorithm) -> bool {
-        artifact.digest(algorithm).is_ok()
-    }
-
-    /// A P-384 key signs over SHA-384 while hashedrekord binds SHA-256. When
-    /// the bundle omits `messageDigest`, streamed input must still produce
-    /// the scheme's digest or prehashed verification cannot run.
-    #[test]
-    fn test_streamed_message_signature_hashes_the_schemes_digest() {
-        let content = message_signature_content(None);
-        let bytes: &[u8] = b"hello world";
-
-        let artifact =
-            PreparedArtifact::from_reader(bytes, &content, Some(SigningScheme::EcdsaP384Sha384))
-                .unwrap();
-        assert!(has_digest(&artifact, HashAlgorithm::Sha2256));
-        assert!(has_digest(&artifact, HashAlgorithm::Sha2384));
-        assert!(!has_digest(&artifact, HashAlgorithm::Sha2512));
-
-        // Unknown key material: hash everything so verification can proceed
-        // far enough to report the real problem.
-        let artifact = PreparedArtifact::from_reader(bytes, &content, None).unwrap();
-        assert!(has_digest(&artifact, HashAlgorithm::Sha2256));
-        assert!(has_digest(&artifact, HashAlgorithm::Sha2384));
-        assert!(has_digest(&artifact, HashAlgorithm::Sha2512));
-
-        // Ed25519 has no external digest; only the binding digest is hashed
-        // and prehashed verification fails closed later.
-        let artifact =
-            PreparedArtifact::from_reader(bytes, &content, Some(SigningScheme::Ed25519)).unwrap();
-        assert!(has_digest(&artifact, HashAlgorithm::Sha2256));
-        assert!(!has_digest(&artifact, HashAlgorithm::Sha2384));
-
-        // Blob input is verified over the bytes themselves, so the scheme's
-        // digest is not computed; the declared messageDigest still is.
-        let artifact = PreparedArtifact::from_artifact(
-            Artifact::from(bytes),
-            &message_signature_content(Some(HashAlgorithm::Sha2384)),
-        );
-        assert!(artifact.blob().is_some());
-        assert!(has_digest(&artifact, HashAlgorithm::Sha2256));
-        assert!(has_digest(&artifact, HashAlgorithm::Sha2384));
-        assert!(!has_digest(&artifact, HashAlgorithm::Sha2512));
-    }
-
-    #[test]
-    fn test_dsse_prepared_blob_hashes_only_subject_algorithms() {
-        let sha256_only = in_toto_envelope(&statement_with_subject_sha256(
-            &sigstore_crypto::sha256(b"hello world").to_hex(),
-        ));
-        let artifact = prepared_blob(b"hello world", &sha256_only);
-        assert!(artifact.digest(HashAlgorithm::Sha2256).is_ok());
-        assert!(artifact.digest(HashAlgorithm::Sha2512).is_err());
-
-        // An unreadable statement falls back to hashing both, so the binding
-        // check can report the real problem.
-        let unreadable = in_toto_envelope("not json");
-        let artifact = prepared_blob(b"hello world", &unreadable);
-        assert!(artifact.digest(HashAlgorithm::Sha2256).is_ok());
-        assert!(artifact.digest(HashAlgorithm::Sha2512).is_ok());
-    }
-
-    /// SHA-512 subjects (sigstore-python and npm provenance bundles) must bind
-    /// a streamed artifact too: the reader pass hashes with SHA-512 only.
-    #[test]
-    fn test_dsse_binding_sha512_subject_from_reader() {
-        let artifact_bytes: &[u8] = b"hello world";
-        let hash_hex = sigstore_crypto::sha512(artifact_bytes).to_hex();
-        let envelope = in_toto_envelope(&format!(
-            r#"{{"_type":"https://in-toto.io/Statement/v1","subject":[{{"name":"artifact","digest":{{"sha512":"{hash_hex}"}}}}],"predicateType":"https://example.com/predicate/v1","predicate":{{}}}}"#
-        ));
-        let content = SignatureContent::DsseEnvelope(envelope.clone());
-
-        let artifact = PreparedArtifact::from_reader(artifact_bytes, &content, None).unwrap();
-        assert!(artifact.digest(HashAlgorithm::Sha2256).is_err());
-        assert!(artifact.digest(HashAlgorithm::Sha2512).is_ok());
-        assert!(verify_dsse_artifact_binding(&envelope, &artifact).is_ok());
-
-        let other = PreparedArtifact::from_reader(&b"other"[..], &content, None).unwrap();
-        assert!(verify_dsse_artifact_binding(&envelope, &other).is_err());
-    }
-
-    #[test]
-    fn test_dsse_binding_matching_subject_ok() {
-        let artifact_bytes = b"hello world";
-        let hash_hex = sigstore_crypto::sha256(artifact_bytes).to_hex();
-        let envelope = in_toto_envelope(&statement_with_subject_sha256(&hash_hex));
-
-        let artifact = prepared_blob(artifact_bytes, &envelope);
-        assert!(verify_dsse_artifact_binding(&envelope, &artifact).is_ok());
-    }
-
-    #[test]
-    fn test_dsse_binding_mismatched_subject_fails() {
-        let hash_hex = sigstore_crypto::sha256(b"some other artifact").to_hex();
-        let envelope = in_toto_envelope(&statement_with_subject_sha256(&hash_hex));
-
-        let artifact = prepared_blob(b"hello world", &envelope);
-        let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("does not match any subject in attestation"));
-    }
-
-    #[test]
-    fn test_dsse_binding_empty_subjects_fails_closed() {
-        let payload = r#"{"_type":"https://in-toto.io/Statement/v1","subject":[],"predicateType":"https://example.com/predicate/v1","predicate":{}}"#;
-        let envelope = in_toto_envelope(payload);
-
-        let artifact = prepared_blob(b"hello world", &envelope);
-        let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
-        assert!(err.to_string().contains("no subjects"));
-    }
-
-    #[test]
-    fn test_dsse_binding_unknown_payload_type_fails_closed() {
-        let envelope = sigstore_types::DsseEnvelope::new(
-            "application/vnd.example+json".to_string(),
-            sigstore_types::PayloadBytes::from_bytes(b"{}"),
-            unused_signature(),
-        );
-
-        let artifact = prepared_blob(b"hello world", &envelope);
-        let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
-        assert!(err.to_string().contains("unsupported DSSE payload type"));
+        .is_err());
     }
 
     const DSSE_TEST_PAYLOAD: &[u8] = br#"{"hello":"world"}"#;

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides the main entry point for verifying Sigstore signatures.
 
+use crate::artifact::PreparedArtifact;
 use crate::error::{Error, Result};
 use base64::Engine;
 use sigstore_bundle::validate_bundle_with_options;
@@ -10,6 +11,72 @@ use sigstore_crypto::{parse_certificate_info, KeyAlgorithm, SigningScheme, Verif
 use sigstore_trust_root::TrustedRoot;
 
 use sigstore_types::{Artifact, Bundle, HashAlgorithm, SignatureContent, Statement};
+
+/// Artifact input for verification.
+#[derive(Debug)]
+pub enum ArtifactSource<'a, R = std::io::Empty> {
+    /// Raw artifact bytes or a pre-computed digest.
+    Artifact(Artifact<'a>),
+    /// Artifact bytes streamed from a reader.
+    Reader(R),
+}
+
+/// Reader input for [`ArtifactSource`].
+#[derive(Debug)]
+pub struct Reader<R>(R);
+
+/// Wrap a reader so it can be passed to `verify(...).`
+pub fn reader<R>(reader: R) -> Reader<R> {
+    Reader(reader)
+}
+
+impl<'a, A> From<A> for ArtifactSource<'a>
+where
+    A: Into<Artifact<'a>>,
+{
+    fn from(artifact: A) -> Self {
+        Self::Artifact(artifact.into())
+    }
+}
+
+impl<'a, R> From<Reader<R>> for ArtifactSource<'a, R> {
+    fn from(reader: Reader<R>) -> Self {
+        Self::Reader(reader.0)
+    }
+}
+
+/// Artifact input for async verification.
+#[derive(Debug)]
+pub enum AsyncArtifactSource<'a, R = futures::io::Empty> {
+    /// Raw artifact bytes or a pre-computed digest.
+    Artifact(Artifact<'a>),
+    /// Artifact bytes streamed from an async reader.
+    Reader(R),
+}
+
+/// Async reader input for [`AsyncArtifactSource`].
+#[derive(Debug)]
+pub struct AsyncReader<R>(R);
+
+/// Wrap an async reader so it can be passed to `verify_async(...).`
+pub fn async_reader<R>(reader: R) -> AsyncReader<R> {
+    AsyncReader(reader)
+}
+
+impl<'a, A> From<A> for AsyncArtifactSource<'a>
+where
+    A: Into<Artifact<'a>>,
+{
+    fn from(artifact: A) -> Self {
+        Self::Artifact(artifact.into())
+    }
+}
+
+impl<'a, R> From<AsyncReader<R>> for AsyncArtifactSource<'a, R> {
+    fn from(reader: AsyncReader<R>) -> Self {
+        Self::Reader(reader.0)
+    }
+}
 
 /// How the signing certificate is verified.
 ///
@@ -242,13 +309,65 @@ impl Verifier {
     ///    public key.
     /// 8. Verify the transparency log entry's consistency against the other
     ///    materials, to prevent variants of CVE-2022-36056.
-    pub fn verify<'a>(
+    pub fn verify<'a, R: std::io::Read>(
         &self,
-        artifact: impl Into<Artifact<'a>>,
+        artifact: impl Into<ArtifactSource<'a, R>>,
         bundle: &Bundle,
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
-        let artifact = artifact.into();
+        let artifact = match artifact.into() {
+            ArtifactSource::Artifact(artifact) => PreparedArtifact::from_artifact(artifact),
+            ArtifactSource::Reader(reader) => PreparedArtifact::from_reader(reader, bundle)?,
+        };
+        self.verify_prepared(artifact, bundle, policy)
+    }
+
+    /// Verify an artifact read synchronously to EOF in constant memory.
+    ///
+    /// Reads happen on the calling thread. Async applications should use
+    /// [`Verifier::verify_async_reader`] to avoid blocking an executor.
+    pub fn verify_reader(
+        &self,
+        reader: impl std::io::Read,
+        bundle: &Bundle,
+        policy: &VerificationPolicy,
+    ) -> Result<VerificationResult> {
+        self.verify(crate::verify::reader(reader), bundle, policy)
+    }
+
+    /// Verify an artifact read asynchronously to EOF in constant memory.
+    pub async fn verify_async_reader(
+        &self,
+        reader: impl futures::io::AsyncRead + Unpin,
+        bundle: &Bundle,
+        policy: &VerificationPolicy,
+    ) -> Result<VerificationResult> {
+        self.verify_async(crate::verify::async_reader(reader), bundle, policy)
+            .await
+    }
+
+    /// Verify an artifact or async reader against a bundle.
+    pub async fn verify_async<'a, R: futures::io::AsyncRead + Unpin>(
+        &self,
+        artifact: impl Into<AsyncArtifactSource<'a, R>>,
+        bundle: &Bundle,
+        policy: &VerificationPolicy,
+    ) -> Result<VerificationResult> {
+        let artifact = match artifact.into() {
+            AsyncArtifactSource::Artifact(artifact) => PreparedArtifact::from_artifact(artifact),
+            AsyncArtifactSource::Reader(reader) => {
+                PreparedArtifact::from_async_reader(reader, bundle).await?
+            }
+        };
+        self.verify_prepared(artifact, bundle, policy)
+    }
+
+    fn verify_prepared(
+        &self,
+        artifact: PreparedArtifact<'_>,
+        bundle: &Bundle,
+        policy: &VerificationPolicy,
+    ) -> Result<VerificationResult> {
         let mut result = VerificationResult::new();
 
         // Validate bundle structure first. This is a purely structural
@@ -434,23 +553,11 @@ impl Verifier {
     }
 }
 
-fn compute_artifact_digest_algo(artifact: &Artifact<'_>, algo: HashAlgorithm) -> Result<Vec<u8>> {
-    match artifact {
-        Artifact::Blob(bytes) => match algo {
-            HashAlgorithm::Sha2256 => Ok(sigstore_crypto::sha256(bytes).as_bytes().to_vec()),
-            HashAlgorithm::Sha2384 => Ok(sigstore_crypto::sha384(bytes)),
-            HashAlgorithm::Sha2512 => Ok(sigstore_crypto::sha512(bytes)),
-        },
-        Artifact::Digest(digest) => {
-            if digest.algorithm() != algo {
-                return Err(Error::Verification(format!(
-                    "verification requires an {algo} artifact digest, got {}",
-                    digest.algorithm()
-                )));
-            }
-            Ok(digest.as_bytes().to_vec())
-        }
-    }
+fn compute_artifact_digest_algo(
+    artifact: &PreparedArtifact<'_>,
+    algo: HashAlgorithm,
+) -> Result<Vec<u8>> {
+    artifact.digest(algo)
 }
 
 /// Verify the DSSE envelope's signature over its PAE with the given key.
@@ -476,7 +583,7 @@ fn verify_dsse_envelope_signature(
 /// subject of the statement, and the statement must have at least one subject.
 fn verify_dsse_artifact_binding(
     envelope: &sigstore_types::DsseEnvelope,
-    artifact: &Artifact<'_>,
+    artifact: &PreparedArtifact<'_>,
 ) -> Result<()> {
     if envelope.payload_type != "application/vnd.in-toto+json" {
         return Err(Error::Verification(format!(
@@ -495,26 +602,15 @@ fn verify_dsse_artifact_binding(
             "in-toto statement has no subjects: cannot bind artifact to attestation".to_string(),
         ));
     }
-    let matches = match artifact {
-        Artifact::Blob(bytes) => {
-            let sha256 = hex::encode(sigstore_crypto::sha256(bytes));
-            let sha512 = hex::encode(sigstore_crypto::sha512(bytes));
-            statement.matches_sha256(&sha256) || statement.matches_sha512(&sha512)
-        }
-        Artifact::Digest(digest) => {
-            let value = hex::encode(digest.as_bytes());
-            match digest.algorithm() {
-                HashAlgorithm::Sha2256 => statement.matches_sha256(&value),
-                HashAlgorithm::Sha2512 => statement.matches_sha512(&value),
-                algorithm => {
-                    return Err(Error::Verification(format!(
-                        "unsupported pre-computed artifact digest algorithm: {}",
-                        algorithm
-                    )))
-                }
-            }
-        }
-    };
+    let sha256_matches = artifact
+        .digest(HashAlgorithm::Sha2256)
+        .map(|digest| statement.matches_sha256(&hex::encode(digest)))
+        .unwrap_or(false);
+    let sha512_matches = artifact
+        .digest(HashAlgorithm::Sha2512)
+        .map(|digest| statement.matches_sha512(&hex::encode(digest)))
+        .unwrap_or(false);
+    let matches = sha256_matches || sha512_matches;
 
     if !matches {
         return Err(Error::Verification(
@@ -534,40 +630,25 @@ fn verify_signature_over_artifact(
     public_key: &sigstore_types::DerPublicKey,
     scheme: SigningScheme,
     signature: &sigstore_types::SignatureBytes,
-    artifact: &Artifact<'_>,
+    artifact: &PreparedArtifact<'_>,
 ) -> Result<()> {
-    let result = match artifact {
-        Artifact::Blob(bytes) => {
-            sigstore_crypto::verify_signature(public_key, bytes, signature, scheme)
+    let result = if let Some(blob) = artifact.blob() {
+        sigstore_crypto::verify_signature(public_key, blob, signature, scheme)
+    } else {
+        if !scheme.supports_prehashed() {
+            return Err(Error::Verification(format!(
+                "cannot verify signature from a digest or reader - scheme {} does not support prehashed mode",
+                scheme.name()
+            )));
         }
-        Artifact::Digest(digest) => {
-            if !scheme.supports_prehashed() {
-                return Err(Error::Verification(format!(
-                    "cannot verify signature with digest-only - scheme {} does not support prehashed mode",
-                    scheme.name()
-                )));
-            }
-            let expected = scheme.hash_algorithm().ok_or_else(|| {
-                Error::Verification(format!(
-                    "cannot verify signature with digest-only - scheme {} has no external digest algorithm",
-                    scheme.name()
-                ))
-            })?;
-            if digest.algorithm() != expected {
-                return Err(Error::Verification(format!(
-                    "signature scheme {} requires an {} artifact digest, got {}",
-                    scheme.name(),
-                    expected,
-                    digest.algorithm()
-                )));
-            }
-            sigstore_crypto::verify_signature_prehashed(
-                public_key,
-                digest.as_bytes(),
-                signature,
-                scheme,
-            )
-        }
+        let expected = scheme.hash_algorithm().ok_or_else(|| {
+            Error::Verification(format!(
+                "scheme {} has no external digest algorithm",
+                scheme.name()
+            ))
+        })?;
+        let digest = artifact.digest(expected)?;
+        sigstore_crypto::verify_signature_prehashed(public_key, &digest, signature, scheme)
     };
     result.map_err(|e| Error::Verification(format!("signature verification failed: {}", e)))
 }
@@ -606,7 +687,7 @@ fn signing_scheme_for_content(
 fn verify_message_signature_crypto(
     cert_info: &sigstore_crypto::CertificateInfo,
     msg_sig: &sigstore_types::bundle::MessageSignature,
-    artifact: &Artifact<'_>,
+    artifact: &PreparedArtifact<'_>,
 ) -> Result<()> {
     verify_signature_over_artifact(
         &cert_info.public_key,
@@ -642,14 +723,52 @@ fn verify_message_signature_crypto(
 /// # Ok(())
 /// # }
 /// ```
-pub fn verify<'a>(
-    artifact: impl Into<Artifact<'a>>,
+pub fn verify<'a, R: std::io::Read>(
+    artifact: impl Into<ArtifactSource<'a, R>>,
     bundle: &Bundle,
     policy: &VerificationPolicy,
     trusted_root: &TrustedRoot,
 ) -> Result<VerificationResult> {
     let verifier = Verifier::new(trusted_root);
     verifier.verify(artifact, bundle, policy)
+}
+
+/// Verify an artifact from a synchronous reader.
+pub fn verify_reader(
+    reader: impl std::io::Read,
+    bundle: &Bundle,
+    policy: &VerificationPolicy,
+    trusted_root: &TrustedRoot,
+) -> Result<VerificationResult> {
+    verify(crate::verify::reader(reader), bundle, policy, trusted_root)
+}
+
+/// Verify an artifact from a runtime-independent asynchronous reader.
+pub async fn verify_async_reader(
+    reader: impl futures::io::AsyncRead + Unpin,
+    bundle: &Bundle,
+    policy: &VerificationPolicy,
+    trusted_root: &TrustedRoot,
+) -> Result<VerificationResult> {
+    verify_async(
+        crate::verify::async_reader(reader),
+        bundle,
+        policy,
+        trusted_root,
+    )
+    .await
+}
+
+/// Verify an artifact or async reader against a bundle.
+pub async fn verify_async<'a, R: futures::io::AsyncRead + Unpin>(
+    artifact: impl Into<AsyncArtifactSource<'a, R>>,
+    bundle: &Bundle,
+    policy: &VerificationPolicy,
+    trusted_root: &TrustedRoot,
+) -> Result<VerificationResult> {
+    Verifier::new(trusted_root)
+        .verify_async(artifact, bundle, policy)
+        .await
 }
 
 /// Derive the key algorithm from the public key's SPKI algorithm identifier.
@@ -724,13 +843,72 @@ fn verify_public_key_hint(hint: &str, public_key: &sigstore_types::DerPublicKey)
 /// # Ok(())
 /// # }
 /// ```
-pub fn verify_with_key<'a>(
-    artifact: impl Into<Artifact<'a>>,
+pub fn verify_with_key<'a, R: std::io::Read>(
+    artifact: impl Into<ArtifactSource<'a, R>>,
     bundle: &Bundle,
     public_key: &sigstore_types::DerPublicKey,
     trusted_root: &TrustedRoot,
 ) -> Result<VerificationResult> {
-    let artifact = artifact.into();
+    let artifact = match artifact.into() {
+        ArtifactSource::Artifact(artifact) => PreparedArtifact::from_artifact(artifact),
+        ArtifactSource::Reader(reader) => PreparedArtifact::from_reader(reader, bundle)?,
+    };
+    verify_with_key_prepared(artifact, bundle, public_key, trusted_root)
+}
+
+/// Verify a managed-key bundle from a synchronous artifact reader.
+pub fn verify_with_key_reader(
+    reader: impl std::io::Read,
+    bundle: &Bundle,
+    public_key: &sigstore_types::DerPublicKey,
+    trusted_root: &TrustedRoot,
+) -> Result<VerificationResult> {
+    verify_with_key(
+        crate::verify::reader(reader),
+        bundle,
+        public_key,
+        trusted_root,
+    )
+}
+
+/// Verify a managed-key bundle from an asynchronous artifact reader.
+pub async fn verify_with_key_async_reader(
+    reader: impl futures::io::AsyncRead + Unpin,
+    bundle: &Bundle,
+    public_key: &sigstore_types::DerPublicKey,
+    trusted_root: &TrustedRoot,
+) -> Result<VerificationResult> {
+    verify_with_key_async(
+        crate::verify::async_reader(reader),
+        bundle,
+        public_key,
+        trusted_root,
+    )
+    .await
+}
+
+/// Verify a managed-key bundle from an artifact or async reader.
+pub async fn verify_with_key_async<'a, R: futures::io::AsyncRead + Unpin>(
+    artifact: impl Into<AsyncArtifactSource<'a, R>>,
+    bundle: &Bundle,
+    public_key: &sigstore_types::DerPublicKey,
+    trusted_root: &TrustedRoot,
+) -> Result<VerificationResult> {
+    let artifact = match artifact.into() {
+        AsyncArtifactSource::Artifact(artifact) => PreparedArtifact::from_artifact(artifact),
+        AsyncArtifactSource::Reader(reader) => {
+            PreparedArtifact::from_async_reader(reader, bundle).await?
+        }
+    };
+    verify_with_key_prepared(artifact, bundle, public_key, trusted_root)
+}
+
+fn verify_with_key_prepared(
+    artifact: PreparedArtifact<'_>,
+    bundle: &Bundle,
+    public_key: &sigstore_types::DerPublicKey,
+    trusted_root: &TrustedRoot,
+) -> Result<VerificationResult> {
     let result = VerificationResult::new();
 
     if let sigstore_types::bundle::VerificationMaterialContent::PublicKey { hint } =
@@ -910,7 +1088,7 @@ mod tests {
         let hash_hex = sigstore_crypto::sha256(artifact_bytes).to_hex();
         let envelope = in_toto_envelope(&statement_with_subject_sha256(&hash_hex));
 
-        let artifact = Artifact::from(artifact_bytes.as_slice());
+        let artifact = PreparedArtifact::from_artifact(Artifact::from(artifact_bytes.as_slice()));
         assert!(verify_dsse_artifact_binding(&envelope, &artifact).is_ok());
     }
 
@@ -919,7 +1097,7 @@ mod tests {
         let hash_hex = sigstore_crypto::sha256(b"some other artifact").to_hex();
         let envelope = in_toto_envelope(&statement_with_subject_sha256(&hash_hex));
 
-        let artifact = Artifact::from(b"hello world".as_slice());
+        let artifact = PreparedArtifact::from_artifact(Artifact::from(b"hello world".as_slice()));
         let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
         assert!(err
             .to_string()
@@ -931,7 +1109,7 @@ mod tests {
         let payload = r#"{"_type":"https://in-toto.io/Statement/v1","subject":[],"predicateType":"https://example.com/predicate/v1","predicate":{}}"#;
         let envelope = in_toto_envelope(payload);
 
-        let artifact = Artifact::from(b"hello world".as_slice());
+        let artifact = PreparedArtifact::from_artifact(Artifact::from(b"hello world".as_slice()));
         let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
         assert!(err.to_string().contains("no subjects"));
     }
@@ -944,7 +1122,7 @@ mod tests {
             unused_signature(),
         );
 
-        let artifact = Artifact::from(b"hello world".as_slice());
+        let artifact = PreparedArtifact::from_artifact(Artifact::from(b"hello world".as_slice()));
         let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
         assert!(err.to_string().contains("unsupported DSSE payload type"));
     }

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -1027,6 +1027,23 @@ mod tests {
     }
 
     #[test]
+    fn test_dsse_prepared_blob_hashes_only_subject_algorithms() {
+        let sha256_only = in_toto_envelope(&statement_with_subject_sha256(
+            &sigstore_crypto::sha256(b"hello world").to_hex(),
+        ));
+        let artifact = prepared_blob(b"hello world", &sha256_only);
+        assert!(artifact.digest(HashAlgorithm::Sha2256).is_ok());
+        assert!(artifact.digest(HashAlgorithm::Sha2512).is_err());
+
+        // An unreadable statement falls back to hashing both, so the binding
+        // check can report the real problem.
+        let unreadable = in_toto_envelope("not json");
+        let artifact = prepared_blob(b"hello world", &unreadable);
+        assert!(artifact.digest(HashAlgorithm::Sha2256).is_ok());
+        assert!(artifact.digest(HashAlgorithm::Sha2512).is_ok());
+    }
+
+    #[test]
     fn test_dsse_binding_matching_subject_ok() {
         let artifact_bytes = b"hello world";
         let hash_hex = sigstore_crypto::sha256(artifact_bytes).to_hex();

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -1140,6 +1140,26 @@ mod tests {
         assert!(artifact.digest(HashAlgorithm::Sha2512).is_ok());
     }
 
+    /// SHA-512 subjects (sigstore-python and npm provenance bundles) must bind
+    /// a streamed artifact too: the reader pass hashes with SHA-512 only.
+    #[test]
+    fn test_dsse_binding_sha512_subject_from_reader() {
+        let artifact_bytes: &[u8] = b"hello world";
+        let hash_hex = sigstore_crypto::sha512(artifact_bytes).to_hex();
+        let envelope = in_toto_envelope(&format!(
+            r#"{{"_type":"https://in-toto.io/Statement/v1","subject":[{{"name":"artifact","digest":{{"sha512":"{hash_hex}"}}}}],"predicateType":"https://example.com/predicate/v1","predicate":{{}}}}"#
+        ));
+        let content = SignatureContent::DsseEnvelope(envelope.clone());
+
+        let artifact = PreparedArtifact::from_reader(artifact_bytes, &content, None).unwrap();
+        assert!(artifact.digest(HashAlgorithm::Sha2256).is_err());
+        assert!(artifact.digest(HashAlgorithm::Sha2512).is_ok());
+        assert!(verify_dsse_artifact_binding(&envelope, &artifact).is_ok());
+
+        let other = PreparedArtifact::from_reader(&b"other"[..], &content, None).unwrap();
+        assert!(verify_dsse_artifact_binding(&envelope, &other).is_err());
+    }
+
     #[test]
     fn test_dsse_binding_matching_subject_ok() {
         let artifact_bytes = b"hello world";

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -300,7 +300,7 @@ impl Verifier {
     /// Verify an artifact read asynchronously to EOF in constant memory.
     pub async fn verify_async_reader(
         &self,
-        reader: impl futures::io::AsyncRead + Unpin,
+        reader: impl futures_io::AsyncRead + Unpin,
         bundle: &Bundle,
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
@@ -566,7 +566,7 @@ impl Verifier {
     /// EOF in constant memory.
     pub async fn verify_with_key_async_reader(
         &self,
-        reader: impl futures::io::AsyncRead + Unpin,
+        reader: impl futures_io::AsyncRead + Unpin,
         bundle: &Bundle,
         public_key: &sigstore_types::DerPublicKey,
         policy: &PublicKeyVerificationPolicy,

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -291,7 +291,11 @@ impl Verifier {
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_prepared(
-            PreparedArtifact::from_reader(reader, &bundle.content)?,
+            PreparedArtifact::from_reader(
+                reader,
+                &bundle.content,
+                certificate_signing_scheme(bundle),
+            )?,
             bundle,
             policy,
         )
@@ -305,7 +309,12 @@ impl Verifier {
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_prepared(
-            PreparedArtifact::from_async_reader(reader, &bundle.content).await?,
+            PreparedArtifact::from_async_reader(
+                reader,
+                &bundle.content,
+                certificate_signing_scheme(bundle),
+            )
+            .await?,
             bundle,
             policy,
         )
@@ -555,7 +564,11 @@ impl Verifier {
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_with_key_prepared(
-            PreparedArtifact::from_reader(reader, &bundle.content)?,
+            PreparedArtifact::from_reader(
+                reader,
+                &bundle.content,
+                public_key_signing_scheme(bundle, public_key),
+            )?,
             bundle,
             public_key,
             policy,
@@ -572,7 +585,12 @@ impl Verifier {
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_with_key_prepared(
-            PreparedArtifact::from_async_reader(reader, &bundle.content).await?,
+            PreparedArtifact::from_async_reader(
+                reader,
+                &bundle.content,
+                public_key_signing_scheme(bundle, public_key),
+            )
+            .await?,
             bundle,
             public_key,
             policy,
@@ -810,6 +828,30 @@ fn signing_scheme_for_content(
     }
 }
 
+/// The scheme a certificate bundle's signature will be verified with, derived
+/// before the artifact is read so one streaming pass can produce the digest
+/// that scheme consumes.
+///
+/// `None` when the certificate cannot be read: streamed input then hashes with
+/// every algorithm and verification reports the certificate problem itself.
+fn certificate_signing_scheme(bundle: &Bundle) -> Option<SigningScheme> {
+    let cert =
+        crate::verify_impl::helpers::extract_certificate(&bundle.verification_material.content)
+            .ok()?;
+    let cert_info = parse_certificate_info(cert.as_bytes()).ok()?;
+    signing_scheme_for_content(cert_info.key_algorithm, &bundle.content).ok()
+}
+
+/// [`certificate_signing_scheme`] for managed-key bundles, whose key is
+/// supplied by the caller.
+fn public_key_signing_scheme(
+    bundle: &Bundle,
+    public_key: &sigstore_types::DerPublicKey,
+) -> Option<SigningScheme> {
+    let key_algorithm = public_key_algorithm(public_key).ok()?;
+    signing_scheme_for_content(key_algorithm, &bundle.content).ok()
+}
+
 fn verify_message_signature_crypto(
     cert_info: &sigstore_crypto::CertificateInfo,
     msg_sig: &sigstore_types::bundle::MessageSignature,
@@ -1024,6 +1066,61 @@ mod tests {
             Artifact::from(blob),
             &SignatureContent::DsseEnvelope(envelope.clone()),
         )
+    }
+
+    fn message_signature_content(message_digest: Option<HashAlgorithm>) -> SignatureContent {
+        SignatureContent::MessageSignature(sigstore_types::bundle::MessageSignature {
+            message_digest: message_digest.map(|algorithm| sigstore_types::bundle::MessageDigest {
+                algorithm,
+                digest: sigstore_types::DigestBytes::from_bytes(vec![0; 32]),
+            }),
+            signature: sigstore_types::SignatureBytes::from_bytes(b"sig"),
+        })
+    }
+
+    fn has_digest(artifact: &PreparedArtifact<'_>, algorithm: HashAlgorithm) -> bool {
+        artifact.digest(algorithm).is_ok()
+    }
+
+    /// A P-384 key signs over SHA-384 while hashedrekord binds SHA-256. When
+    /// the bundle omits `messageDigest`, streamed input must still produce
+    /// the scheme's digest or prehashed verification cannot run.
+    #[test]
+    fn test_streamed_message_signature_hashes_the_schemes_digest() {
+        let content = message_signature_content(None);
+        let bytes: &[u8] = b"hello world";
+
+        let artifact =
+            PreparedArtifact::from_reader(bytes, &content, Some(SigningScheme::EcdsaP384Sha384))
+                .unwrap();
+        assert!(has_digest(&artifact, HashAlgorithm::Sha2256));
+        assert!(has_digest(&artifact, HashAlgorithm::Sha2384));
+        assert!(!has_digest(&artifact, HashAlgorithm::Sha2512));
+
+        // Unknown key material: hash everything so verification can proceed
+        // far enough to report the real problem.
+        let artifact = PreparedArtifact::from_reader(bytes, &content, None).unwrap();
+        assert!(has_digest(&artifact, HashAlgorithm::Sha2256));
+        assert!(has_digest(&artifact, HashAlgorithm::Sha2384));
+        assert!(has_digest(&artifact, HashAlgorithm::Sha2512));
+
+        // Ed25519 has no external digest; only the binding digest is hashed
+        // and prehashed verification fails closed later.
+        let artifact =
+            PreparedArtifact::from_reader(bytes, &content, Some(SigningScheme::Ed25519)).unwrap();
+        assert!(has_digest(&artifact, HashAlgorithm::Sha2256));
+        assert!(!has_digest(&artifact, HashAlgorithm::Sha2384));
+
+        // Blob input is verified over the bytes themselves, so the scheme's
+        // digest is not computed; the declared messageDigest still is.
+        let artifact = PreparedArtifact::from_artifact(
+            Artifact::from(bytes),
+            &message_signature_content(Some(HashAlgorithm::Sha2384)),
+        );
+        assert!(artifact.blob().is_some());
+        assert!(has_digest(&artifact, HashAlgorithm::Sha2256));
+        assert!(has_digest(&artifact, HashAlgorithm::Sha2384));
+        assert!(!has_digest(&artifact, HashAlgorithm::Sha2512));
     }
 
     #[test]

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -15,72 +15,6 @@ use sigstore_types::{
     Statement,
 };
 
-/// Artifact input for verification.
-#[derive(Debug)]
-pub enum ArtifactSource<'a, R = std::io::Empty> {
-    /// Raw artifact bytes or a pre-computed digest.
-    Artifact(Artifact<'a>),
-    /// Artifact bytes streamed from a reader.
-    Reader(R),
-}
-
-/// Reader input for [`ArtifactSource`].
-#[derive(Debug)]
-pub struct Reader<R>(R);
-
-/// Wrap a reader so it can be passed to `verify(...).`
-pub fn reader<R>(reader: R) -> Reader<R> {
-    Reader(reader)
-}
-
-impl<'a, A> From<A> for ArtifactSource<'a>
-where
-    A: Into<Artifact<'a>>,
-{
-    fn from(artifact: A) -> Self {
-        Self::Artifact(artifact.into())
-    }
-}
-
-impl<'a, R> From<Reader<R>> for ArtifactSource<'a, R> {
-    fn from(reader: Reader<R>) -> Self {
-        Self::Reader(reader.0)
-    }
-}
-
-/// Artifact input for async verification.
-#[derive(Debug)]
-pub enum AsyncArtifactSource<'a, R = futures::io::Empty> {
-    /// Raw artifact bytes or a pre-computed digest.
-    Artifact(Artifact<'a>),
-    /// Artifact bytes streamed from an async reader.
-    Reader(R),
-}
-
-/// Async reader input for [`AsyncArtifactSource`].
-#[derive(Debug)]
-pub struct AsyncReader<R>(R);
-
-/// Wrap an async reader so it can be passed to `verify_async(...).`
-pub fn async_reader<R>(reader: R) -> AsyncReader<R> {
-    AsyncReader(reader)
-}
-
-impl<'a, A> From<A> for AsyncArtifactSource<'a>
-where
-    A: Into<Artifact<'a>>,
-{
-    fn from(artifact: A) -> Self {
-        Self::Artifact(artifact.into())
-    }
-}
-
-impl<'a, R> From<AsyncReader<R>> for AsyncArtifactSource<'a, R> {
-    fn from(reader: AsyncReader<R>) -> Self {
-        Self::Reader(reader.0)
-    }
-}
-
 /// How the signing certificate is verified.
 ///
 /// SCT verification depends on the issuer identified while verifying the
@@ -336,17 +270,17 @@ impl Verifier {
     ///    public key.
     /// 8. Verify the transparency log entry's consistency against the other
     ///    materials, to prevent variants of CVE-2022-36056.
-    pub fn verify<'a, R: std::io::Read>(
+    pub fn verify<'a>(
         &self,
-        artifact: impl Into<ArtifactSource<'a, R>>,
+        artifact: impl Into<Artifact<'a>>,
         bundle: &Bundle,
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
-        let artifact = match artifact.into() {
-            ArtifactSource::Artifact(artifact) => PreparedArtifact::from_artifact(artifact),
-            ArtifactSource::Reader(reader) => PreparedArtifact::from_reader(reader, bundle)?,
-        };
-        self.verify_prepared(artifact, bundle, policy)
+        self.verify_prepared(
+            PreparedArtifact::from_artifact(artifact.into()),
+            bundle,
+            policy,
+        )
     }
 
     /// Verify an artifact read synchronously to EOF in constant memory.
@@ -359,7 +293,11 @@ impl Verifier {
         bundle: &Bundle,
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
-        self.verify(crate::verify::reader(reader), bundle, policy)
+        self.verify_prepared(
+            PreparedArtifact::from_reader(reader, bundle)?,
+            bundle,
+            policy,
+        )
     }
 
     /// Verify an artifact read asynchronously to EOF in constant memory.
@@ -369,24 +307,11 @@ impl Verifier {
         bundle: &Bundle,
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
-        self.verify_async(crate::verify::async_reader(reader), bundle, policy)
-            .await
-    }
-
-    /// Verify an artifact or async reader against a bundle.
-    pub async fn verify_async<'a, R: futures::io::AsyncRead + Unpin>(
-        &self,
-        artifact: impl Into<AsyncArtifactSource<'a, R>>,
-        bundle: &Bundle,
-        policy: &VerificationPolicy,
-    ) -> Result<VerificationResult> {
-        let artifact = match artifact.into() {
-            AsyncArtifactSource::Artifact(artifact) => PreparedArtifact::from_artifact(artifact),
-            AsyncArtifactSource::Reader(reader) => {
-                PreparedArtifact::from_async_reader(reader, bundle).await?
-            }
-        };
-        self.verify_prepared(artifact, bundle, policy)
+        self.verify_prepared(
+            PreparedArtifact::from_async_reader(reader, bundle).await?,
+            bundle,
+            policy,
+        )
     }
 
     fn verify_prepared(
@@ -580,6 +505,39 @@ impl Verifier {
     }
 
     /// Verify a managed-key bundle using a caller-supplied public key.
+    ///
+    /// Managed-key bundles carry a public key hint instead of a signing
+    /// certificate, so the key itself must be supplied by the caller. This
+    /// verifies the signature with that key and the transparency log entries
+    /// against the trusted root, and skips certificate chain and
+    /// identity checks because no certificate is present.
+    ///
+    /// The artifact can be provided as raw bytes or as a pre-computed digest,
+    /// exactly as for [`Verifier::verify`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use sigstore_verify::{PublicKeyVerificationPolicy, Verifier};
+    /// use sigstore_trust_root::TrustedRoot;
+    /// use sigstore_types::{Bundle, DerPublicKey};
+    ///
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let trusted_root = TrustedRoot::from_file("trusted_root.json")?;
+    /// let verifier = Verifier::new(&trusted_root);
+    /// let bundle = Bundle::from_json(&std::fs::read_to_string("artifact.sigstore.json")?)?;
+    /// let public_key = DerPublicKey::from_pem(&std::fs::read_to_string("key.pub")?)?;
+    /// let artifact = std::fs::read("artifact.txt")?;
+    ///
+    /// verifier.verify_with_key(
+    ///     &artifact,
+    ///     &bundle,
+    ///     &public_key,
+    ///     &PublicKeyVerificationPolicy::default(),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn verify_with_key<'a>(
         &self,
         artifact: impl Into<Artifact<'a>>,
@@ -587,7 +545,145 @@ impl Verifier {
         public_key: &sigstore_types::DerPublicKey,
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
-        verify_with_key(artifact, bundle, public_key, policy, &self.trusted_root)
+        self.verify_with_key_prepared(
+            PreparedArtifact::from_artifact(artifact.into()),
+            bundle,
+            public_key,
+            policy,
+        )
+    }
+
+    /// Verify a managed-key bundle against an artifact read synchronously to
+    /// EOF in constant memory.
+    ///
+    /// Reads happen on the calling thread. Async applications should use
+    /// [`Verifier::verify_with_key_async_reader`] to avoid blocking an
+    /// executor.
+    pub fn verify_with_key_reader(
+        &self,
+        reader: impl std::io::Read,
+        bundle: &Bundle,
+        public_key: &sigstore_types::DerPublicKey,
+        policy: &PublicKeyVerificationPolicy,
+    ) -> Result<VerificationResult> {
+        self.verify_with_key_prepared(
+            PreparedArtifact::from_reader(reader, bundle)?,
+            bundle,
+            public_key,
+            policy,
+        )
+    }
+
+    /// Verify a managed-key bundle against an artifact read asynchronously to
+    /// EOF in constant memory.
+    pub async fn verify_with_key_async_reader(
+        &self,
+        reader: impl futures::io::AsyncRead + Unpin,
+        bundle: &Bundle,
+        public_key: &sigstore_types::DerPublicKey,
+        policy: &PublicKeyVerificationPolicy,
+    ) -> Result<VerificationResult> {
+        self.verify_with_key_prepared(
+            PreparedArtifact::from_async_reader(reader, bundle).await?,
+            bundle,
+            public_key,
+            policy,
+        )
+    }
+
+    fn verify_with_key_prepared(
+        &self,
+        artifact: PreparedArtifact<'_>,
+        bundle: &Bundle,
+        public_key: &sigstore_types::DerPublicKey,
+        policy: &PublicKeyVerificationPolicy,
+    ) -> Result<VerificationResult> {
+        if !matches!(
+            &bundle.verification_material.content,
+            VerificationMaterialContent::PublicKey { .. }
+        ) {
+            return Err(Error::Verification(
+                "bundle contains a certificate but public-key verification was requested"
+                    .to_string(),
+            ));
+        }
+
+        let mut result = VerificationResult::new();
+
+        // Validate bundle structure (structural only; the cryptographic checks
+        // follow below)
+        let options = ValidationOptions {
+            require_inclusion_proof: policy.verify_tlog,
+            require_timestamp: false,
+        };
+        validate_bundle_with_options(bundle, &options)
+            .map_err(|e| Error::Verification(format!("bundle validation failed: {}", e)))?;
+
+        let key_algorithm = public_key_algorithm(public_key)?;
+        let signing_scheme = signing_scheme_for_content(key_algorithm, &bundle.content)?;
+
+        // Verify transparency log entries (Merkle inclusion proofs, checkpoints,
+        // SETs) without certificate time validation.
+        if policy.verify_tlog {
+            for entry in &bundle.verification_material.tlog_entries {
+                crate::verify_impl::tlog::verify_entry_inclusion(entry, &self.trusted_root)?;
+
+                let is_rekor_v1 = matches!(
+                    entry.kind_version,
+                    KindVersion::HashedRekordV001 | KindVersion::DsseV001 | KindVersion::IntotoV002
+                );
+                if is_rekor_v1 && entry.inclusion_promise.is_some() {
+                    if let Some(time) = entry.integrated_time {
+                        crate::verify_impl::tlog::validate_integrated_time_not_in_future(
+                            time,
+                            jiff::Timestamp::now(),
+                        )?;
+                        result.integrated_time = Some(time);
+                    }
+                }
+            }
+        }
+
+        // Verify the signature
+        match &bundle.content {
+            SignatureContent::MessageSignature(msg_sig) => {
+                // Verify message digest matches artifact
+                if let Some(ref digest) = msg_sig.message_digest {
+                    let artifact_hash = compute_artifact_digest_algo(&artifact, digest.algorithm)?;
+                    if digest.digest != artifact_hash {
+                        return Err(Error::Verification(
+                            "message digest in bundle does not match artifact hash".to_string(),
+                        ));
+                    }
+                }
+
+                // Verify signature over the artifact
+                verify_signature_over_artifact(
+                    public_key,
+                    signing_scheme,
+                    &msg_sig.signature,
+                    &artifact,
+                )?;
+            }
+            SignatureContent::DsseEnvelope(envelope) => {
+                verify_dsse_envelope_signature(envelope, public_key, signing_scheme)?;
+
+                // Verify the payload binds the artifact
+                verify_dsse_artifact_binding(envelope, &artifact)?;
+            }
+        }
+
+        // Verify the transparency log entries' consistency against the bundle's
+        // other materials and the artifact (CVE-2022-36056 class), mirroring
+        // step 8 of `Verifier::verify`. Pass the caller-supplied key so legacy
+        // intoto entries can bind their logged verifier in managed-key bundles.
+        crate::verify_impl::rekor::verify_tlog_consistency_with_key(
+            bundle,
+            &artifact,
+            Some(public_key),
+        )?;
+
+        Ok(result)
     }
 }
 
@@ -739,12 +835,10 @@ fn verify_message_signature_crypto(
 
 /// Convenience function to verify an artifact against a bundle
 ///
-/// This uses the trusted root for all cryptographic material
-/// (Rekor keys, Fulcio certs, TSA certs).
-///
-/// The artifact can be provided as raw bytes or as a pre-computed SHA-256 digest:
-/// - `verify(artifact_bytes, ...)` - pass raw bytes
-/// - `verify(digest, ...)` - pass pre-computed digest
+/// This is a thin wrapper over [`Verifier::verify`]. The artifact can be
+/// provided as raw bytes or as a pre-computed digest. Use a [`Verifier`]
+/// directly to stream the artifact from a reader with
+/// [`Verifier::verify_reader`] or [`Verifier::verify_async_reader`].
 ///
 /// # Example
 ///
@@ -763,52 +857,13 @@ fn verify_message_signature_crypto(
 /// # Ok(())
 /// # }
 /// ```
-pub fn verify<'a, R: std::io::Read>(
-    artifact: impl Into<ArtifactSource<'a, R>>,
+pub fn verify<'a>(
+    artifact: impl Into<Artifact<'a>>,
     bundle: &Bundle,
     policy: &VerificationPolicy,
     trusted_root: &TrustedRoot,
 ) -> Result<VerificationResult> {
-    let verifier = Verifier::new(trusted_root);
-    verifier.verify(artifact, bundle, policy)
-}
-
-/// Verify an artifact from a synchronous reader.
-pub fn verify_reader(
-    reader: impl std::io::Read,
-    bundle: &Bundle,
-    policy: &VerificationPolicy,
-    trusted_root: &TrustedRoot,
-) -> Result<VerificationResult> {
-    verify(crate::verify::reader(reader), bundle, policy, trusted_root)
-}
-
-/// Verify an artifact from a runtime-independent asynchronous reader.
-pub async fn verify_async_reader(
-    reader: impl futures::io::AsyncRead + Unpin,
-    bundle: &Bundle,
-    policy: &VerificationPolicy,
-    trusted_root: &TrustedRoot,
-) -> Result<VerificationResult> {
-    verify_async(
-        crate::verify::async_reader(reader),
-        bundle,
-        policy,
-        trusted_root,
-    )
-    .await
-}
-
-/// Verify an artifact or async reader against a bundle.
-pub async fn verify_async<'a, R: futures::io::AsyncRead + Unpin>(
-    artifact: impl Into<AsyncArtifactSource<'a, R>>,
-    bundle: &Bundle,
-    policy: &VerificationPolicy,
-    trusted_root: &TrustedRoot,
-) -> Result<VerificationResult> {
-    Verifier::new(trusted_root)
-        .verify_async(artifact, bundle, policy)
-        .await
+    Verifier::new(trusted_root).verify(artifact, bundle, policy)
 }
 
 /// Derive the key algorithm from the public key's SPKI algorithm identifier.
@@ -833,16 +888,13 @@ fn public_key_algorithm(public_key: &sigstore_types::DerPublicKey) -> Result<Key
     }
 }
 
-/// Verify an artifact against a bundle using a provided public key
+/// Convenience function to verify a managed-key bundle with a caller-supplied
+/// public key
 ///
-/// This is used for managed key verification where the bundle contains a public key
-/// hint instead of a certificate. The actual public key is provided separately.
-///
-/// This verification:
-/// - Verifies the signature using the provided public key
-/// - Verifies transparency log entries (Merkle inclusion proofs, checkpoints, SETs)
-/// - Skips certificate chain verification (no certificate present)
-/// - Skips identity/issuer verification
+/// This is a thin wrapper over [`Verifier::verify_with_key`]. Use a
+/// [`Verifier`] directly to stream the artifact from a reader with
+/// [`Verifier::verify_with_key_reader`] or
+/// [`Verifier::verify_with_key_async_reader`].
 ///
 /// # Example
 ///
@@ -869,164 +921,14 @@ fn public_key_algorithm(public_key: &sigstore_types::DerPublicKey) -> Result<Key
 /// # Ok(())
 /// # }
 /// ```
-pub fn verify_with_key<'a, R: std::io::Read>(
-    artifact: impl Into<ArtifactSource<'a, R>>,
+pub fn verify_with_key<'a>(
+    artifact: impl Into<Artifact<'a>>,
     bundle: &Bundle,
     public_key: &sigstore_types::DerPublicKey,
     policy: &PublicKeyVerificationPolicy,
     trusted_root: &TrustedRoot,
 ) -> Result<VerificationResult> {
-    let artifact = match artifact.into() {
-        ArtifactSource::Artifact(artifact) => PreparedArtifact::from_artifact(artifact),
-        ArtifactSource::Reader(reader) => PreparedArtifact::from_reader(reader, bundle)?,
-    };
-    verify_with_key_prepared(artifact, bundle, public_key, policy, trusted_root)
-}
-
-/// Verify a managed-key bundle from a synchronous artifact reader.
-pub fn verify_with_key_reader(
-    reader: impl std::io::Read,
-    bundle: &Bundle,
-    public_key: &sigstore_types::DerPublicKey,
-    policy: &PublicKeyVerificationPolicy,
-    trusted_root: &TrustedRoot,
-) -> Result<VerificationResult> {
-    verify_with_key(
-        crate::verify::reader(reader),
-        bundle,
-        public_key,
-        policy,
-        trusted_root,
-    )
-}
-
-/// Verify a managed-key bundle from an asynchronous artifact reader.
-pub async fn verify_with_key_async_reader(
-    reader: impl futures::io::AsyncRead + Unpin,
-    bundle: &Bundle,
-    public_key: &sigstore_types::DerPublicKey,
-    policy: &PublicKeyVerificationPolicy,
-    trusted_root: &TrustedRoot,
-) -> Result<VerificationResult> {
-    verify_with_key_async(
-        crate::verify::async_reader(reader),
-        bundle,
-        public_key,
-        policy,
-        trusted_root,
-    )
-    .await
-}
-
-/// Verify a managed-key bundle from an artifact or async reader.
-pub async fn verify_with_key_async<'a, R: futures::io::AsyncRead + Unpin>(
-    artifact: impl Into<AsyncArtifactSource<'a, R>>,
-    bundle: &Bundle,
-    public_key: &sigstore_types::DerPublicKey,
-    policy: &PublicKeyVerificationPolicy,
-    trusted_root: &TrustedRoot,
-) -> Result<VerificationResult> {
-    let artifact = match artifact.into() {
-        AsyncArtifactSource::Artifact(artifact) => PreparedArtifact::from_artifact(artifact),
-        AsyncArtifactSource::Reader(reader) => {
-            PreparedArtifact::from_async_reader(reader, bundle).await?
-        }
-    };
-    verify_with_key_prepared(artifact, bundle, public_key, policy, trusted_root)
-}
-
-fn verify_with_key_prepared(
-    artifact: PreparedArtifact<'_>,
-    bundle: &Bundle,
-    public_key: &sigstore_types::DerPublicKey,
-    policy: &PublicKeyVerificationPolicy,
-    trusted_root: &TrustedRoot,
-) -> Result<VerificationResult> {
-    if !matches!(
-        &bundle.verification_material.content,
-        VerificationMaterialContent::PublicKey { .. }
-    ) {
-        return Err(Error::Verification(
-            "bundle contains a certificate but public-key verification was requested".to_string(),
-        ));
-    }
-
-    let mut result = VerificationResult::new();
-
-    // Validate bundle structure (structural only; the cryptographic checks
-    // follow below)
-    let options = ValidationOptions {
-        require_inclusion_proof: policy.verify_tlog,
-        require_timestamp: false,
-    };
-    validate_bundle_with_options(bundle, &options)
-        .map_err(|e| Error::Verification(format!("bundle validation failed: {}", e)))?;
-
-    let key_algorithm = public_key_algorithm(public_key)?;
-    let signing_scheme = signing_scheme_for_content(key_algorithm, &bundle.content)?;
-
-    // Verify transparency log entries (Merkle inclusion proofs, checkpoints,
-    // SETs) without certificate time validation.
-    if policy.verify_tlog {
-        for entry in &bundle.verification_material.tlog_entries {
-            crate::verify_impl::tlog::verify_entry_inclusion(entry, trusted_root)?;
-
-            let is_rekor_v1 = matches!(
-                entry.kind_version,
-                KindVersion::HashedRekordV001 | KindVersion::DsseV001 | KindVersion::IntotoV002
-            );
-            if is_rekor_v1 && entry.inclusion_promise.is_some() {
-                if let Some(time) = entry.integrated_time {
-                    crate::verify_impl::tlog::validate_integrated_time_not_in_future(
-                        time,
-                        jiff::Timestamp::now(),
-                    )?;
-                    result.integrated_time = Some(time);
-                }
-            }
-        }
-    }
-
-    // Verify the signature
-    match &bundle.content {
-        SignatureContent::MessageSignature(msg_sig) => {
-            // Verify message digest matches artifact
-            if let Some(ref digest) = msg_sig.message_digest {
-                let artifact_hash = compute_artifact_digest_algo(&artifact, digest.algorithm)?;
-                if digest.digest != artifact_hash {
-                    return Err(Error::Verification(
-                        "message digest in bundle does not match artifact hash".to_string(),
-                    ));
-                }
-            }
-
-            // Verify signature over the artifact
-            verify_signature_over_artifact(
-                public_key,
-                signing_scheme,
-                &msg_sig.signature,
-                &artifact,
-            )?;
-        }
-        SignatureContent::DsseEnvelope(envelope) => {
-            verify_dsse_envelope_signature(envelope, public_key, signing_scheme)?;
-
-            // Verify the payload binds the artifact
-            verify_dsse_artifact_binding(envelope, &artifact)?;
-        }
-    }
-
-    // Verify the transparency log entries' consistency against the bundle's
-    // other materials and the artifact (CVE-2022-36056 class), mirroring
-    // step 8 of `Verifier::verify`. Pass the caller-supplied key so legacy
-    // intoto entries can bind their logged verifier in managed-key bundles.
-    crate::verify_impl::rekor::verify_tlog_consistency_with_key(
-        bundle,
-        &artifact,
-        Some(public_key),
-    )?;
-
-    Ok(result)
+    Verifier::new(trusted_root).verify_with_key(artifact, bundle, public_key, policy)
 }
 
 #[cfg(test)]

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -274,7 +274,7 @@ impl Verifier {
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_prepared(
-            PreparedArtifact::from_artifact(artifact.into()),
+            PreparedArtifact::from_artifact(artifact.into(), &bundle.content),
             bundle,
             policy,
         )
@@ -291,7 +291,7 @@ impl Verifier {
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_prepared(
-            PreparedArtifact::from_reader(reader, bundle)?,
+            PreparedArtifact::from_reader(reader, &bundle.content)?,
             bundle,
             policy,
         )
@@ -305,7 +305,7 @@ impl Verifier {
         policy: &VerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_prepared(
-            PreparedArtifact::from_async_reader(reader, bundle).await?,
+            PreparedArtifact::from_async_reader(reader, &bundle.content).await?,
             bundle,
             policy,
         )
@@ -534,7 +534,7 @@ impl Verifier {
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_with_key_prepared(
-            PreparedArtifact::from_artifact(artifact.into()),
+            PreparedArtifact::from_artifact(artifact.into(), &bundle.content),
             bundle,
             public_key,
             policy,
@@ -555,7 +555,7 @@ impl Verifier {
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_with_key_prepared(
-            PreparedArtifact::from_reader(reader, bundle)?,
+            PreparedArtifact::from_reader(reader, &bundle.content)?,
             bundle,
             public_key,
             policy,
@@ -572,7 +572,7 @@ impl Verifier {
         policy: &PublicKeyVerificationPolicy,
     ) -> Result<VerificationResult> {
         self.verify_with_key_prepared(
-            PreparedArtifact::from_async_reader(reader, bundle).await?,
+            PreparedArtifact::from_async_reader(reader, &bundle.content).await?,
             bundle,
             public_key,
             policy,
@@ -1016,13 +1016,23 @@ mod tests {
         )
     }
 
+    fn prepared_blob<'a>(
+        blob: &'a [u8],
+        envelope: &sigstore_types::DsseEnvelope,
+    ) -> PreparedArtifact<'a> {
+        PreparedArtifact::from_artifact(
+            Artifact::from(blob),
+            &SignatureContent::DsseEnvelope(envelope.clone()),
+        )
+    }
+
     #[test]
     fn test_dsse_binding_matching_subject_ok() {
         let artifact_bytes = b"hello world";
         let hash_hex = sigstore_crypto::sha256(artifact_bytes).to_hex();
         let envelope = in_toto_envelope(&statement_with_subject_sha256(&hash_hex));
 
-        let artifact = PreparedArtifact::from_artifact(Artifact::from(artifact_bytes.as_slice()));
+        let artifact = prepared_blob(artifact_bytes, &envelope);
         assert!(verify_dsse_artifact_binding(&envelope, &artifact).is_ok());
     }
 
@@ -1031,7 +1041,7 @@ mod tests {
         let hash_hex = sigstore_crypto::sha256(b"some other artifact").to_hex();
         let envelope = in_toto_envelope(&statement_with_subject_sha256(&hash_hex));
 
-        let artifact = PreparedArtifact::from_artifact(Artifact::from(b"hello world".as_slice()));
+        let artifact = prepared_blob(b"hello world", &envelope);
         let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
         assert!(err
             .to_string()
@@ -1043,7 +1053,7 @@ mod tests {
         let payload = r#"{"_type":"https://in-toto.io/Statement/v1","subject":[],"predicateType":"https://example.com/predicate/v1","predicate":{}}"#;
         let envelope = in_toto_envelope(payload);
 
-        let artifact = PreparedArtifact::from_artifact(Artifact::from(b"hello world".as_slice()));
+        let artifact = prepared_blob(b"hello world", &envelope);
         let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
         assert!(err.to_string().contains("no subjects"));
     }
@@ -1056,7 +1066,7 @@ mod tests {
             unused_signature(),
         );
 
-        let artifact = PreparedArtifact::from_artifact(Artifact::from(b"hello world".as_slice()));
+        let artifact = prepared_blob(b"hello world", &envelope);
         let err = verify_dsse_artifact_binding(&envelope, &artifact).unwrap_err();
         assert!(err.to_string().contains("unsupported DSSE payload type"));
     }

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -10,10 +10,7 @@ use sigstore_crypto::{parse_certificate_info, KeyAlgorithm, SigningScheme, Verif
 use sigstore_trust_root::TrustedRoot;
 
 use sigstore_types::bundle::VerificationMaterialContent;
-use sigstore_types::{
-    Artifact, Bundle, HashAlgorithm, KindVersion, Sha256Hash, Sha512Hash, SignatureContent,
-    Statement,
-};
+use sigstore_types::{Artifact, Bundle, KindVersion, SignatureContent, Statement};
 
 /// How the signing certificate is verified.
 ///
@@ -472,16 +469,7 @@ impl Verifier {
 
         // For MessageSignature bundles, verify the messageDigest matches the artifact
         if let SignatureContent::MessageSignature(msg_sig) = &bundle.content {
-            if let Some(ref digest) = msg_sig.message_digest {
-                let artifact_hash = compute_artifact_digest_algo(&artifact, digest.algorithm)?;
-
-                // Compare the digest in the bundle with the computed artifact hash
-                if digest.digest != artifact_hash {
-                    return Err(Error::Verification(
-                        "message digest in bundle does not match artifact hash".to_string(),
-                    ));
-                }
-            }
+            verify_message_digest_binding(msg_sig, &artifact)?;
 
             // Cryptographically verify the signature over the artifact. This runs
             // regardless of `policy.verify_tlog` so the signature is always checked;
@@ -647,15 +635,7 @@ impl Verifier {
         // Verify the signature
         match &bundle.content {
             SignatureContent::MessageSignature(msg_sig) => {
-                // Verify message digest matches artifact
-                if let Some(ref digest) = msg_sig.message_digest {
-                    let artifact_hash = compute_artifact_digest_algo(&artifact, digest.algorithm)?;
-                    if digest.digest != artifact_hash {
-                        return Err(Error::Verification(
-                            "message digest in bundle does not match artifact hash".to_string(),
-                        ));
-                    }
-                }
+                verify_message_digest_binding(msg_sig, &artifact)?;
 
                 // Verify signature over the artifact
                 verify_signature_over_artifact(
@@ -687,11 +667,21 @@ impl Verifier {
     }
 }
 
-fn compute_artifact_digest_algo(
+/// Check that a `MessageSignature`'s declared `messageDigest`, if any, matches
+/// the artifact.
+fn verify_message_digest_binding(
+    msg_sig: &sigstore_types::bundle::MessageSignature,
     artifact: &PreparedArtifact<'_>,
-    algo: HashAlgorithm,
-) -> Result<Vec<u8>> {
-    artifact.digest(algo)
+) -> Result<()> {
+    if let Some(digest) = &msg_sig.message_digest {
+        let artifact_digest = artifact.digest(digest.algorithm)?;
+        if digest.digest != artifact_digest.as_bytes() {
+            return Err(Error::Verification(
+                "message digest in bundle does not match artifact hash".to_string(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Verify the DSSE envelope's signature over its PAE with the given key.
@@ -736,17 +726,12 @@ fn verify_dsse_artifact_binding(
             "in-toto statement has no subjects: cannot bind artifact to attestation".to_string(),
         ));
     }
-    let sha256_matches = artifact
-        .digest(HashAlgorithm::Sha2256)
-        .ok()
-        .and_then(|digest| Sha256Hash::try_from_slice(&digest).ok())
-        .is_some_and(|digest| statement.matches_sha256(&digest));
-    let sha512_matches = artifact
-        .digest(HashAlgorithm::Sha2512)
-        .ok()
-        .and_then(|digest| Sha512Hash::try_from_slice(&digest).ok())
-        .is_some_and(|digest| statement.matches_sha512(&digest));
-    let matches = sha256_matches || sha512_matches;
+    let matches = artifact
+        .sha256()
+        .is_ok_and(|digest| statement.matches_sha256(&digest))
+        || artifact
+            .sha512()
+            .is_ok_and(|digest| statement.matches_sha512(&digest));
 
     if !matches {
         return Err(Error::Verification(
@@ -784,7 +769,12 @@ fn verify_signature_over_artifact(
             ))
         })?;
         let digest = artifact.digest(expected)?;
-        sigstore_crypto::verify_signature_prehashed(public_key, &digest, signature, scheme)
+        sigstore_crypto::verify_signature_prehashed(
+            public_key,
+            digest.as_bytes(),
+            signature,
+            scheme,
+        )
     };
     result.map_err(|e| Error::Verification(format!("signature verification failed: {}", e)))
 }
@@ -934,6 +924,7 @@ pub fn verify_with_key<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sigstore_types::HashAlgorithm;
 
     #[test]
     fn public_key_policy_defaults_to_tlog_verification() {

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -37,7 +37,7 @@ pub(crate) fn verify_hashedrekord_entry(
 
     // Compute hash from artifact (bytes or pre-computed digest) or DSSE envelope
     let hash = match &bundle.content {
-        SignatureContent::MessageSignature(_) => compute_artifact_digest(artifact)?,
+        SignatureContent::MessageSignature(_) => artifact.sha256()?,
         SignatureContent::DsseEnvelope(envelope) => sigstore_crypto::sha256(&envelope.pae()),
     };
 
@@ -82,17 +82,6 @@ pub(crate) fn verify_hashedrekord_entry(
     validate_integrated_time(entry, bundle)?;
 
     Ok(())
-}
-
-/// Compute the SHA-256 digest from an artifact for Rekor inclusion proof
-fn compute_artifact_digest(artifact: &PreparedArtifact<'_>) -> Result<Sha256Hash> {
-    Sha256Hash::try_from_slice(&artifact.digest(sigstore_types::HashAlgorithm::Sha2256)?).map_err(
-        |_| {
-            Error::Verification(
-                "Rekor entry verification requires a 32-byte SHA-256 digest".to_string(),
-            )
-        },
-    )
 }
 
 /// Validate artifact hash matches expected hash

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -3,12 +3,11 @@
 //! This module handles validation of hashedrekord entries, including
 //! artifact hash verification and certificate/signature matching.
 
+use crate::artifact::PreparedArtifact;
 use crate::error::{Error, Result};
 use sigstore_rekor::body::RekorEntryBody;
 use sigstore_types::bundle::VerificationMaterialContent;
-use sigstore_types::{
-    Artifact, Bundle, DerPublicKey, Sha256Hash, SignatureContent, TransparencyLogEntry,
-};
+use sigstore_types::{Bundle, DerPublicKey, Sha256Hash, SignatureContent, TransparencyLogEntry};
 use x509_cert::der::Decode;
 use x509_cert::Certificate;
 
@@ -23,7 +22,7 @@ use x509_cert::Certificate;
 pub(crate) fn verify_hashedrekord_entry(
     entry: &TransparencyLogEntry,
     bundle: &Bundle,
-    artifact: &Artifact<'_>,
+    artifact: &PreparedArtifact<'_>,
     managed_key: Option<&DerPublicKey>,
 ) -> Result<()> {
     // Parse the Rekor entry body (convert canonicalized body to base64 string)
@@ -84,23 +83,14 @@ pub(crate) fn verify_hashedrekord_entry(
 }
 
 /// Compute the SHA-256 digest from an artifact for Rekor inclusion proof
-fn compute_artifact_digest(artifact: &Artifact<'_>) -> Result<Sha256Hash> {
-    match artifact {
-        Artifact::Blob(bytes) => Ok(sigstore_crypto::sha256(bytes)),
-        Artifact::Digest(digest) => {
-            if digest.algorithm() != sigstore_types::HashAlgorithm::Sha2256 {
-                return Err(Error::Verification(format!(
-                    "Rekor entry verification requires SHA-256, got {}",
-                    digest.algorithm()
-                )));
-            }
-            Sha256Hash::try_from_slice(digest.as_bytes()).map_err(|_| {
-                Error::Verification(
-                    "Rekor entry verification requires a 32-byte SHA-256 digest".to_string(),
-                )
-            })
-        }
-    }
+fn compute_artifact_digest(artifact: &PreparedArtifact<'_>) -> Result<Sha256Hash> {
+    Sha256Hash::try_from_slice(&artifact.digest(sigstore_types::HashAlgorithm::Sha2256)?).map_err(
+        |_| {
+            Error::Verification(
+                "Rekor entry verification requires a 32-byte SHA-256 digest".to_string(),
+            )
+        },
+    )
 }
 
 /// Validate artifact hash matches expected hash

--- a/crates/sigstore-verify/src/verify_impl/helpers.rs
+++ b/crates/sigstore-verify/src/verify_impl/helpers.rs
@@ -9,28 +9,8 @@ use rustls_pki_types::{CertificateDer, UnixTime};
 use sigstore_crypto::CertificateInfo;
 use sigstore_trust_root::{TrustedRoot, TsaAuthority};
 use sigstore_types::bundle::VerificationMaterialContent;
-use sigstore_types::{
-    Bundle, DerCertificate, DerPublicKey, KindVersion, SignatureBytes, SignatureContent,
-};
+use sigstore_types::{Bundle, DerPublicKey, KindVersion, SignatureBytes, SignatureContent};
 use webpki::{anchor_from_trusted_cert, EndEntityCert, KeyUsage, ALL_VERIFICATION_ALGS};
-
-/// Extract and decode the signing certificate from verification material
-pub fn extract_certificate(
-    verification_material: &VerificationMaterialContent,
-) -> Result<DerCertificate> {
-    match verification_material {
-        VerificationMaterialContent::Certificate(cert) => Ok(cert.raw_bytes.clone()),
-        VerificationMaterialContent::X509CertificateChain { certificates } => {
-            if certificates.is_empty() {
-                return Err(Error::Verification("no certificates in chain".to_string()));
-            }
-            Ok(certificates[0].raw_bytes.clone())
-        }
-        VerificationMaterialContent::PublicKey { .. } => Err(Error::Verification(
-            "public key verification not yet supported".to_string(),
-        )),
-    }
-}
 
 /// Extract signature from bundle content (needed for TSA verification).
 ///
@@ -472,7 +452,13 @@ mod tests {
         // Err("SCT signature verification failed: ... signature invalid").
         let issuer_spki = verify_certificate_chain(material, validation_time, &trusted_root)
             .expect("certificate chain should verify against the staging root");
-        let cert = extract_certificate(material).unwrap();
+        let cert = match material {
+            VerificationMaterialContent::Certificate(cert) => &cert.raw_bytes,
+            VerificationMaterialContent::X509CertificateChain { certificates } => {
+                &certificates[0].raw_bytes
+            }
+            _ => panic!("fixture must have a signing certificate"),
+        };
         super::super::sct::verify_sct(cert.as_bytes(), issuer_spki.as_bytes(), &trusted_root)
             .expect("SCT verification should succeed once the correct issuer is selected");
     }

--- a/crates/sigstore-verify/src/verify_impl/rekor.rs
+++ b/crates/sigstore-verify/src/verify_impl/rekor.rs
@@ -289,8 +289,10 @@ mod tests {
 
     fn verify_consistency(bundle: &Bundle) -> Result<()> {
         let digest = [0u8; 32];
-        let artifact =
-            PreparedArtifact::from_artifact(Artifact::from(Sha256Hash::from_bytes(digest)));
+        let artifact = PreparedArtifact::from_artifact(
+            Artifact::from(Sha256Hash::from_bytes(digest)),
+            &bundle.content,
+        );
         verify_tlog_consistency(bundle, &artifact)
     }
 
@@ -316,8 +318,10 @@ mod tests {
             hint: sigstore_crypto::sha256(public_key.as_bytes()).to_base64(),
         };
         let digest = [0u8; 32];
-        let artifact =
-            PreparedArtifact::from_artifact(Artifact::from(Sha256Hash::from_bytes(digest)));
+        let artifact = PreparedArtifact::from_artifact(
+            Artifact::from(Sha256Hash::from_bytes(digest)),
+            &bundle.content,
+        );
         verify_tlog_consistency_with_key(&bundle, &artifact, Some(&public_key)).unwrap();
 
         let wrong_key = DerPublicKey::new(vec![1, 2, 3]);

--- a/crates/sigstore-verify/src/verify_impl/rekor.rs
+++ b/crates/sigstore-verify/src/verify_impl/rekor.rs
@@ -3,6 +3,7 @@
 //! This module handles validation of different Rekor entry types against
 //! bundle content to ensure consistency.
 
+use crate::artifact::PreparedArtifact;
 use crate::error::{Error, Result};
 use base64::Engine;
 use sigstore_rekor::body::RekorEntryBody;
@@ -13,10 +14,7 @@ use sigstore_types::{
 use x509_cert::der::{Decode, Encode};
 
 /// Verify that all log entries are consistent with the bundle's content and artifact
-pub fn verify_tlog_consistency(
-    bundle: &Bundle,
-    artifact: &sigstore_types::Artifact<'_>,
-) -> Result<()> {
+pub fn verify_tlog_consistency(bundle: &Bundle, artifact: &PreparedArtifact<'_>) -> Result<()> {
     verify_tlog_consistency_with_key(bundle, artifact, None)
 }
 
@@ -24,7 +22,7 @@ pub fn verify_tlog_consistency(
 /// public key that the bundle references only by hint.
 pub(crate) fn verify_tlog_consistency_with_key(
     bundle: &Bundle,
-    artifact: &sigstore_types::Artifact<'_>,
+    artifact: &PreparedArtifact<'_>,
     managed_key: Option<&DerPublicKey>,
 ) -> Result<()> {
     for entry in &bundle.verification_material.tlog_entries {
@@ -329,7 +327,9 @@ mod tests {
 
     fn verify_consistency(bundle: &Bundle) -> Result<()> {
         let digest = [0u8; 32];
-        verify_tlog_consistency(bundle, &Artifact::from(Sha256Hash::from_bytes(digest)))
+        let artifact =
+            PreparedArtifact::from_artifact(Artifact::from(Sha256Hash::from_bytes(digest)));
+        verify_tlog_consistency(bundle, &artifact)
     }
 
     #[test]
@@ -354,20 +354,12 @@ mod tests {
             hint: sigstore_crypto::sha256(public_key.as_bytes()).to_base64(),
         };
         let digest = [0u8; 32];
-        verify_tlog_consistency_with_key(
-            &bundle,
-            &Artifact::from(Sha256Hash::from_bytes(digest)),
-            Some(&public_key),
-        )
-        .unwrap();
+        let artifact =
+            PreparedArtifact::from_artifact(Artifact::from(Sha256Hash::from_bytes(digest)));
+        verify_tlog_consistency_with_key(&bundle, &artifact, Some(&public_key)).unwrap();
 
         let wrong_key = DerPublicKey::new(vec![1, 2, 3]);
-        assert!(verify_tlog_consistency_with_key(
-            &bundle,
-            &Artifact::from(Sha256Hash::from_bytes(digest)),
-            Some(&wrong_key),
-        )
-        .is_err());
+        assert!(verify_tlog_consistency_with_key(&bundle, &artifact, Some(&wrong_key)).is_err());
     }
 
     #[test]

--- a/crates/sigstore-verify/src/verify_impl/rekor.rs
+++ b/crates/sigstore-verify/src/verify_impl/rekor.rs
@@ -291,7 +291,11 @@ mod tests {
         let digest = [0u8; 32];
         let artifact = PreparedArtifact::from_artifact(
             Artifact::from(Sha256Hash::from_bytes(digest)),
-            &bundle.content,
+            &crate::artifact::ArtifactRequirements::new(
+                &bundle.content,
+                sigstore_crypto::SigningScheme::EcdsaP256Sha256,
+            )
+            .unwrap(),
         );
         verify_tlog_consistency(bundle, &artifact)
     }
@@ -320,7 +324,11 @@ mod tests {
         let digest = [0u8; 32];
         let artifact = PreparedArtifact::from_artifact(
             Artifact::from(Sha256Hash::from_bytes(digest)),
-            &bundle.content,
+            &crate::artifact::ArtifactRequirements::new(
+                &bundle.content,
+                sigstore_crypto::SigningScheme::EcdsaP256Sha256,
+            )
+            .unwrap(),
         );
         verify_tlog_consistency_with_key(&bundle, &artifact, Some(&public_key)).unwrap();
 

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -6,7 +6,7 @@ use sigstore_trust_root::{SigstoreInstance, TrustedRoot, SIGSTORE_PRODUCTION_TRU
 use sigstore_types::{ArtifactDigest, DigestBytes, HashAlgorithm, LogIndex, Sha256Hash};
 use sigstore_verify::bundle::{validate_bundle, validate_bundle_with_options, ValidationOptions};
 use sigstore_verify::types::Bundle;
-use sigstore_verify::{verify, VerificationPolicy, Verifier};
+use sigstore_verify::{verify, verify_async_reader, verify_reader, VerificationPolicy, Verifier};
 use x509_cert::der::Decode;
 
 /// Extract the expected artifact digest from a bundle
@@ -1074,6 +1074,37 @@ fn test_verify_cosign_v3_blob_bundle() {
 
     let result = verify(artifact, &bundle, &policy, &production_root());
     assert!(result.is_ok(), "Verification failed: {:?}", result.err());
+}
+
+#[test]
+fn test_verify_cosign_bundle_from_sync_reader() {
+    let bundle = Bundle::from_json(COSIGN_V3_BLOB_BUNDLE).unwrap();
+    let artifact = include_bytes!("../test_data/bundles/cosign-v3-blob.txt");
+    let policy = VerificationPolicy::default().require_issuer("https://github.com/login/oauth");
+
+    verify_reader(
+        std::io::Cursor::new(artifact),
+        &bundle,
+        &policy,
+        &production_root(),
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_verify_cosign_bundle_from_async_reader() {
+    let bundle = Bundle::from_json(COSIGN_V3_BLOB_BUNDLE).unwrap();
+    let artifact = include_bytes!("../test_data/bundles/cosign-v3-blob.txt");
+    let policy = VerificationPolicy::default().require_issuer("https://github.com/login/oauth");
+
+    verify_async_reader(
+        futures::io::Cursor::new(artifact),
+        &bundle,
+        &policy,
+        &production_root(),
+    )
+    .await
+    .unwrap();
 }
 
 /// Replace `bundle`'s tlog entries with the first entry of `donor`.

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -1108,6 +1108,30 @@ fn test_verify_cosign_v3_blob_bundle() {
     assert!(result.is_ok(), "Verification failed: {:?}", result.err());
 }
 
+#[tokio::test]
+async fn invalid_certificate_does_not_consume_readers() {
+    let mut bundle = Bundle::from_json(COSIGN_V3_BLOB_BUNDLE).unwrap();
+    bundle.verification_material.content =
+        sigstore_types::bundle::VerificationMaterialContent::Certificate(
+            sigstore_types::bundle::CertificateContent {
+                raw_bytes: sigstore_types::DerCertificate::new(vec![0]),
+            },
+        );
+    let verifier = Verifier::new(&production_root());
+    let mut reader = std::io::Cursor::new(b"do not consume");
+    let error = verifier
+        .verify_reader(&mut reader, &bundle, &VerificationPolicy::default())
+        .unwrap_err();
+    assert!(error.to_string().contains("failed to parse certificate"));
+    assert_eq!(reader.position(), 0);
+    let mut reader = futures::io::Cursor::new(b"do not consume");
+    assert!(verifier
+        .verify_async_reader(&mut reader, &bundle, &VerificationPolicy::default())
+        .await
+        .is_err());
+    assert_eq!(reader.position(), 0);
+}
+
 #[test]
 fn test_verify_cosign_bundle_from_sync_reader() {
     let bundle = Bundle::from_json(COSIGN_V3_BLOB_BUNDLE).unwrap();

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -956,6 +956,62 @@ fn test_verify_conda_package_attestation() {
     assert!(verification.integrated_time.is_some());
 }
 
+fn conda_attestation_policy() -> VerificationPolicy {
+    VerificationPolicy::default()
+        .require_identity("https://github.com/prefix-dev/sigstore-example/.github/workflows/action.yaml@refs/heads/main")
+        .require_issuer("https://token.actions.githubusercontent.com")
+}
+
+/// DSSE bundles bind the artifact only through the in-toto subjects, so the
+/// streaming path hashes with the subject algorithms (SHA-256 here) and must
+/// verify end to end from a reader.
+#[test]
+fn test_verify_conda_package_attestation_from_sync_reader() {
+    let bundle = Bundle::from_json(CONDA_ATTESTATION_BUNDLE).unwrap();
+
+    let verification = Verifier::new(&production_root())
+        .verify_reader(
+            std::io::Cursor::new(CONDA_PACKAGE),
+            &bundle,
+            &conda_attestation_policy(),
+        )
+        .unwrap();
+    assert!(verification.integrated_time.is_some());
+}
+
+#[tokio::test]
+async fn test_verify_conda_package_attestation_from_async_reader() {
+    let bundle = Bundle::from_json(CONDA_ATTESTATION_BUNDLE).unwrap();
+
+    Verifier::new(&production_root())
+        .verify_async_reader(
+            futures::io::Cursor::new(CONDA_PACKAGE),
+            &bundle,
+            &conda_attestation_policy(),
+        )
+        .await
+        .unwrap();
+}
+
+/// A streamed artifact that does not match the attestation subject must be
+/// rejected, like the tampered blob above.
+#[test]
+fn test_verify_conda_package_tampered_from_reader() {
+    let bundle = Bundle::from_json(CONDA_ATTESTATION_BUNDLE).unwrap();
+
+    let err = Verifier::new(&production_root())
+        .verify_reader(
+            std::io::Cursor::new(b"this is not the original package content"),
+            &bundle,
+            &conda_attestation_policy(),
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("does not match any subject"),
+        "unexpected error: {err}"
+    );
+}
+
 /// Test that verification fails with wrong identity
 #[test]
 fn test_verify_conda_package_wrong_identity() {

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -6,10 +6,7 @@ use sigstore_trust_root::{SigstoreInstance, TrustedRoot, SIGSTORE_PRODUCTION_TRU
 use sigstore_types::{ArtifactDigest, DigestBytes, HashAlgorithm, LogIndex, Sha256Hash};
 use sigstore_verify::bundle::{validate_bundle, validate_bundle_with_options, ValidationOptions};
 use sigstore_verify::types::Bundle;
-use sigstore_verify::{
-    verify, verify_async_reader, verify_reader, PublicKeyVerificationPolicy, VerificationPolicy,
-    Verifier,
-};
+use sigstore_verify::{verify, PublicKeyVerificationPolicy, VerificationPolicy, Verifier};
 use x509_cert::der::Decode;
 
 /// Extract the expected artifact digest from a bundle
@@ -1061,13 +1058,9 @@ fn test_verify_cosign_bundle_from_sync_reader() {
     let artifact = include_bytes!("../test_data/bundles/cosign-v3-blob.txt");
     let policy = VerificationPolicy::default().require_issuer("https://github.com/login/oauth");
 
-    verify_reader(
-        std::io::Cursor::new(artifact),
-        &bundle,
-        &policy,
-        &production_root(),
-    )
-    .unwrap();
+    Verifier::new(&production_root())
+        .verify_reader(std::io::Cursor::new(artifact), &bundle, &policy)
+        .unwrap();
 }
 
 #[tokio::test]
@@ -1076,14 +1069,10 @@ async fn test_verify_cosign_bundle_from_async_reader() {
     let artifact = include_bytes!("../test_data/bundles/cosign-v3-blob.txt");
     let policy = VerificationPolicy::default().require_issuer("https://github.com/login/oauth");
 
-    verify_async_reader(
-        futures::io::Cursor::new(artifact),
-        &bundle,
-        &policy,
-        &production_root(),
-    )
-    .await
-    .unwrap();
+    Verifier::new(&production_root())
+        .verify_async_reader(futures::io::Cursor::new(artifact), &bundle, &policy)
+        .await
+        .unwrap();
 }
 
 /// Replace `bundle`'s tlog entries with the first entry of `donor`.
@@ -1437,6 +1426,35 @@ fn test_verifier_with_key_accepts_digest_and_reports_integrated_time() {
         .unwrap();
 
     assert_eq!(result.integrated_time, expected_time);
+}
+
+#[test]
+fn test_verifier_with_key_from_sync_reader() {
+    let bundle = Bundle::from_json(MANAGED_KEY_BUNDLE).unwrap();
+
+    Verifier::new(&production_root())
+        .verify_with_key_reader(
+            std::io::Cursor::new(MANAGED_KEY_ARTIFACT),
+            &bundle,
+            &managed_key_public_key(),
+            &PublicKeyVerificationPolicy::default(),
+        )
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_verifier_with_key_from_async_reader() {
+    let bundle = Bundle::from_json(MANAGED_KEY_BUNDLE).unwrap();
+
+    Verifier::new(&production_root())
+        .verify_with_key_async_reader(
+            futures::io::Cursor::new(MANAGED_KEY_ARTIFACT),
+            &bundle,
+            &managed_key_public_key(),
+            &PublicKeyVerificationPolicy::default(),
+        )
+        .await
+        .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds constant-memory artifact streaming to signing and verification.

### Signing

- `Signer::sign(...)` keeps accepting raw bytes or a typed SHA-256 digest
- `Signer::sign_reader(...)` streams a blocking `std::io::Read` to EOF
- `Signer::sign_async_reader(...)` streams a runtime-independent `futures_io::AsyncRead`

The artifact is hashed before the Fulcio certificate is requested, so large inputs no longer eat into the certificate's lifetime. The signer configuration is validated before any hashing starts.

### Verification

- `Verifier::verify(...)` and the free `verify(...)` keep accepting raw bytes or a typed digest
- `Verifier::verify_reader(...)` and `Verifier::verify_async_reader(...)` stream the artifact
- Managed-key verification mirrors this with `verify_with_key`, `verify_with_key_reader` and `verify_with_key_async_reader`
- The free `verify_with_key(...)` is now a thin wrapper over the `Verifier` method instead of a second copy of the verification flow

Readers are consumed exactly once. A new crate-private `PreparedArtifact` hashes the input in a single pass with every algorithm the bundle can ask for, and message-signature checks, DSSE subject binding, and Rekor consistency checks all draw on those digests without retaining or rereading the artifact. DSSE bundles hash only with the algorithms their in-toto subjects use; message-signature bundles hash SHA-256 for hashedrekord, the declared `messageDigest` algorithm, and, for streamed input, the digest the signing scheme consumes (derived from the bundle's certificate or the supplied managed key up front).

Blob input remains available for schemes such as Ed25519 that need the original message. Reader and digest input fail closed when the selected scheme does not support prehashed verification. Synchronous reader methods document that reads block the calling thread.

### Shared hashing helpers

`sigstore_crypto` gains `hash_reader`, `hash_reader_yielding` and `hash_async_reader`, which feed one pass over a reader into any set of hashers. The async variants yield to the executor after every 64 KiB chunk (TOB-SIGSTORE-8), and the signer's cooperative in-memory hashing now goes through the same code. The library crates depend on `futures-io` only; `futures` remains a dev-dependency.

CLI examples stream files. Tests verify real hashedrekord and DSSE bundles through both sync and async readers, and unit tests pin the per-bundle digest selection.

## Stack

1. #183: incremental/prehashed signing foundation
2. #184: typed blob and digest inputs
3. **This PR:** synchronous/asynchronous reader sources

Signed-off-by: Wolf Vollprecht <w.vollprecht@gmail.com>
