### PR TITLE
refactor(tuf)!: remove obsolete target accessors

### DIFF
--- a/crates/sigstore-tuf/src/client.rs
+++ b/crates/sigstore-tuf/src/client.rs
@@ -391,13 +391,6 @@ impl Updater {
         Ok(None)
     }
 
-    /// Look up a target by path in the trusted **top-level** targets metadata
-    /// only (no delegation walk). Use [`Updater::get_targetinfo`] to search
-    /// delegated roles.
-    pub fn find_target(&self, target_path: &str) -> Option<&TargetFile> {
-        self.trusted.targets_role("targets")?.target(target_path)
-    }
-
     /// Return a cached, already-verified copy of `target` from the attached
     /// store, or `None` when there is no store, no cached file, or the cached
     /// bytes no longer match the pinned length and hash.

--- a/crates/sigstore-tuf/src/trusted.rs
+++ b/crates/sigstore-tuf/src/trusted.rs
@@ -69,11 +69,6 @@ impl TrustedMetadataSet {
         self.snapshot.as_ref().map(|m| &m.signed)
     }
 
-    /// The trusted top-level targets payload, if one has been loaded.
-    pub fn targets(&self) -> Option<&Targets> {
-        self.targets.get("targets").map(|m| &m.signed)
-    }
-
     /// Incorporate a candidate newer root.
     ///
     /// Enforces:

--- a/crates/sigstore-tuf/tests/end_to_end.rs
+++ b/crates/sigstore-tuf/tests/end_to_end.rs
@@ -394,7 +394,12 @@ async fn full_refresh_resolves_delegated_target_and_caches() {
 
     // The target lives only in the delegated role, so the top-level lookup
     // misses but the delegation walk finds it.
-    assert!(updater.find_target("delegated/file.txt").is_none());
+    assert!(updater
+        .trusted()
+        .targets_role("targets")
+        .unwrap()
+        .target("delegated/file.txt")
+        .is_none());
     let info = updater
         .get_targetinfo("delegated/file.txt", now())
         .await

--- a/crates/sigstore-tuf/tests/reference_impl.rs
+++ b/crates/sigstore-tuf/tests/reference_impl.rs
@@ -90,7 +90,11 @@ async fn full_refresh_and_read_targets() {
     assert_eq!(f2, b"This is an another example target file.");
 
     // `custom` metadata round-trips.
-    let info = updater.find_target("file1.txt").unwrap();
+    let info = updater
+        .get_targetinfo("file1.txt", now())
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         info.custom.as_ref().unwrap()["file_permissions"],
         serde_json::json!("0644")
@@ -107,7 +111,12 @@ async fn resolves_target_through_delegation() {
     updater.refresh(now()).await.unwrap();
 
     assert!(
-        updater.find_target("file3.txt").is_none(),
+        updater
+            .trusted()
+            .targets_role("targets")
+            .unwrap()
+            .target("file3.txt")
+            .is_none(),
         "file3.txt should not be in top-level targets"
     );
     let info = updater


### PR DESCRIPTION
## Summary

- remove `TrustedMetadataSet::targets()`, superseded by `targets_role("targets")`
- remove the top-level-only `Updater::find_target()`, superseded by delegation-aware `get_targetinfo()`
- update TUF tests to exercise the current APIs directly

## Breaking change

`TrustedMetadataSet::targets()` and `Updater::find_target()` are removed.

## Testing

- `cargo fmt --check`
- `cargo test -p sigstore-tuf --all-features`
