### PR TITLE
fix(tuf): preserve rollback floors and recheck target authorization

### DIFF
--- a/crates/sigstore-tuf/src/client.rs
+++ b/crates/sigstore-tuf/src/client.rs
@@ -118,10 +118,9 @@ impl Updater {
     /// a fresh `Updater` started against a populated cache treats the cached
     /// versions as the floor that the network must meet or exceed.
     ///
-    /// Best-effort — a cached file that is missing, stale, expired, or no longer
-    /// consistent with the trusted root is simply skipped; the subsequent
-    /// network refresh will replace it. (This mirrors how `python-tuf`'s
-    /// `ngclient` loads its local trusted metadata at startup.)
+    /// Invalid cache files are skipped, but authenticated expired timestamps
+    /// and snapshots still establish version floors. Freshness is required
+    /// separately before metadata can authorize a target.
     fn seed_lower_from_store(&mut self, now: jiff::Timestamp) {
         let Some((ts, snap, tgt)) = self.store.as_ref().map(|s| {
             (
@@ -133,10 +132,10 @@ impl Updater {
             return;
         };
         if let Some(bytes) = ts {
-            let _ = self.trusted.update_timestamp(&bytes, now);
+            let _ = self.trusted.load_cached_timestamp(&bytes);
         }
         if let Some(bytes) = snap {
-            let _ = self.trusted.update_snapshot(&bytes, now);
+            let _ = self.trusted.load_cached_snapshot(&bytes);
         }
         if let Some(bytes) = tgt {
             let _ = self.trusted.update_targets(&bytes, now);
@@ -307,6 +306,8 @@ impl Updater {
                 "refresh() must be called before resolving targets".to_string(),
             ));
         }
+
+        self.trusted.check_target_authorization(now)?;
 
         // Queue of (role_name, delegator_name) to visit, front = next.
         let mut to_visit: Vec<(String, String)> = vec![("targets".to_string(), "root".to_string())];
@@ -581,6 +582,7 @@ mod http {
             let client = reqwest::Client::builder()
                 .connect_timeout(std::time::Duration::from_secs(30))
                 .read_timeout(std::time::Duration::from_secs(60))
+                .timeout(std::time::Duration::from_secs(120))
                 .build()
                 .map_err(|e| Error::Transport(format!("failed to build HTTP client: {e}")))?;
             Ok(Self {

--- a/crates/sigstore-tuf/src/trusted.rs
+++ b/crates/sigstore-tuf/src/trusted.rs
@@ -151,6 +151,16 @@ impl TrustedMetadataSet {
     /// timestamp it already has and the candidate is discarded. The trusted state
     /// is left unchanged in that case.
     pub fn update_timestamp(&mut self, bytes: &[u8], now: jiff::Timestamp) -> Result<()> {
+        self.update_timestamp_inner(bytes, Some(now))
+    }
+
+    // Expired authenticated cache entries still establish rollback floors.
+    // They never authorize target resolution without fresh metadata.
+    pub(crate) fn load_cached_timestamp(&mut self, bytes: &[u8]) -> Result<()> {
+        self.update_timestamp_inner(bytes, None)
+    }
+
+    fn update_timestamp_inner(&mut self, bytes: &[u8], now: Option<jiff::Timestamp>) -> Result<()> {
         let new = Metadata::<Timestamp>::from_slice(bytes)?;
         verify_with_root(&new, &self.root.signed, "timestamp")?;
 
@@ -182,7 +192,9 @@ impl TrustedMetadataSet {
             }
         }
 
-        ensure_not_expired(&new.signed, "timestamp", now)?;
+        if let Some(now) = now {
+            ensure_not_expired(&new.signed, "timestamp", now)?;
+        }
         self.timestamp = Some(new);
         Ok(())
     }
@@ -194,13 +206,23 @@ impl TrustedMetadataSet {
     /// threshold, enforces no per-target rollback versus the trusted snapshot,
     /// and checks expiry.
     pub fn update_snapshot(&mut self, bytes: &[u8], now: jiff::Timestamp) -> Result<()> {
+        self.update_snapshot_inner(bytes, Some(now))
+    }
+
+    pub(crate) fn load_cached_snapshot(&mut self, bytes: &[u8]) -> Result<()> {
+        self.update_snapshot_inner(bytes, None)
+    }
+
+    fn update_snapshot_inner(&mut self, bytes: &[u8], now: Option<jiff::Timestamp>) -> Result<()> {
         let timestamp = self
             .timestamp
             .as_ref()
             .ok_or_else(|| Error::Malformed("cannot load snapshot before timestamp".to_string()))?;
         // The timestamp authorizing this snapshot must itself still be fresh
         // (freeze protection; python-tuf's `_check_final_timestamp`).
-        ensure_not_expired(&timestamp.signed, "timestamp", now)?;
+        if let Some(now) = now {
+            ensure_not_expired(&timestamp.signed, "timestamp", now)?;
+        }
         let pin = timestamp
             .signed
             .snapshot_meta()
@@ -242,10 +264,38 @@ impl TrustedMetadataSet {
             }
         }
 
-        ensure_not_expired(&new.signed, "snapshot", now)?;
+        if let Some(now) = now {
+            ensure_not_expired(&new.signed, "snapshot", now)?;
+        }
         self.snapshot = Some(new);
         // A new snapshot invalidates previously trusted targets.
         self.targets.clear();
+        Ok(())
+    }
+
+    /// Check the entire authorization chain at target-resolution time, including
+    /// version pins that may have changed during an unsuccessful refresh.
+    pub(crate) fn check_target_authorization(&self, now: jiff::Timestamp) -> Result<()> {
+        self.check_root_expired(now)?;
+        self.check_timestamp_expired(now)?;
+        self.check_snapshot_expired(now)?;
+        let timestamp = self.timestamp().ok_or_else(|| {
+            Error::Malformed("refresh() must be called before resolving targets".into())
+        })?;
+        let snapshot = self
+            .snapshot()
+            .ok_or_else(|| Error::Malformed("no trusted snapshot".into()))?;
+        let targets = self
+            .targets_role("targets")
+            .ok_or_else(|| Error::Malformed("no trusted targets".into()))?;
+        ensure_not_expired(targets, "targets", now)?;
+        if timestamp.snapshot_meta().map(|pin| pin.version) != Some(snapshot.version)
+            || snapshot.meta.get("targets.json").map(|pin| pin.version) != Some(targets.version)
+        {
+            return Err(Error::IntegrityMismatch(
+                "incomplete refresh: target authorization pins have changed".into(),
+            ));
+        }
         Ok(())
     }
 

--- a/crates/sigstore-tuf/tests/end_to_end.rs
+++ b/crates/sigstore-tuf/tests/end_to_end.rs
@@ -526,6 +526,83 @@ fn future_spec_version_is_rejected() {
 }
 
 #[tokio::test]
+async fn target_resolution_requires_fresh_metadata_even_after_failed_refresh() {
+    let (repo, root) = build_repo_with_timestamp_expiry("2026-06-02T00:00:00Z");
+    let mut updater = Updater::new(repo, &root).unwrap();
+    updater.refresh(now()).await.unwrap();
+    updater
+        .get_target("delegated/file.txt", now())
+        .await
+        .unwrap();
+    let later = "2026-06-03T00:00:00Z".parse().unwrap();
+    assert!(updater
+        .get_target("delegated/file.txt", later)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("expired"));
+    assert!(updater.refresh(later).await.is_err());
+    assert!(updater
+        .get_target("delegated/file.txt", later)
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn expired_cached_timestamp_preserves_rollback_floor() {
+    let kp = KeyPair::generate_ecdsa_p256().unwrap();
+    let (kid, key) = key_entry(&kp);
+    let sign = |value: Value| envelope(value.clone(), vec![signature(&value, &kid, &kp)]);
+    let role = json!({"keyids":[kid.clone()],"threshold":1});
+    let root = sign(
+        json!({"_type":"root","spec_version":"1.0.0","version":1,"expires":FAR_FUTURE,
+        "keys":{kid.clone():key},"roles":{"root":role,"timestamp":role,"snapshot":role,"targets":role}}),
+    );
+    let targets = sign(
+        json!({"_type":"targets","spec_version":"1.0.0","version":1,"expires":FAR_FUTURE,"targets":{}}),
+    );
+    let snapshot = sign(
+        json!({"_type":"snapshot","spec_version":"1.0.0","version":1,"expires":FAR_FUTURE,"meta":{"targets.json":metafile(&targets,1)}}),
+    );
+    let timestamp = |version, expires| {
+        sign(
+            json!({"_type":"timestamp","spec_version":"1.0.0","version":version,"expires":expires,"meta":{"snapshot.json":metafile(&snapshot,1)}}),
+        )
+    };
+    let mut repo = MemRepo::default();
+    repo.metadata.insert(
+        "timestamp.json".into(),
+        timestamp(2, "2026-06-02T00:00:00Z"),
+    );
+    repo.metadata
+        .insert("snapshot.json".into(), snapshot.clone());
+    repo.metadata.insert("targets.json".into(), targets.clone());
+    let store = Arc::new(MemoryStore::new());
+    let mut updater = Updater::new(repo, &root).unwrap().with_store(store.clone());
+    updater.refresh(now()).await.unwrap();
+    let mut replay = MemRepo::default();
+    replay.metadata.insert(
+        "timestamp.json".into(),
+        timestamp(1, "2027-01-01T00:00:00Z"),
+    );
+    replay.metadata.insert("snapshot.json".into(), snapshot);
+    replay.metadata.insert("targets.json".into(), targets);
+    let mut restarted = Updater::new(replay, &root).unwrap().with_store(store);
+    let error = restarted
+        .refresh("2026-06-03T00:00:00Z".parse().unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        sigstore_tuf::Error::Rollback {
+            trusted: 2,
+            new: 1,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
 async fn expired_metadata_is_rejected() {
     let (repo, root_bytes) = build_repo();
     let mut updater = Updater::new(repo, &root_bytes).unwrap();


### PR DESCRIPTION
Stack: follows #185.

- Preserve authenticated timestamp/snapshot version floors even after cached metadata expires.
- Recheck root, timestamp, snapshot, targets expiry and version pins at target resolution, including after unsuccessful refreshes.
- Bound HTTP retrieval with an overall deadline in addition to inactivity timeouts.
- Add regressions for cross-process replay and target access after expiry/failed refresh.

Validation: cargo test and clippy for sigstore-tuf and sigstore-trust-root, all features.

Signed-off-by: Wolf Vollprecht <w.vollprecht@gmail.com>