### PR TITLE
fix(crypto): use explicit-scheme SPKI constructor in signing test

### DIFF
--- a/crates/sigstore-crypto/src/signing.rs
+++ b/crates/sigstore-crypto/src/signing.rs
@@ -266,7 +266,7 @@ mod tests {
         assert_eq!(digest, crate::hash::sha256(message));
 
         // The signature verifies as ECDSA-SHA256 over the full message.
-        let key = VerificationKey::from_spki(
+        let key = VerificationKey::from_spki_with_scheme(
             &kp.public_key_der().unwrap(),
             SigningScheme::EcdsaP256Sha256,
         )


### PR DESCRIPTION
Fix the main-branch CI regression introduced when #183 landed after the SPKI constructor rename in #178.

The signing test supplies an explicit scheme, so call `from_spki_with_scheme` instead of the auto-detecting `from_spki`.

Verified with:
- `cargo test -p sigstore-crypto`
- `cargo clippy -p sigstore-crypto --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`