### PR TITLE
refactor(types)!: deserialize semantic bundle values eagerly

### DIFF
--- a/crates/sigstore-bundle/src/builder.rs
+++ b/crates/sigstore-bundle/src/builder.rs
@@ -8,7 +8,7 @@ use sigstore_types::{
         TransparencyLogEntry, VerificationMaterial, VerificationMaterialContent,
     },
     Bundle, CanonicalizedBody, DerCertificate, DsseEnvelope, LogIndex, LogKeyId, MediaType,
-    Sha256Hash, SignatureBytes, SignedTimestamp, TimestampToken,
+    Result as TypesResult, Sha256Hash, SignatureBytes, SignedTimestamp, TimestampToken,
 };
 
 /// Verification material for v0.3 bundles.
@@ -118,7 +118,7 @@ impl BundleV03 {
         };
 
         Bundle {
-            media_type: MediaType::Bundle0_3.as_str().to_string(),
+            media_type: MediaType::Bundle0_3,
             verification_material: VerificationMaterial {
                 content: verification_content,
                 tlog_entries: self.tlog_entries,
@@ -135,8 +135,7 @@ impl BundleV03 {
 pub struct TlogEntryBuilder {
     log_index: u64,
     log_id: String,
-    kind: String,
-    kind_version: String,
+    kind_version: KindVersion,
     integrated_time: Option<jiff::Timestamp>,
     canonicalized_body: Vec<u8>,
     inclusion_promise: Option<InclusionPromise>,
@@ -149,8 +148,7 @@ impl TlogEntryBuilder {
         Self {
             log_index: 0,
             log_id: String::new(),
-            kind: "hashedrekord".to_string(),
-            kind_version: "0.0.1".to_string(),
+            kind_version: KindVersion::HashedRekordV001,
             integrated_time: None,
             canonicalized_body: Vec::new(),
             inclusion_promise: None,
@@ -165,9 +163,8 @@ impl TlogEntryBuilder {
     ///
     /// # Arguments
     /// * `entry` - The LogEntry returned from the Rekor API
-    /// * `kind` - The entry kind (e.g., "hashedrekord", "dsse")
-    /// * `version` - The entry version (e.g., "0.0.1")
-    pub fn from_log_entry(entry: &LogEntry, kind: &str, version: &str) -> Self {
+    /// * `kind_version` - The typed Rekor entry format
+    pub fn from_log_entry(entry: &LogEntry, kind_version: KindVersion) -> TypesResult<Self> {
         // Convert hex log_id to base64 using the type-safe method
         let log_id_base64 = entry
             .log_id
@@ -177,8 +174,7 @@ impl TlogEntryBuilder {
         let mut builder = Self {
             log_index: entry.log_index,
             log_id: log_id_base64,
-            kind: kind.to_string(),
-            kind_version: version.to_string(),
+            kind_version,
             integrated_time: entry.integrated_time,
             canonicalized_body: entry.body.as_bytes().to_vec(),
             inclusion_promise: None,
@@ -194,31 +190,17 @@ impl TlogEntryBuilder {
             }
 
             if let Some(proof) = &verification.inclusion_proof {
-                // Rekor V1 API returns hashes as hex, bundle format expects base64
-                // Convert root_hash from hex to Sha256Hash
-                let root_hash = Sha256Hash::from_hex(&proof.root_hash)
-                    .unwrap_or_else(|_| Sha256Hash::from_bytes([0u8; 32]));
-
-                // Convert all proof hashes from hex to Sha256Hash
-                let hashes: Vec<Sha256Hash> = proof
-                    .hashes
-                    .iter()
-                    .filter_map(|h| Sha256Hash::from_hex(h).ok())
-                    .collect();
-
                 builder.inclusion_proof = Some(InclusionProof {
                     log_index: LogIndex::new(proof.log_index),
-                    root_hash,
+                    root_hash: proof.root_hash,
                     tree_size: proof.tree_size,
-                    hashes,
-                    checkpoint: CheckpointData {
-                        envelope: proof.checkpoint.clone(),
-                    },
+                    hashes: proof.hashes.clone(),
+                    checkpoint: CheckpointData::new(proof.checkpoint.clone())?,
                 });
             }
         }
 
-        builder
+        Ok(builder)
     }
 
     /// Set the log index.
@@ -256,17 +238,15 @@ impl TlogEntryBuilder {
         tree_size: u64,
         hashes: Vec<Sha256Hash>,
         checkpoint: String,
-    ) -> Self {
+    ) -> TypesResult<Self> {
         self.inclusion_proof = Some(InclusionProof {
             log_index: LogIndex::new(log_index),
             root_hash,
             tree_size,
             hashes,
-            checkpoint: CheckpointData {
-                envelope: checkpoint,
-            },
+            checkpoint: CheckpointData::new(checkpoint)?,
         });
-        self
+        Ok(self)
     }
 
     /// Build the transparency log entry.
@@ -276,10 +256,7 @@ impl TlogEntryBuilder {
             log_id: LogId {
                 key_id: LogKeyId::new(self.log_id),
             },
-            kind_version: KindVersion {
-                kind: self.kind,
-                version: self.kind_version,
-            },
+            kind_version: self.kind_version,
             integrated_time: self.integrated_time,
             inclusion_promise: self.inclusion_promise,
             inclusion_proof: self.inclusion_proof,

--- a/crates/sigstore-bundle/src/validation.rs
+++ b/crates/sigstore-bundle/src/validation.rs
@@ -20,7 +20,7 @@
 //! root material required to do so.
 
 use crate::error::{Error, Result};
-use sigstore_types::{Bundle, MediaType};
+use sigstore_types::{Bundle, KindVersion, MediaType};
 
 /// Options controlling which materials must be *present* in the bundle.
 ///
@@ -98,13 +98,7 @@ pub fn validate_bundle(bundle: &Bundle) -> Result<()> {
 /// Those checks require trusted key material and are performed by the
 /// verification path in the `sigstore-verify` crate.
 pub fn validate_bundle_with_options(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
-    // Check media type is valid
-    let version = bundle
-        .version()
-        .map_err(|e| Error::Validation(format!("invalid media type: {}", e)))?;
-
-    // Version-specific validation
-    match version {
+    match bundle.version() {
         MediaType::Bundle0_1 => validate_v0_1(bundle, options),
         MediaType::Bundle0_2 => validate_v0_2(bundle, options),
         MediaType::Bundle0_3 => validate_v0_3(bundle, options),
@@ -214,14 +208,11 @@ fn validate_common(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
 fn validate_inclusion_proof_structure(bundle: &Bundle) -> Result<()> {
     for entry in &bundle.verification_material.tlog_entries {
         if let Some(proof) = &entry.inclusion_proof {
-            // The checkpoint must be a parseable signed note
-            let checkpoint = proof
-                .checkpoint
-                .parse()
-                .map_err(|e| Error::Validation(format!("failed to parse checkpoint: {}", e)))?;
+            let checkpoint = proof.checkpoint.checkpoint().ok_or_else(|| {
+                Error::Validation("inclusion proof has no checkpoint".to_string())
+            })?;
 
-            let is_v2 =
-                entry.kind_version.kind == "hashedrekord" && entry.kind_version.version == "0.0.2";
+            let is_v2 = entry.kind_version == KindVersion::HashedRekordV002;
             if is_v2 {
                 let leaf_index = entry.log_index.value();
                 if leaf_index >= checkpoint.tree_size {

--- a/crates/sigstore-bundle/tests/bundle_v3_tests.rs
+++ b/crates/sigstore-bundle/tests/bundle_v3_tests.rs
@@ -3,7 +3,7 @@
 //! These tests use real bundle fixtures from the sigstore-python project.
 
 use sigstore_bundle::{validate_bundle, validate_bundle_with_options, ValidationOptions};
-use sigstore_types::{Bundle, LogIndex, MediaType};
+use sigstore_types::{Bundle, KindVersion, LogIndex, MediaType};
 
 /// Test bundle JSON from sigstore-python/test/assets/bundle_v3.txt.sigstore
 const BUNDLE_V3_JSON: &str = r#"{
@@ -65,7 +65,7 @@ fn test_parse_v3_bundle() {
     let bundle = Bundle::from_json(BUNDLE_V3_JSON).unwrap();
 
     // Check media type
-    assert_eq!(bundle.version().unwrap(), MediaType::Bundle0_3);
+    assert_eq!(bundle.version(), MediaType::Bundle0_3);
 
     // Check we have a certificate
     assert!(bundle.signing_certificate().is_some());
@@ -78,8 +78,7 @@ fn test_parse_v3_bundle() {
         entry.integrated_time,
         Some(jiff::Timestamp::from_second(1712085549).unwrap())
     );
-    assert_eq!(entry.kind_version.kind, "hashedrekord");
-    assert_eq!(entry.kind_version.version, "0.0.1");
+    assert_eq!(entry.kind_version, KindVersion::HashedRekordV001);
 
     // Check inclusion proof exists
     assert!(bundle.has_inclusion_proof());
@@ -122,7 +121,7 @@ fn test_v3_bundle_checkpoint_parsing() {
     let proof = entry.inclusion_proof.as_ref().unwrap();
 
     // Parse the checkpoint
-    let checkpoint = proof.checkpoint.parse().unwrap();
+    let checkpoint = proof.checkpoint.checkpoint().unwrap();
 
     assert_eq!(
         checkpoint.origin,
@@ -186,8 +185,7 @@ fn test_invalid_bundle_version() {
         }
     }"#;
 
-    let bundle = Bundle::from_json(invalid_json).unwrap();
-    assert!(bundle.version().is_err());
+    assert!(Bundle::from_json(invalid_json).is_err());
 }
 
 #[test]

--- a/crates/sigstore-bundle/tests/bundle_versions_tests.rs
+++ b/crates/sigstore-bundle/tests/bundle_versions_tests.rs
@@ -67,14 +67,8 @@ fn test_parse_v01_bundle() {
     let bundle = Bundle::from_json(V01_BUNDLE).expect("Failed to parse v0.1 bundle");
 
     // Check media type
-    assert_eq!(
-        bundle.media_type,
-        "application/vnd.dev.sigstore.bundle+json;version=0.1"
-    );
-
-    // Check version
-    let version = bundle.version().expect("Failed to get version");
-    assert_eq!(version, sigstore_types::MediaType::Bundle0_1);
+    assert_eq!(bundle.media_type, sigstore_types::MediaType::Bundle0_1);
+    assert_eq!(bundle.version(), sigstore_types::MediaType::Bundle0_1);
 
     // Check it has x509CertificateChain (not single certificate)
     match &bundle.verification_material.content {
@@ -128,14 +122,8 @@ fn test_parse_v03_bundle() {
     let bundle = Bundle::from_json(V03_BUNDLE_WITH_PROOF).expect("Failed to parse v0.3 bundle");
 
     // Check media type
-    assert_eq!(
-        bundle.media_type,
-        "application/vnd.dev.sigstore.bundle.v0.3+json"
-    );
-
-    // Check version
-    let version = bundle.version().expect("Failed to get version");
-    assert_eq!(version, sigstore_types::MediaType::Bundle0_3);
+    assert_eq!(bundle.media_type, sigstore_types::MediaType::Bundle0_3);
+    assert_eq!(bundle.version(), sigstore_types::MediaType::Bundle0_3);
 
     // Check it has single certificate (not chain)
     match &bundle.verification_material.content {
@@ -218,10 +206,7 @@ fn test_v03_github_attestation_no_tlog_entries() {
     let bundle =
         Bundle::from_json(V03_BUNDLE_GITHUB_NO_TLOG).expect("Failed to parse GitHub bundle");
 
-    assert_eq!(
-        bundle.version().unwrap(),
-        sigstore_types::MediaType::Bundle0_3
-    );
+    assert_eq!(bundle.version(), sigstore_types::MediaType::Bundle0_3);
     assert!(bundle.verification_material.tlog_entries.is_empty());
     assert_eq!(
         bundle
@@ -294,8 +279,8 @@ fn test_media_type_parsing() {
     let v01 = Bundle::from_json(V01_BUNDLE).expect("Failed to parse v0.1");
     let v03 = Bundle::from_json(V03_BUNDLE_WITH_PROOF).expect("Failed to parse v0.3");
 
-    assert_eq!(v01.version().unwrap(), sigstore_types::MediaType::Bundle0_1);
-    assert_eq!(v03.version().unwrap(), sigstore_types::MediaType::Bundle0_3);
+    assert_eq!(v01.version(), sigstore_types::MediaType::Bundle0_1);
+    assert_eq!(v03.version(), sigstore_types::MediaType::Bundle0_3);
 }
 
 // ==== Error Cases ====
@@ -350,8 +335,7 @@ fn test_v03_with_certificate_chain_fails() {
                     "logIndex": "1",
                     "rootHash": "{}",
                     "treeSize": "2",
-                    "hashes": [],
-                    "checkpoint": {{"envelope": "test\n1\n{}\n"}}
+                    "hashes": []
                 }},
                 "canonicalizedBody": "dGVzdA=="
             }}]
@@ -362,7 +346,7 @@ fn test_v03_with_certificate_chain_fails() {
             "signatures": [{{"sig": "dGVzdA=="}}]
         }}
     }}"#,
-        fake_hash, fake_hash
+        fake_hash
     );
 
     let bundle = Bundle::from_json(&json).expect("Failed to parse bundle");
@@ -460,9 +444,5 @@ fn test_invalid_media_type() {
         }
     }"#;
 
-    let bundle = Bundle::from_json(json).expect("Failed to parse bundle");
-
-    // Should fail with invalid media type
-    let result = validate_bundle(&bundle);
-    assert!(result.is_err(), "Should fail with invalid media type");
+    assert!(Bundle::from_json(json).is_err());
 }

--- a/crates/sigstore-rekor/src/client.rs
+++ b/crates/sigstore-rekor/src/client.rs
@@ -6,7 +6,7 @@ use crate::entry::{
     SearchIndex,
 };
 use crate::error::{Error, Result};
-use sigstore_types::{Checkpoint, TransparencyLogEntry};
+use sigstore_types::{Checkpoint, KindVersion, TransparencyLogEntry};
 use std::num::NonZeroU8;
 use std::time::Duration;
 
@@ -569,16 +569,17 @@ impl RekorClientBuilder {
 }
 
 fn validate_v2_entry(entry: &TransparencyLogEntry, request: &HashedRekordV2) -> Result<()> {
-    if entry.kind_version.kind != "hashedrekord" || entry.kind_version.version != "0.0.2" {
+    if entry.kind_version != KindVersion::HashedRekordV002 {
         return Err(Error::InvalidResponse(format!(
             "expected hashedrekord/0.0.2, received {}/{}",
-            entry.kind_version.kind, entry.kind_version.version
+            entry.kind_version.kind(),
+            entry.kind_version.version()
         )));
     }
     let body = RekorEntryBody::from_base64_json(
         &entry.canonicalized_body.to_base64(),
-        &entry.kind_version.kind,
-        &entry.kind_version.version,
+        entry.kind_version.kind(),
+        entry.kind_version.version(),
     )?;
     let RekorEntryBody::HashedRekordV002(body) = body else {
         return Err(Error::InvalidResponse(

--- a/crates/sigstore-rekor/src/entry.rs
+++ b/crates/sigstore-rekor/src/entry.rs
@@ -89,11 +89,13 @@ pub struct RekorInclusionProof {
     /// Checkpoint (signed tree head)
     pub checkpoint: String,
     /// Hashes in the proof path (hex-encoded in V1 API)
-    pub hashes: Vec<String>,
+    #[serde(with = "hex_sha256_vec")]
+    pub hashes: Vec<Sha256Hash>,
     /// Log index
     pub log_index: u64,
     /// Root hash (hex-encoded in V1 API)
-    pub root_hash: String,
+    #[serde(with = "hex_sha256")]
+    pub root_hash: Sha256Hash,
     /// Tree size
     pub tree_size: u64,
 }
@@ -103,7 +105,8 @@ pub struct RekorInclusionProof {
 #[serde(rename_all = "camelCase")]
 pub struct LogInfo {
     /// Root hash of the tree
-    pub root_hash: String,
+    #[serde(with = "hex_sha256")]
+    pub root_hash: Sha256Hash,
     /// Signed tree head (checkpoint)
     pub signed_tree_head: String,
     /// Tree ID
@@ -120,13 +123,60 @@ pub struct LogInfo {
 #[serde(rename_all = "camelCase")]
 pub struct InactiveShard {
     /// Root hash
-    pub root_hash: String,
+    #[serde(with = "hex_sha256")]
+    pub root_hash: Sha256Hash,
     /// Signed tree head
     pub signed_tree_head: String,
     /// Tree ID
     pub tree_i_d: String,
     /// Tree size
     pub tree_size: u64,
+}
+
+mod hex_sha256 {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use sigstore_types::Sha256Hash;
+
+    pub fn serialize<S>(value: &Sha256Hash, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&value.to_hex())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Sha256Hash, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Sha256Hash::from_hex(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+mod hex_sha256_vec {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use sigstore_types::Sha256Hash;
+
+    pub fn serialize<S>(values: &[Sha256Hash], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        values
+            .iter()
+            .map(Sha256Hash::to_hex)
+            .collect::<Vec<_>>()
+            .serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Sha256Hash>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<String>::deserialize(deserializer)?
+            .into_iter()
+            .map(|value| Sha256Hash::from_hex(&value).map_err(serde::de::Error::custom))
+            .collect()
+    }
 }
 
 /// Response from creating a log entry (map of UUID to LogEntry)

--- a/crates/sigstore-rekor/tests/v2_client.rs
+++ b/crates/sigstore-rekor/tests/v2_client.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use sigstore_rekor::{HashedRekordV2, RekorV2Client, RekorV2KeyDetails};
-use sigstore_types::{DerCertificate, Sha256Hash, SignatureBytes};
+use sigstore_types::{DerCertificate, KindVersion, Sha256Hash, SignatureBytes};
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::num::NonZeroU8;
@@ -17,7 +17,7 @@ const VALID_ENTRY: &str = r#"{
     "rootHash":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
     "treeSize":"8",
     "hashes":[],
-    "checkpoint":{"envelope":"example.com/log\n8\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n\n"}
+    "checkpoint":{"envelope":"example.com/log\n8\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n\n— example.com/log AAAAAAAA\n"}
   },
   "canonicalizedBody":"eyJzcGVjIjp7Imhhc2hlZFJla29yZFYwMDIiOnsiZGF0YSI6eyJhbGdvcml0aG0iOiJTSEEyXzI1NiIsImRpZ2VzdCI6IkFRRUJBUUVCQVFFQkFRRUJBUUVCQVFFQkFRRUJBUUVCQVFFQkFRRUJBUUU9In0sInNpZ25hdHVyZSI6eyJjb250ZW50IjoiYzJsbmJtRjBkWEpsIiwidmVyaWZpZXIiOnsia2V5RGV0YWlscyI6IlBLSVhfRUNEU0FfUDI1Nl9TSEFfMjU2IiwieDUwOUNlcnRpZmljYXRlIjp7InJhd0J5dGVzIjoiTUFBPSJ9fX19fX0="
 }"#;
@@ -98,8 +98,7 @@ async fn create_entry_returns_the_protobuf_entry_without_lossy_conversion() {
         entry.log_id.key_id.as_str(),
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     );
-    assert_eq!(entry.kind_version.kind, "hashedrekord");
-    assert_eq!(entry.kind_version.version, "0.0.2");
+    assert_eq!(entry.kind_version, KindVersion::HashedRekordV002);
     assert!(entry.integrated_time.is_none());
     assert!(entry.inclusion_promise.is_none());
     assert_eq!(entry.inclusion_proof.unwrap().tree_size, 8);

--- a/crates/sigstore-sign/examples/sign_attestation.rs
+++ b/crates/sigstore-sign/examples/sign_attestation.rs
@@ -215,7 +215,8 @@ async fn main() {
     if let Some(entry) = bundle.verification_material.tlog_entries.first() {
         println!(
             "  Entry Kind: {} v{}",
-            entry.kind_version.kind, entry.kind_version.version
+            entry.kind_version.kind(),
+            entry.kind_version.version()
         );
         println!("  Log Index: {}", entry.log_index);
         match entry.integrated_time {

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -219,7 +219,8 @@ async fn main() {
     if let Some(entry) = bundle.verification_material.tlog_entries.first() {
         println!(
             "  Entry Kind: {} v{}",
-            entry.kind_version.kind, entry.kind_version.version
+            entry.kind_version.kind(),
+            entry.kind_version.version()
         );
         println!("  Log Index: {}", entry.log_index);
         // For V2, integrated_time is absent - RFC3161 timestamps are used instead

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -18,7 +18,7 @@ use sigstore_trust_root::{
 use sigstore_tsa::TimestampClient;
 use sigstore_types::{
     Artifact, Bundle, DerCertificate, DsseEnvelope, DsseSignature, HashAlgorithm, KeyId,
-    PayloadBytes, Sha256Hash, SignatureBytes, Statement, Subject, TimestampToken,
+    KindVersion, PayloadBytes, Sha256Hash, SignatureBytes, Statement, Subject, TimestampToken,
     TransparencyLogEntry,
 };
 
@@ -435,7 +435,11 @@ impl Signer {
                     .create_entry(request)
                     .await
                     .map_err(|e| Error::Signing(format!("Failed to create Rekor entry: {e}")))?;
-                Ok(TlogEntryBuilder::from_log_entry(&entry, "hashedrekord", "0.0.1").build())
+                Ok(
+                    TlogEntryBuilder::from_log_entry(&entry, KindVersion::HashedRekordV001)
+                        .map_err(|e| Error::Signing(format!("invalid Rekor response: {e}")))?
+                        .build(),
+                )
             }
             RekorApiVersion::V2 => {
                 let rekor = RekorV2Client::new(&self.rekor_url);
@@ -581,7 +585,11 @@ impl Signer {
                 let entry = rekor.create_dsse_entry(request).await.map_err(|e| {
                     Error::Signing(format!("Failed to create DSSE Rekor entry: {e}"))
                 })?;
-                Ok(TlogEntryBuilder::from_log_entry(&entry, "dsse", "0.0.1").build())
+                Ok(
+                    TlogEntryBuilder::from_log_entry(&entry, KindVersion::DsseV001)
+                        .map_err(|e| Error::Signing(format!("invalid Rekor response: {e}")))?
+                        .build(),
+                )
             }
             RekorApiVersion::V2 => {
                 let rekor = RekorV2Client::new(&self.rekor_url);
@@ -705,7 +713,7 @@ impl Attestation {
                 .map(|s| Subject {
                     name: s.name.clone(),
                     digest: Digest {
-                        sha256: Some(s.digest.to_hex()),
+                        sha256: Some(s.digest),
                         sha512: None,
                     },
                 })

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -715,6 +715,7 @@ impl Attestation {
                     digest: Digest {
                         sha256: Some(s.digest),
                         sha512: None,
+                        other: Default::default(),
                     },
                 })
                 .collect(),

--- a/crates/sigstore-types/src/bundle.rs
+++ b/crates/sigstore-types/src/bundle.rs
@@ -47,6 +47,39 @@ impl MediaType {
     }
 }
 
+impl std::ops::Deref for MediaType {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for MediaType {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Serialize for MediaType {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for MediaType {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::from_str(&value).map_err(serde::de::Error::custom)
+    }
+}
+
 impl FromStr for MediaType {
     type Err = Error;
 
@@ -81,7 +114,7 @@ pub enum BundleVersion {
 #[serde(rename_all = "camelCase")]
 pub struct Bundle {
     /// Media type identifying the bundle version
-    pub media_type: String,
+    pub media_type: MediaType,
     /// Verification material (certificate chain or public key)
     pub verification_material: VerificationMaterial,
     /// The content being signed (message signature or DSSE envelope)
@@ -106,8 +139,8 @@ impl Bundle {
     }
 
     /// Get the bundle version from the media type
-    pub fn version(&self) -> Result<MediaType> {
-        MediaType::from_str(&self.media_type)
+    pub fn version(&self) -> MediaType {
+        self.media_type
     }
 
     /// Get the signing certificate if present
@@ -261,14 +294,68 @@ pub struct LogId {
     pub key_id: LogKeyId,
 }
 
-/// Entry kind and version
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct KindVersion {
-    /// Entry kind (e.g., "hashedrekord")
-    pub kind: String,
-    /// Entry version (e.g., "0.0.1")
-    pub version: String,
+/// Supported Rekor entry format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KindVersion {
+    HashedRekordV001,
+    HashedRekordV002,
+    DsseV001,
+    IntotoV002,
+}
+
+impl KindVersion {
+    pub fn kind(self) -> &'static str {
+        match self {
+            Self::HashedRekordV001 | Self::HashedRekordV002 => "hashedrekord",
+            Self::DsseV001 => "dsse",
+            Self::IntotoV002 => "intoto",
+        }
+    }
+
+    pub fn version(self) -> &'static str {
+        match self {
+            Self::HashedRekordV001 | Self::DsseV001 => "0.0.1",
+            Self::HashedRekordV002 | Self::IntotoV002 => "0.0.2",
+        }
+    }
+}
+
+impl Serialize for KindVersion {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("KindVersion", 2)?;
+        state.serialize_field("kind", self.kind())?;
+        state.serialize_field("version", self.version())?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for KindVersion {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireKindVersion {
+            kind: String,
+            version: String,
+        }
+
+        let value = WireKindVersion::deserialize(deserializer)?;
+        match (value.kind.as_str(), value.version.as_str()) {
+            ("hashedrekord", "0.0.1") => Ok(Self::HashedRekordV001),
+            ("hashedrekord", "0.0.2") => Ok(Self::HashedRekordV002),
+            ("dsse", "0.0.1") => Ok(Self::DsseV001),
+            ("intoto", "0.0.2") => Ok(Self::IntotoV002),
+            _ => Err(serde::de::Error::custom(format!(
+                "unsupported Rekor entry format: {}/{}",
+                value.kind, value.version
+            ))),
+        }
+    }
 }
 
 /// Inclusion promise (Signed Entry Timestamp)
@@ -320,24 +407,68 @@ mod sha256_hash_vec {
     }
 }
 
-/// Checkpoint data in inclusion proof
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+/// A checkpoint parsed at the bundle deserialization boundary.
+///
+/// The original envelope is retained because checkpoint signatures cover its
+/// exact bytes; consumers use the parsed representation for semantic fields.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CheckpointData {
-    /// Text representation of the checkpoint
-    #[serde(default)]
-    pub envelope: String,
+    envelope: String,
+    checkpoint: Option<Checkpoint>,
 }
 
 impl CheckpointData {
-    /// Parse the checkpoint text
-    pub fn parse(&self) -> Result<Checkpoint> {
-        Checkpoint::from_text(&self.envelope)
+    pub fn new(envelope: impl Into<String>) -> Result<Self> {
+        let envelope = envelope.into();
+        let checkpoint = if envelope.is_empty() {
+            None
+        } else {
+            Some(Checkpoint::from_text(&envelope)?)
+        };
+        Ok(Self {
+            envelope,
+            checkpoint,
+        })
     }
 
-    /// Check if checkpoint data is empty
+    pub fn envelope(&self) -> &str {
+        &self.envelope
+    }
+
+    pub fn checkpoint(&self) -> Option<&Checkpoint> {
+        self.checkpoint.as_ref()
+    }
+
     pub fn is_empty(&self) -> bool {
-        self.envelope.is_empty()
+        self.checkpoint.is_none()
+    }
+}
+
+impl Serialize for CheckpointData {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("CheckpointData", 1)?;
+        state.serialize_field("envelope", &self.envelope)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CheckpointData {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireCheckpointData {
+            #[serde(default)]
+            envelope: String,
+        }
+
+        let wire = WireCheckpointData::deserialize(deserializer)?;
+        Self::new(wire.envelope).map_err(serde::de::Error::custom)
     }
 }
 
@@ -359,8 +490,8 @@ pub struct Rfc3161Timestamp {
 }
 
 /// Default media type for bundles that don't specify one (pre-v0.1 format)
-fn default_media_type() -> String {
-    "application/vnd.dev.sigstore.bundle+json;version=0.1".to_string()
+fn default_media_type() -> MediaType {
+    MediaType::Bundle0_1
 }
 
 // Custom Deserialize implementation for Bundle
@@ -374,7 +505,7 @@ impl<'de> Deserialize<'de> for Bundle {
         struct BundleHelper {
             // Cosign V1 bundles may not have mediaType - default to v0.1
             #[serde(default = "default_media_type")]
-            media_type: String,
+            media_type: MediaType,
             verification_material: VerificationMaterial,
             #[serde(flatten)]
             content: SignatureContent,
@@ -434,7 +565,7 @@ mod tests {
         let json = r#"{
             "rootHash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
             "treeSize": "1",
-            "checkpoint": {"envelope": "test\n1\nAAA=\n\n— test AAAA\n"}
+            "checkpoint": {"envelope": "test\n1\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n\n— test AAAAAAAA\n"}
         }"#;
         let proof: InclusionProof = serde_json::from_str(json).unwrap();
         assert_eq!(proof.log_index.value(), 0);
@@ -476,7 +607,7 @@ mod tests {
             assert_eq!(statement.subject[0].name, "");
             assert_eq!(
                 statement.subject[0].digest.sha256,
-                Some("abc123".to_string())
+                Some(Sha256Hash::from_bytes([0; 32]))
             );
         } else {
             panic!("expected DSSE envelope");

--- a/crates/sigstore-types/src/encoding.rs
+++ b/crates/sigstore-types/src/encoding.rs
@@ -818,6 +818,50 @@ impl<'de> serde::Deserialize<'de> for Sha256Hash {
 }
 
 // ============================================================================
+// SHA-512 Hash Type (Fixed Size)
+// ============================================================================
+
+/// SHA-512 hash digest (64 bytes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Sha512Hash([u8; 64]);
+
+impl Sha512Hash {
+    pub fn from_bytes(bytes: [u8; 64]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn try_from_slice(bytes: &[u8]) -> Result<Self> {
+        let bytes: [u8; 64] = bytes.try_into().map_err(|_| {
+            Error::InvalidEncoding(format!(
+                "SHA-512 hash must be 64 bytes, got {}",
+                bytes.len()
+            ))
+        })?;
+        Ok(Self(bytes))
+    }
+
+    pub fn from_hex(value: &str) -> Result<Self> {
+        let bytes =
+            hex::decode(value).map_err(|e| Error::InvalidEncoding(format!("invalid hex: {e}")))?;
+        Self::try_from_slice(&bytes)
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 64] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Sha512Hash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+// ============================================================================
 // Arbitrary Digest Type (Flexible Size)
 // ============================================================================
 

--- a/crates/sigstore-types/src/intoto.rs
+++ b/crates/sigstore-types/src/intoto.rs
@@ -46,7 +46,7 @@ pub struct Subject {
 ///
 /// Contains one or more cryptographic hashes of the artifact.
 /// At minimum, sha256 should be provided.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Digest {
     /// SHA-256 hash (hex-encoded)
     #[serde(
@@ -62,6 +62,42 @@ pub struct Digest {
         skip_serializing_if = "Option::is_none"
     )]
     pub sha512: Option<Sha512Hash>,
+    /// Additional in-toto digest algorithms, preserved without interpretation.
+    ///
+    /// The in-toto digest map is extensible. Algorithms understood by this
+    /// crate are parsed into fixed-size semantic values above; other entries
+    /// remain available for lossless round trips.
+    #[serde(flatten)]
+    pub other: std::collections::BTreeMap<String, String>,
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireDigest {
+            #[serde(default, with = "option_hex_sha256")]
+            sha256: Option<Sha256Hash>,
+            #[serde(default, with = "option_hex_sha512")]
+            sha512: Option<Sha512Hash>,
+            #[serde(flatten)]
+            other: std::collections::BTreeMap<String, String>,
+        }
+
+        let wire = WireDigest::deserialize(deserializer)?;
+        if wire.sha256.is_none() && wire.sha512.is_none() && wire.other.is_empty() {
+            return Err(serde::de::Error::custom(
+                "subject digest must contain at least one algorithm",
+            ));
+        }
+        Ok(Self {
+            sha256: wire.sha256,
+            sha512: wire.sha512,
+            other: wire.other,
+        })
+    }
 }
 
 impl Statement {
@@ -148,6 +184,7 @@ mod tests {
                     digest: Digest {
                         sha256: Some(sha256_1),
                         sha512: Some(sha512_1),
+                        other: Default::default(),
                     },
                 },
                 Subject {
@@ -155,6 +192,7 @@ mod tests {
                     digest: Digest {
                         sha256: Some(sha256_2),
                         sha512: None,
+                        other: Default::default(),
                     },
                 },
             ],
@@ -190,6 +228,31 @@ mod tests {
         let json = r#"{
             "_type": "https://in-toto.io/Statement/v1",
             "subject": [{"digest": {"sha256": "abc123"}}],
+            "predicateType": "https://sigstore.dev/cosign/sign/v1",
+            "predicate": {}
+        }"#;
+        assert!(serde_json::from_str::<Statement>(json).is_err());
+    }
+
+    #[test]
+    fn additional_subject_digest_is_preserved_instead_of_discarded() {
+        let json = r#"{
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [{"digest": {"sha384": "00"}}],
+            "predicateType": "https://sigstore.dev/cosign/sign/v1",
+            "predicate": {}
+        }"#;
+        let statement = serde_json::from_str::<Statement>(json).unwrap();
+        assert_eq!(statement.subject[0].digest.other["sha384"], "00");
+        let serialized = serde_json::to_value(statement).unwrap();
+        assert_eq!(serialized["subject"][0]["digest"]["sha384"], "00");
+    }
+
+    #[test]
+    fn empty_subject_digest_is_rejected() {
+        let json = r#"{
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [{"digest": {}}],
             "predicateType": "https://sigstore.dev/cosign/sign/v1",
             "predicate": {}
         }"#;

--- a/crates/sigstore-types/src/intoto.rs
+++ b/crates/sigstore-types/src/intoto.rs
@@ -6,6 +6,7 @@
 //!
 //! Specification: <https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md>
 
+use crate::{Sha256Hash, Sha512Hash};
 use serde::{Deserialize, Serialize};
 
 /// In-toto Statement v1
@@ -48,28 +49,64 @@ pub struct Subject {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Digest {
     /// SHA-256 hash (hex-encoded)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sha256: Option<String>,
+    #[serde(
+        default,
+        with = "option_hex_sha256",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sha256: Option<Sha256Hash>,
     /// SHA-512 hash (hex-encoded)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sha512: Option<String>,
+    #[serde(
+        default,
+        with = "option_hex_sha512",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sha512: Option<Sha512Hash>,
 }
 
 impl Statement {
     /// Check if any subject in the statement matches the given SHA-256 hash
-    pub fn matches_sha256(&self, hash_hex: &str) -> bool {
+    pub fn matches_sha256(&self, hash: &Sha256Hash) -> bool {
         self.subject
             .iter()
-            .any(|subject| subject.digest.sha256.as_deref() == Some(hash_hex))
+            .any(|subject| subject.digest.sha256.as_ref() == Some(hash))
     }
 
     /// Check if any subject in the statement matches the given SHA-512 hash
-    pub fn matches_sha512(&self, hash_hex: &str) -> bool {
+    pub fn matches_sha512(&self, hash: &Sha512Hash) -> bool {
         self.subject
             .iter()
-            .any(|subject| subject.digest.sha512.as_deref() == Some(hash_hex))
+            .any(|subject| subject.digest.sha512.as_ref() == Some(hash))
     }
 }
+
+macro_rules! option_hex_digest {
+    ($module:ident, $type:ty) => {
+        mod $module {
+            use super::*;
+            use serde::{Deserializer, Serializer};
+
+            pub fn serialize<S>(value: &Option<$type>, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                value.as_ref().map(<$type>::to_hex).serialize(serializer)
+            }
+
+            pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<$type>, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Option::<String>::deserialize(deserializer)?
+                    .map(|value| <$type>::from_hex(&value).map_err(serde::de::Error::custom))
+                    .transpose()
+            }
+        }
+    };
+}
+
+option_hex_digest!(option_hex_sha256, Sha256Hash);
+option_hex_digest!(option_hex_sha512, Sha512Hash);
 
 #[cfg(test)]
 mod tests {
@@ -79,44 +116,44 @@ mod tests {
     fn test_statement_deserialization() {
         let json = r#"{
             "_type": "https://in-toto.io/Statement/v1",
-            "subject": [
-                {
-                    "name": "example.txt",
-                    "digest": {
-                        "sha256": "abc123"
-                    }
-                }
-            ],
+            "subject": [{
+                "name": "example.txt",
+                "digest": {"sha256": "0000000000000000000000000000000000000000000000000000000000000000"}
+            }],
             "predicateType": "https://slsa.dev/provenance/v1",
             "predicate": {}
         }"#;
 
         let statement: Statement = serde_json::from_str(json).unwrap();
         assert_eq!(statement.type_, "https://in-toto.io/Statement/v1");
-        assert_eq!(statement.subject.len(), 1);
         assert_eq!(statement.subject[0].name, "example.txt");
         assert_eq!(
             statement.subject[0].digest.sha256,
-            Some("abc123".to_string())
+            Some(Sha256Hash::from_bytes([0; 32]))
         );
     }
 
     #[test]
-    fn test_matches_sha256() {
+    fn test_matches_typed_digests() {
+        let sha256_1 = Sha256Hash::from_bytes([1; 32]);
+        let sha256_2 = Sha256Hash::from_bytes([2; 32]);
+        let sha256_3 = Sha256Hash::from_bytes([3; 32]);
+        let sha512_1 = Sha512Hash::from_bytes([1; 64]);
+        let sha512_2 = Sha512Hash::from_bytes([2; 64]);
         let statement = Statement {
             type_: "https://in-toto.io/Statement/v1".to_string(),
             subject: vec![
                 Subject {
                     name: "file1.txt".to_string(),
                     digest: Digest {
-                        sha256: Some("hash1".to_string()),
-                        sha512: Some("long-hash1".to_string()),
+                        sha256: Some(sha256_1),
+                        sha512: Some(sha512_1),
                     },
                 },
                 Subject {
                     name: "file2.txt".to_string(),
                     digest: Digest {
-                        sha256: Some("hash2".to_string()),
+                        sha256: Some(sha256_2),
                         sha512: None,
                     },
                 },
@@ -125,19 +162,18 @@ mod tests {
             predicate: serde_json::json!({}),
         };
 
-        assert!(statement.matches_sha256("hash1"));
-        assert!(statement.matches_sha256("hash2"));
-        assert!(!statement.matches_sha256("hash3"));
-        assert!(statement.matches_sha512("long-hash1"));
-        assert!(!statement.matches_sha512("long-hash2"));
+        assert!(statement.matches_sha256(&sha256_1));
+        assert!(statement.matches_sha256(&sha256_2));
+        assert!(!statement.matches_sha256(&sha256_3));
+        assert!(statement.matches_sha512(&sha512_1));
+        assert!(!statement.matches_sha512(&sha512_2));
     }
 
     #[test]
     fn test_subject_missing_name() {
-        // cosign v3 omits "name" from in-toto statement subjects
         let json = r#"{
             "_type": "https://in-toto.io/Statement/v1",
-            "subject": [{"digest": {"sha256": "abc123"}}],
+            "subject": [{"digest": {"sha256": "0000000000000000000000000000000000000000000000000000000000000000"}}],
             "predicateType": "https://sigstore.dev/cosign/sign/v1",
             "predicate": {}
         }"#;
@@ -145,7 +181,18 @@ mod tests {
         assert_eq!(statement.subject[0].name, "");
         assert_eq!(
             statement.subject[0].digest.sha256,
-            Some("abc123".to_string())
+            Some(Sha256Hash::from_bytes([0; 32]))
         );
+    }
+
+    #[test]
+    fn malformed_subject_digest_is_rejected() {
+        let json = r#"{
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [{"digest": {"sha256": "abc123"}}],
+            "predicateType": "https://sigstore.dev/cosign/sign/v1",
+            "predicate": {}
+        }"#;
+        assert!(serde_json::from_str::<Statement>(json).is_err());
     }
 }

--- a/crates/sigstore-types/src/lib.rs
+++ b/crates/sigstore-types/src/lib.rs
@@ -25,8 +25,8 @@ pub use dsse::{pae, DsseEnvelope, DsseSignature};
 pub use encoding::{
     base64_bytes, base64_bytes_option, hex_bytes, string_timestamp_opt, string_u64,
     CanonicalizedBody, DerCertificate, DerPublicKey, DigestBytes, EntryUuid, HexHash, HexLogId,
-    KeyHint, KeyId, LogIndex, LogKeyId, PayloadBytes, PemContent, Sha256Hash, SignatureBytes,
-    SignedTimestamp, TimestampToken,
+    KeyHint, KeyId, LogIndex, LogKeyId, PayloadBytes, PemContent, Sha256Hash, Sha512Hash,
+    SignatureBytes, SignedTimestamp, TimestampToken,
 };
 pub use error::{Error, Result};
 pub use hash::HashAlgorithm;

--- a/crates/sigstore-types/test_data/cosign_v3_missing_fields.json
+++ b/crates/sigstore-types/test_data/cosign_v3_missing_fields.json
@@ -21,7 +21,7 @@
           "rootHash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
           "treeSize": "1",
           "checkpoint": {
-            "envelope": "test - 123\n1\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n\n\u2014 test AAAA\n"
+            "envelope": "test - 123\n1\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n\n\u2014 test AAAAAAAA\n"
           }
         },
         "canonicalizedBody": "e30="
@@ -29,7 +29,7 @@
     ]
   },
   "dsseEnvelope": {
-    "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJkaWdlc3QiOnsic2hhMjU2IjoiYWJjMTIzIn19XSwicHJlZGljYXRlVHlwZSI6Imh0dHBzOi8vc2lnc3RvcmUuZGV2L2Nvc2lnbi9zaWduL3YxIiwicHJlZGljYXRlIjp7fX0=",
+    "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJkaWdlc3QiOnsic2hhMjU2IjoiMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMCJ9fV0sInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3NpZ3N0b3JlLmRldi9jb3NpZ24vc2lnbi92MSIsInByZWRpY2F0ZSI6e319",
     "payloadType": "application/vnd.in-toto+json",
     "signatures": [
       {

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -201,9 +201,7 @@ async fn main() {
     }
     println!("  Bundle: {}", bundle_path);
     println!("  Media Type: {}", bundle.media_type);
-    if let Ok(v) = bundle.version() {
-        println!("  Version: {:?}", v);
-    }
+    println!("  Version: {:?}", bundle.version());
     if let Some(id) = &identity {
         println!("  Required Identity: {}", id);
     }

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -9,7 +9,9 @@ use sigstore_bundle::ValidationOptions;
 use sigstore_crypto::{parse_certificate_info, KeyAlgorithm, SigningScheme, VerificationKey};
 use sigstore_trust_root::TrustedRoot;
 
-use sigstore_types::{Artifact, Bundle, HashAlgorithm, SignatureContent, Statement};
+use sigstore_types::{
+    Artifact, Bundle, HashAlgorithm, Sha256Hash, Sha512Hash, SignatureContent, Statement,
+};
 
 /// How the signing certificate is verified.
 ///
@@ -497,23 +499,27 @@ fn verify_dsse_artifact_binding(
     }
     let matches = match artifact {
         Artifact::Blob(bytes) => {
-            let sha256 = hex::encode(sigstore_crypto::sha256(bytes));
-            let sha512 = hex::encode(sigstore_crypto::sha512(bytes));
+            let sha256 = sigstore_crypto::sha256(bytes);
+            let sha512 = Sha512Hash::try_from_slice(&sigstore_crypto::sha512(bytes))
+                .expect("SHA-512 produces a 64-byte digest");
             statement.matches_sha256(&sha256) || statement.matches_sha512(&sha512)
         }
-        Artifact::Digest(digest) => {
-            let value = hex::encode(digest.as_bytes());
-            match digest.algorithm() {
-                HashAlgorithm::Sha2256 => statement.matches_sha256(&value),
-                HashAlgorithm::Sha2512 => statement.matches_sha512(&value),
-                algorithm => {
-                    return Err(Error::Verification(format!(
-                        "unsupported pre-computed artifact digest algorithm: {}",
-                        algorithm
-                    )))
-                }
+        Artifact::Digest(digest) => match digest.algorithm() {
+            HashAlgorithm::Sha2256 => statement.matches_sha256(
+                &Sha256Hash::try_from_slice(digest.as_bytes())
+                    .expect("typed SHA-256 digest has 32 bytes"),
+            ),
+            HashAlgorithm::Sha2512 => statement.matches_sha512(
+                &Sha512Hash::try_from_slice(digest.as_bytes())
+                    .expect("typed SHA-512 digest has 64 bytes"),
+            ),
+            algorithm => {
+                return Err(Error::Verification(format!(
+                    "unsupported pre-computed artifact digest algorithm: {}",
+                    algorithm
+                )))
             }
-        }
+        },
     };
 
     if !matches {

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use sigstore_rekor::body::RekorEntryBody;
 use sigstore_types::bundle::VerificationMaterialContent;
 use sigstore_types::{
-    Artifact, Bundle, DerPublicKey, Sha256Hash, SignatureContent, TransparencyLogEntry,
+    Artifact, Bundle, DerPublicKey, KindVersion, Sha256Hash, SignatureContent, TransparencyLogEntry,
 };
 use x509_cert::der::Decode;
 use x509_cert::Certificate;
@@ -29,8 +29,8 @@ pub(crate) fn verify_hashedrekord_entry(
     // Parse the Rekor entry body (convert canonicalized body to base64 string)
     let body = RekorEntryBody::from_base64_json(
         &entry.canonicalized_body.to_base64(),
-        &entry.kind_version.kind,
-        &entry.kind_version.version,
+        entry.kind_version.kind(),
+        entry.kind_version.version(),
     )
     .map_err(|e| Error::Verification(format!("failed to parse Rekor body: {}", e)))?;
 
@@ -66,7 +66,7 @@ pub(crate) fn verify_hashedrekord_entry(
         _ => {
             return Err(Error::Verification(format!(
                 "expected HashedRekord body, got different type for version {}",
-                entry.kind_version.version
+                entry.kind_version.version()
             )));
         }
     };
@@ -274,7 +274,7 @@ fn validate_integrated_time(entry: &TransparencyLogEntry, bundle: &Bundle) -> Re
         // For 0.0.2 (Rekor v2), integrated_time is not present
         let v1_integrated_time = entry
             .integrated_time
-            .filter(|_| entry.kind_version.version == "0.0.1");
+            .filter(|_| entry.kind_version == KindVersion::HashedRekordV001);
         if let Some(integrated_time) = v1_integrated_time {
             let cert = Certificate::from_der(bundle_cert_der).map_err(|e| {
                 Error::Verification(format!(

--- a/crates/sigstore-verify/src/verify_impl/helpers.rs
+++ b/crates/sigstore-verify/src/verify_impl/helpers.rs
@@ -9,7 +9,9 @@ use rustls_pki_types::{CertificateDer, UnixTime};
 use sigstore_crypto::CertificateInfo;
 use sigstore_trust_root::{TrustedRoot, TsaAuthority};
 use sigstore_types::bundle::VerificationMaterialContent;
-use sigstore_types::{Bundle, DerCertificate, DerPublicKey, SignatureBytes, SignatureContent};
+use sigstore_types::{
+    Bundle, DerCertificate, DerPublicKey, KindVersion, SignatureBytes, SignatureContent,
+};
 use webpki::{anchor_from_trusted_cert, EndEntityCert, KeyUsage, ALL_VERIFICATION_ALGS};
 
 /// Extract and decode the signing certificate from verification material
@@ -129,9 +131,7 @@ pub fn has_v2_tlog_entries(bundle: &Bundle) -> bool {
         .verification_material
         .tlog_entries
         .iter()
-        .any(|entry| {
-            entry.kind_version.kind == "hashedrekord" && entry.kind_version.version == "0.0.2"
-        })
+        .any(|entry| entry.kind_version == KindVersion::HashedRekordV002)
 }
 
 /// Extract integrated time from V1 tlog entries that have inclusion promises.
@@ -157,9 +157,10 @@ fn extract_v1_integrated_times_with_promise(
 
     for entry in &bundle.verification_material.tlog_entries {
         // Rekor v1 uses 0.0.1 for hashedrekord/dsse and 0.0.2 for intoto.
-        let is_v1 = (entry.kind_version.version == "0.0.1"
-            && matches!(entry.kind_version.kind.as_str(), "hashedrekord" | "dsse"))
-            || (entry.kind_version.kind == "intoto" && entry.kind_version.version == "0.0.2");
+        let is_v1 = matches!(
+            entry.kind_version,
+            KindVersion::HashedRekordV001 | KindVersion::DsseV001 | KindVersion::IntotoV002
+        );
 
         if !is_v1 || entry.inclusion_promise.is_none() {
             continue;

--- a/crates/sigstore-verify/src/verify_impl/rekor.rs
+++ b/crates/sigstore-verify/src/verify_impl/rekor.rs
@@ -8,7 +8,8 @@ use base64::Engine;
 use sigstore_rekor::body::RekorEntryBody;
 use sigstore_types::bundle::VerificationMaterialContent;
 use sigstore_types::{
-    Bundle, DerCertificate, DerPublicKey, HashAlgorithm, SignatureContent, TransparencyLogEntry,
+    Bundle, DerCertificate, DerPublicKey, HashAlgorithm, KindVersion, SignatureContent,
+    TransparencyLogEntry,
 };
 use x509_cert::der::{Decode, Encode};
 
@@ -28,76 +29,37 @@ pub(crate) fn verify_tlog_consistency_with_key(
     managed_key: Option<&DerPublicKey>,
 ) -> Result<()> {
     for entry in &bundle.verification_material.tlog_entries {
-        match &bundle.content {
-            // DSSE envelope handling depends on Rekor version:
-            // * Rekor 1 gives us a "dsse 0.0.1" entry (or "intoto 0.0.2")
-            // * Rekor 2 gives us a "hashedrekord 0.0.2" entry
-            SignatureContent::DsseEnvelope(envelope) => match entry.kind_version.kind.as_str() {
-                "hashedrekord" => match entry.kind_version.version.as_str() {
-                    "0.0.2" => {
-                        super::hashedrekord::verify_hashedrekord_entry(
-                            entry,
-                            bundle,
-                            artifact,
-                            managed_key,
-                        )?;
-                    }
-                    version => {
-                        return Err(Error::Verification(format!(
-                            "unsupported hashedrekord entry version for DSSE envelope: {}",
-                            version
-                        )))
-                    }
-                },
-                "dsse" => match entry.kind_version.version.as_str() {
-                    "0.0.1" => verify_dsse_v001(entry, envelope, bundle)?,
-                    version => {
-                        return Err(Error::Verification(format!(
-                            "unsupported dsse entry version: {}",
-                            version
-                        )))
-                    }
-                },
-                "intoto" => match entry.kind_version.version.as_str() {
-                    "0.0.2" => verify_intoto_v002(entry, envelope, bundle, managed_key)?,
-                    version => {
-                        return Err(Error::Verification(format!(
-                            "unsupported intoto entry version: {}",
-                            version
-                        )))
-                    }
-                },
-                kind => {
-                    return Err(Error::Verification(format!(
-                        "unsupported log entry kind for DSSE envelope: {}",
-                        kind
-                    )))
-                }
-            },
-            SignatureContent::MessageSignature(_) => match entry.kind_version.kind.as_str() {
-                "hashedrekord" => match entry.kind_version.version.as_str() {
-                    "0.0.1" | "0.0.2" => {
-                        super::hashedrekord::verify_hashedrekord_entry(
-                            entry,
-                            bundle,
-                            artifact,
-                            managed_key,
-                        )?;
-                    }
-                    version => {
-                        return Err(Error::Verification(format!(
-                            "unsupported hashedrekord entry version: {}",
-                            version
-                        )))
-                    }
-                },
-                kind => {
-                    return Err(Error::Verification(format!(
-                        "unsupported log entry kind for MessageSignature: {}",
-                        kind
-                    )))
-                }
-            },
+        match (&bundle.content, entry.kind_version) {
+            (SignatureContent::DsseEnvelope(_), KindVersion::HashedRekordV002)
+            | (
+                SignatureContent::MessageSignature(_),
+                KindVersion::HashedRekordV001 | KindVersion::HashedRekordV002,
+            ) => super::hashedrekord::verify_hashedrekord_entry(
+                entry,
+                bundle,
+                artifact,
+                managed_key,
+            )?,
+            (SignatureContent::DsseEnvelope(envelope), KindVersion::DsseV001) => {
+                verify_dsse_v001(entry, envelope, bundle)?
+            }
+            (SignatureContent::DsseEnvelope(envelope), KindVersion::IntotoV002) => {
+                verify_intoto_v002(entry, envelope, bundle, managed_key)?
+            }
+            (SignatureContent::DsseEnvelope(_), format) => {
+                return Err(Error::Verification(format!(
+                    "Rekor entry {}/{} is incompatible with a DSSE envelope",
+                    format.kind(),
+                    format.version()
+                )))
+            }
+            (SignatureContent::MessageSignature(_), format) => {
+                return Err(Error::Verification(format!(
+                    "Rekor entry {}/{} is incompatible with a message signature",
+                    format.kind(),
+                    format.version()
+                )))
+            }
         }
     }
 
@@ -122,8 +84,8 @@ fn verify_dsse_v001(
 ) -> Result<()> {
     let body = RekorEntryBody::from_base64_json(
         &entry.canonicalized_body.to_base64(),
-        &entry.kind_version.kind,
-        &entry.kind_version.version,
+        entry.kind_version.kind(),
+        entry.kind_version.version(),
     )
     .map_err(|e| Error::Verification(format!("failed to parse Rekor body: {}", e)))?;
 
@@ -203,8 +165,8 @@ fn verify_intoto_v002(
 ) -> Result<()> {
     let body = RekorEntryBody::from_base64_json(
         &entry.canonicalized_body.to_base64(),
-        &entry.kind_version.kind,
-        &entry.kind_version.version,
+        entry.kind_version.kind(),
+        entry.kind_version.version(),
     )
     .map_err(|e| Error::Verification(format!("failed to parse Rekor body: {}", e)))?;
 

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use sigstore_crypto::Checkpoint;
 use sigstore_trust_root::TrustedRoot;
 use sigstore_types::bundle::InclusionProof;
-use sigstore_types::{Bundle, Sha256Hash, SignatureBytes, TransparencyLogEntry};
+use sigstore_types::{Bundle, KindVersion, Sha256Hash, SignatureBytes, TransparencyLogEntry};
 
 /// Verify transparency log entries (checkpoints, Merkle inclusion proofs and SETs)
 ///
@@ -43,8 +43,7 @@ pub fn verify_tlog_entries(
 
         // Only Rekor v1 authenticates integratedTime via the SET. Rekor v2
         // uses RFC 3161 timestamps; ignore an unauthenticated top-level value.
-        let is_rekor_v2 =
-            entry.kind_version.kind == "hashedrekord" && entry.kind_version.version == "0.0.2";
+        let is_rekor_v2 = entry.kind_version == KindVersion::HashedRekordV002;
         if !is_rekor_v2 {
             if let Some(time) = entry.integrated_time {
                 validate_integrated_time(time, jiff::Timestamp::now(), not_before, not_after)?;
@@ -111,7 +110,7 @@ pub fn verify_entry_inclusion(
     if let Some(ref inclusion_proof) = entry.inclusion_proof {
         verify_merkle_inclusion(entry, inclusion_proof)?;
         verify_checkpoint(
-            &inclusion_proof.checkpoint.envelope,
+            inclusion_proof.checkpoint.envelope(),
             inclusion_proof,
             is_rekor_v2(entry),
             trusted_root,
@@ -134,8 +133,8 @@ pub fn verify_entry_inclusion(
 /// The checkpoint signature check authenticates the selected root.
 fn verify_merkle_inclusion(entry: &TransparencyLogEntry, proof: &InclusionProof) -> Result<()> {
     let (leaf_index, tree_size, root_hash) = if is_rekor_v2(entry) {
-        let checkpoint = proof.checkpoint.parse().map_err(|e| {
-            Error::Verification(format!("failed to parse Rekor v2 checkpoint: {e}"))
+        let checkpoint = proof.checkpoint.checkpoint().ok_or_else(|| {
+            Error::Verification("Rekor v2 inclusion proof has no checkpoint".to_string())
         })?;
         let leaf_index = entry.log_index.value();
         (leaf_index, checkpoint.tree_size, checkpoint.root_hash)
@@ -209,7 +208,7 @@ pub fn verify_checkpoint(
 }
 
 fn is_rekor_v2(entry: &TransparencyLogEntry) -> bool {
-    entry.kind_version.kind == "hashedrekord" && entry.kind_version.version == "0.0.2"
+    entry.kind_version == KindVersion::HashedRekordV002
 }
 
 #[derive(Serialize)]

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -370,7 +370,7 @@ fn test_full_verification_flow() {
 
     // Extract tlog entry info
     let entry = &bundle.verification_material.tlog_entries[0];
-    assert_eq!(entry.kind_version.kind, "dsse");
+    assert_eq!(entry.kind_version.kind(), "dsse");
     assert_eq!(entry.log_index, LogIndex::new(166143216));
 
     // Verify inclusion proof
@@ -413,7 +413,7 @@ fn test_full_verification_flow_happy_path() {
 
     // Extract tlog entry info
     let entry = &bundle.verification_material.tlog_entries[0];
-    assert_eq!(entry.kind_version.kind, "dsse");
+    assert_eq!(entry.kind_version.kind(), "dsse");
     assert_eq!(entry.log_index, LogIndex::new(155690850));
 
     // Verify inclusion proof
@@ -468,11 +468,10 @@ fn test_checkpoint_parsing() {
     let entry = &bundle.verification_material.tlog_entries[0];
     let proof = entry.inclusion_proof.as_ref().unwrap();
 
-    // Parse checkpoint
     let checkpoint = proof
         .checkpoint
-        .parse()
-        .expect("Failed to parse checkpoint");
+        .checkpoint()
+        .expect("checkpoint should be parsed during bundle deserialization");
 
     assert_eq!(
         checkpoint.origin,
@@ -521,7 +520,7 @@ fn test_parse_dsse_bundle_from_python() {
     // Verify tlog entry exists
     assert_eq!(bundle.verification_material.tlog_entries.len(), 1);
     let entry = &bundle.verification_material.tlog_entries[0];
-    assert_eq!(entry.kind_version.kind, "intoto");
+    assert_eq!(entry.kind_version.kind(), "intoto");
 }
 
 /// Regression test for TOB-SIGSTORE-9: DSSE bundles with multiple signatures
@@ -542,18 +541,8 @@ fn test_dsse_bundle_with_2_signatures_rejected_at_parse() {
 }
 
 #[test]
-fn test_parse_bundle_invalid_version_still_parses() {
-    // This bundle has an invalid mediaType ("this is completely wrong")
-    // Parsing should still succeed, but validation may fail
-    let bundle_result = Bundle::from_json(BUNDLE_INVALID_VERSION);
-
-    // The bundle should still parse (we don't validate media type strictly during parse)
-    // Note: Depending on implementation, this might fail. Let's see what happens.
-    if let Ok(bundle) = bundle_result {
-        // If it parses, the media type should be wrong
-        assert_eq!(bundle.media_type, "this is completely wrong");
-    }
-    // If it fails to parse, that's also acceptable behavior
+fn test_parse_bundle_rejects_invalid_version() {
+    assert!(Bundle::from_json(BUNDLE_INVALID_VERSION).is_err());
 }
 
 #[test]
@@ -566,7 +555,7 @@ fn test_parse_cve_2022_36056_bundle() {
 
     // Check it's a hashedrekord type
     let entry = &bundle.verification_material.tlog_entries[0];
-    assert_eq!(entry.kind_version.kind, "hashedrekord");
+    assert_eq!(entry.kind_version.kind(), "hashedrekord");
 
     // Bundle structure should be valid
     let result = validate_bundle(&bundle);
@@ -747,18 +736,8 @@ fn test_bundle_no_checkpoint() {
     // The inclusion proof should exist but lack the checkpoint
     let proof = proof.unwrap();
 
-    // Checkpoint should be empty (default value)
-    assert!(
-        proof.checkpoint.envelope.is_empty(),
-        "Checkpoint should be empty when missing from bundle"
-    );
-
-    // Parsing empty checkpoint should fail
-    let checkpoint_result = proof.checkpoint.parse();
-    assert!(
-        checkpoint_result.is_err(),
-        "Checkpoint parsing should fail when checkpoint is missing"
-    );
+    assert!(proof.checkpoint.is_empty());
+    assert!(proof.checkpoint.checkpoint().is_none());
 }
 
 /// Test bundle with empty transparency log entries
@@ -938,7 +917,7 @@ fn test_parse_conda_attestation_bundle() {
     // Should have tlog entry
     assert!(!bundle.verification_material.tlog_entries.is_empty());
     let entry = &bundle.verification_material.tlog_entries[0];
-    assert_eq!(entry.kind_version.kind, "dsse");
+    assert_eq!(entry.kind_version.kind(), "dsse");
 
     // Should have inclusion proof
     assert!(
@@ -1027,10 +1006,7 @@ fn test_parse_cosign_v3_blob_bundle() {
         Bundle::from_json(COSIGN_V3_BLOB_BUNDLE).expect("Failed to parse cosign v3 blob bundle");
 
     // Check media type
-    assert_eq!(
-        bundle.media_type,
-        "application/vnd.dev.sigstore.bundle.v0.3+json"
-    );
+    assert_eq!(bundle.media_type, sigstore_types::MediaType::Bundle0_3);
 
     // Check it's a message signature (not DSSE)
     assert!(
@@ -1044,8 +1020,8 @@ fn test_parse_cosign_v3_blob_bundle() {
     // Check tlog entry
     assert_eq!(bundle.verification_material.tlog_entries.len(), 1);
     let entry = &bundle.verification_material.tlog_entries[0];
-    assert_eq!(entry.kind_version.kind, "hashedrekord");
-    assert_eq!(entry.kind_version.version, "0.0.1");
+    assert_eq!(entry.kind_version.kind(), "hashedrekord");
+    assert_eq!(entry.kind_version.version(), "0.0.1");
 
     // Check it has both inclusion proof and inclusion promise
     assert!(entry.inclusion_proof.is_some(), "Expected inclusion proof");
@@ -1181,16 +1157,8 @@ fn test_verify_fails_with_unknown_log_entry_kind() {
         .push(corrupted_entry);
     let corrupted_bundle_json = serde_json::to_string(&json_val).unwrap();
 
-    let bundle =
-        Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
-    let artifact_digest =
-        extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default();
-
-    let result = verify(artifact_digest, &bundle, &policy, &production_root());
-    assert!(result.is_err());
-    let err_msg = result.err().unwrap().to_string();
-    assert!(err_msg.contains("unsupported log entry kind"));
+    let error = Bundle::from_json(&corrupted_bundle_json).unwrap_err();
+    assert!(error.to_string().contains("unsupported Rekor entry format"));
 }
 
 #[test]
@@ -1204,19 +1172,8 @@ fn test_verify_fails_with_unknown_log_entry_version() {
         .push(corrupted_entry);
     let corrupted_bundle_json = serde_json::to_string(&json_val).unwrap();
 
-    let bundle =
-        Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
-    let artifact_digest =
-        extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default();
-
-    let result = verify(artifact_digest, &bundle, &policy, &production_root());
-    assert!(result.is_err());
-    let err_msg = result.err().unwrap().to_string();
-    assert!(
-        err_msg.contains("unsupported dsse entry version")
-            || err_msg.contains("unsupported dsse entry version")
-    );
+    let error = Bundle::from_json(&corrupted_bundle_json).unwrap_err();
+    assert!(error.to_string().contains("unsupported Rekor entry format"));
 }
 
 #[test]
@@ -1231,16 +1188,8 @@ fn test_verify_fails_with_mismatched_log_entry_kind() {
         .push(corrupted_entry);
     let corrupted_bundle_json = serde_json::to_string(&json_val).unwrap();
 
-    let bundle =
-        Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
-    let artifact_digest =
-        extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
-    let policy = VerificationPolicy::default();
-
-    let result = verify(artifact_digest, &bundle, &policy, &production_root());
-    assert!(result.is_err());
-    let err_msg = result.err().unwrap().to_string();
-    assert!(err_msg.contains("unsupported log entry kind for DSSE envelope"));
+    let error = Bundle::from_json(&corrupted_bundle_json).unwrap_err();
+    assert!(error.to_string().contains("unsupported Rekor entry format"));
 }
 
 #[test]
@@ -1265,7 +1214,7 @@ fn test_verify_fails_with_mismatched_hashedrekord_version_for_dsse() {
     assert!(result.is_err());
     let err_msg = result.err().unwrap().to_string();
 
-    assert!(err_msg.contains("unsupported hashedrekord entry version for DSSE envelope"));
+    assert!(err_msg.contains("incompatible with a DSSE envelope"));
 }
 
 fn staging_root() -> TrustedRoot {
@@ -1521,39 +1470,13 @@ fn test_verify_dsse_with_key_succeeds_with_correct_artifact() {
 /// with the bundle content (CVE-2022-36056 class), like Verifier::verify does.
 #[test]
 fn test_verify_with_key_fails_with_mismatched_log_entry_kind() {
-    use sigstore_verify::verify_with_key;
-
     let mut json_val: serde_json::Value = serde_json::from_str(CONDA_ATTESTATION_BUNDLE).unwrap();
     json_val["verificationMaterial"]["tlogEntries"][0]["kindVersion"]["kind"] =
         serde_json::json!("not-a-known-kind");
     let corrupted_bundle_json = serde_json::to_string(&json_val).unwrap();
 
-    let bundle =
-        Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
-
-    let cert = bundle
-        .signing_certificate()
-        .expect("Should have a signing certificate");
-    let cert_info = sigstore_crypto::parse_certificate_info(cert.as_bytes())
-        .expect("Failed to parse certificate info");
-
-    let result = verify_with_key(
-        CONDA_PACKAGE,
-        &bundle,
-        &cert_info.public_key,
-        &production_root(),
-    );
-
-    assert!(
-        result.is_err(),
-        "Key-based verification must fail when the log entry kind does not match the bundle content"
-    );
-    let err_msg = result.err().unwrap().to_string();
-    assert!(
-        err_msg.contains("unsupported log entry kind"),
-        "Unexpected error: {}",
-        err_msg
-    );
+    let error = Bundle::from_json(&corrupted_bundle_json).unwrap_err();
+    assert!(error.to_string().contains("unsupported Rekor entry format"));
 }
 
 /// The certificate must be validated against *every* verified timestamp, not


### PR DESCRIPTION
Follow-up to #176. This moves validation to deserialization boundaries so downstream code works with semantic values rather than repeatedly parsing wire representations.

- deserialize bundle media types and supported Rekor kind/version pairs as enums
- parse checkpoints once while retaining their exact signed envelope bytes
- deserialize Rekor v1 proof hashes into fixed-size SHA-256 values (removing lossy fallback/filtering)
- represent in-toto SHA-256 and SHA-512 subject digests as fixed-size types
- reject malformed or unsupported values while parsing

The temporary base branch mirrors the exact #176 head so this PR shows only the follow-up diff. Once #176 merges, this PR should be retargeted to `main` and the temporary base deleted.

BREAKING CHANGE: bundle media types, Rekor kind/version pairs, checkpoints, proof hashes, and in-toto subject digests now use semantic types.