### PR TITLE
refactor: address Rekor review follow-ups

### DIFF
--- a/crates/sigstore-crypto/src/hash.rs
+++ b/crates/sigstore-crypto/src/hash.rs
@@ -1,7 +1,7 @@
 //! Hashing utilities using aws-lc-rs
 
 use aws_lc_rs::digest::{self, Context, SHA256, SHA384, SHA512};
-use sigstore_types::Sha256Hash;
+use sigstore_types::{Sha256Hash, Sha512Hash};
 use std::io::{self, Read};
 
 /// Hash data using SHA-256, returning a typed hash
@@ -18,10 +18,12 @@ pub fn sha384(data: &[u8]) -> Vec<u8> {
     digest.as_ref().to_vec()
 }
 
-/// Hash data using SHA-512, returning raw bytes
-pub fn sha512(data: &[u8]) -> Vec<u8> {
+/// Hash data using SHA-512, returning a typed hash
+pub fn sha512(data: &[u8]) -> Sha512Hash {
     let digest = digest::digest(&SHA512, data);
-    digest.as_ref().to_vec()
+    let mut result = [0u8; 64];
+    result.copy_from_slice(digest.as_ref());
+    Sha512Hash::from_bytes(result)
 }
 
 /// Incremental SHA-256 hasher
@@ -103,6 +105,19 @@ mod tests {
         let expected =
             hex::decode("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
                 .unwrap();
+        assert_eq!(hash.as_bytes(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_sha512() {
+        let hash = sha512(b"hello");
+        assert_eq!(hash.as_bytes().len(), 64);
+
+        let expected = hex::decode(concat!(
+            "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7",
+            "2323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+        ))
+        .unwrap();
         assert_eq!(hash.as_bytes(), expected.as_slice());
     }
 

--- a/crates/sigstore-rekor/README.md
+++ b/crates/sigstore-rekor/README.md
@@ -49,7 +49,8 @@ let request = HashedRekordV2::new_with_certificate(
     &certificate,
     RekorV2KeyDetails::PkixEcdsaP256Sha256,
 );
-let entry = RekorV2Client::public().create_entry(request).await?;
+let client = RekorV2Client::new("https://log2025-1.rekor.sigstore.dev");
+let entry = client.create_entry(request).await?;
 println!("log index: {}", entry.log_index);
 # Ok(())
 # }
@@ -66,7 +67,7 @@ use sigstore_rekor::RekorV2Client;
 use std::num::NonZeroU8;
 
 # async fn example() -> Result<(), sigstore_rekor::Error> {
-let client = RekorV2Client::public();
+let client = RekorV2Client::new("https://log2025-1.rekor.sigstore.dev");
 let checkpoint = client.get_checkpoint().await?;
 let full_tile = client.get_tile(0, 12, None).await?;
 let partial_entries = client

--- a/crates/sigstore-rekor/src/client.rs
+++ b/crates/sigstore-rekor/src/client.rs
@@ -382,16 +382,6 @@ impl RekorV2Client {
         }
     }
 
-    /// Create a client for the public Sigstore Rekor v2 instance.
-    pub fn public() -> Self {
-        Self::new(RekorApiVersion::V2.default_url())
-    }
-
-    /// Create a client for the Sigstore staging Rekor v2 instance.
-    pub fn staging() -> Self {
-        Self::new(RekorApiVersion::V2.default_staging_url())
-    }
-
     /// Create a Rekor v2 hashedrekord entry.
     ///
     /// Rekor v2 returns the protobuf `TransparencyLogEntry` JSON representation

--- a/crates/sigstore-rekor/src/entry.rs
+++ b/crates/sigstore-rekor/src/entry.rs
@@ -46,7 +46,7 @@ pub struct LogEntry {
     /// UUID of the entry (the key in the response map)
     #[serde(skip)]
     pub uuid: EntryUuid,
-    /// Body of the entry (base64 encoded canonicalized body)
+    /// Canonicalized JSON body of the entry.
     pub body: CanonicalizedBody,
     /// Integrated time. Always present in Rekor V1 API responses; `None` for
     /// entries converted from the V2 API, which has no integrated time.

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -441,7 +441,7 @@ fn compute_artifact_digest_algo(artifact: &Artifact<'_>, algo: HashAlgorithm) ->
         Artifact::Blob(bytes) => match algo {
             HashAlgorithm::Sha2256 => Ok(sigstore_crypto::sha256(bytes).as_bytes().to_vec()),
             HashAlgorithm::Sha2384 => Ok(sigstore_crypto::sha384(bytes)),
-            HashAlgorithm::Sha2512 => Ok(sigstore_crypto::sha512(bytes)),
+            HashAlgorithm::Sha2512 => Ok(sigstore_crypto::sha512(bytes).as_bytes().to_vec()),
         },
         Artifact::Digest(digest) => {
             if digest.algorithm() != algo {
@@ -500,8 +500,7 @@ fn verify_dsse_artifact_binding(
     let matches = match artifact {
         Artifact::Blob(bytes) => {
             let sha256 = sigstore_crypto::sha256(bytes);
-            let sha512 = Sha512Hash::try_from_slice(&sigstore_crypto::sha512(bytes))
-                .expect("SHA-512 produces a 64-byte digest");
+            let sha512 = sigstore_crypto::sha512(bytes);
             statement.matches_sha256(&sha256) || statement.matches_sha512(&sha512)
         }
         Artifact::Digest(digest) => match digest.algorithm() {


### PR DESCRIPTION
## Summary

Follow-ups from review comments on the recently merged stack PRs:

- make `sigstore_crypto::sha512` return `Sha512Hash`
- remove redundant conversion in DSSE artifact binding
- clarify `LogEntry::body` docs now that it is a semantic type
- remove `RekorV2Client::public/staging` convenience constructors so examples keep the log URL explicit

## Testing

- `git diff --check`
- Not run: `cargo check` (cargo/rustc unavailable in this environment)
