### PR TITLE
fix(types)!: checked log indices, unambiguous digests and DSSE verifier binding

### DIFF
--- a/crates/sigstore-bundle/src/builder.rs
+++ b/crates/sigstore-bundle/src/builder.rs
@@ -133,7 +133,7 @@ impl BundleV03 {
 
 /// Helper to create a transparency log entry.
 pub struct TlogEntryBuilder {
-    log_index: u64,
+    log_index: LogIndex,
     log_id: String,
     kind_version: KindVersion,
     integrated_time: Option<jiff::Timestamp>,
@@ -143,14 +143,19 @@ pub struct TlogEntryBuilder {
 }
 
 impl TlogEntryBuilder {
-    /// Create a new tlog entry builder.
-    pub fn new() -> Self {
+    /// Create a builder with the required entry fields.
+    pub fn new(
+        log_index: LogIndex,
+        log_id: LogKeyId,
+        kind_version: KindVersion,
+        body: CanonicalizedBody,
+    ) -> Self {
         Self {
-            log_index: 0,
-            log_id: String::new(),
-            kind_version: KindVersion::HashedRekordV001,
+            log_index,
+            log_id: log_id.as_str().to_owned(),
+            kind_version,
             integrated_time: None,
-            canonicalized_body: Vec::new(),
+            canonicalized_body: body.as_bytes().to_vec(),
             inclusion_promise: None,
             inclusion_proof: None,
         }
@@ -166,13 +171,10 @@ impl TlogEntryBuilder {
     /// * `kind_version` - The typed Rekor entry format
     pub fn from_log_entry(entry: &LogEntry, kind_version: KindVersion) -> TypesResult<Self> {
         // Convert hex log_id to base64 using the type-safe method
-        let log_id_base64 = entry
-            .log_id
-            .to_base64()
-            .unwrap_or_else(|_| entry.log_id.to_string());
+        let log_id_base64 = entry.log_id.to_base64()?;
 
         let mut builder = Self {
-            log_index: entry.log_index,
+            log_index: LogIndex::new(entry.log_index)?,
             log_id: log_id_base64,
             kind_version,
             integrated_time: entry.integrated_time,
@@ -191,7 +193,7 @@ impl TlogEntryBuilder {
 
             if let Some(proof) = &verification.inclusion_proof {
                 builder.inclusion_proof = Some(InclusionProof {
-                    log_index: LogIndex::new(proof.log_index),
+                    log_index: LogIndex::new(proof.log_index)?,
                     root_hash: proof.root_hash,
                     tree_size: proof.tree_size,
                     hashes: proof.hashes.clone(),
@@ -204,7 +206,7 @@ impl TlogEntryBuilder {
     }
 
     /// Set the log index.
-    pub fn log_index(mut self, index: u64) -> Self {
+    pub fn log_index(mut self, index: LogIndex) -> Self {
         self.log_index = index;
         self
     }
@@ -240,7 +242,7 @@ impl TlogEntryBuilder {
         checkpoint: String,
     ) -> TypesResult<Self> {
         self.inclusion_proof = Some(InclusionProof {
-            log_index: LogIndex::new(log_index),
+            log_index: LogIndex::new(log_index)?,
             root_hash,
             tree_size,
             hashes,
@@ -252,7 +254,7 @@ impl TlogEntryBuilder {
     /// Build the transparency log entry.
     pub fn build(self) -> TransparencyLogEntry {
         TransparencyLogEntry {
-            log_index: LogIndex::new(self.log_index),
+            log_index: self.log_index,
             log_id: LogId {
                 key_id: LogKeyId::new(self.log_id),
             },
@@ -265,8 +267,13 @@ impl TlogEntryBuilder {
     }
 }
 
-impl Default for TlogEntryBuilder {
-    fn default() -> Self {
-        Self::new()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rekor_index_overflow_returns_an_error() {
+        let entry: LogEntry = serde_json::from_str(r#"{"body":"e30=","integratedTime":0,"logID":"0000000000000000000000000000000000000000000000000000000000000000","logIndex":18446744073709551615}"#).unwrap();
+        assert!(TlogEntryBuilder::from_log_entry(&entry, KindVersion::HashedRekordV001).is_err());
     }
 }

--- a/crates/sigstore-bundle/tests/bundle_v3_tests.rs
+++ b/crates/sigstore-bundle/tests/bundle_v3_tests.rs
@@ -73,7 +73,7 @@ fn test_parse_v3_bundle() {
     // Check tlog entries
     assert_eq!(bundle.verification_material.tlog_entries.len(), 1);
     let entry = &bundle.verification_material.tlog_entries[0];
-    assert_eq!(entry.log_index, LogIndex::new(25915956));
+    assert_eq!(entry.log_index, LogIndex::new(25915956).unwrap());
     assert_eq!(
         entry.integrated_time,
         Some(jiff::Timestamp::from_second(1712085549).unwrap())
@@ -86,7 +86,7 @@ fn test_parse_v3_bundle() {
 
     // Check inclusion proof details
     let proof = entry.inclusion_proof.as_ref().unwrap();
-    assert_eq!(proof.log_index, LogIndex::new(25901137));
+    assert_eq!(proof.log_index, LogIndex::new(25901137).unwrap());
     assert_eq!(proof.tree_size, 25901138);
     assert_eq!(proof.hashes.len(), 11);
 }

--- a/crates/sigstore-bundle/tests/bundle_versions_tests.rs
+++ b/crates/sigstore-bundle/tests/bundle_versions_tests.rs
@@ -420,7 +420,7 @@ fn test_structural_validation_rejects_out_of_range_log_index() {
         .inclusion_proof
         .as_mut()
         .expect("bundle has inclusion proof");
-    proof.log_index = sigstore_types::LogIndex::new(proof.tree_size);
+    proof.log_index = sigstore_types::LogIndex::new(proof.tree_size).unwrap();
 
     let result = validate_bundle(&bundle);
     assert!(

--- a/crates/sigstore-types/src/encoding.rs
+++ b/crates/sigstore-types/src/encoding.rs
@@ -13,6 +13,27 @@ use crate::error::{Error, Result};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 
+// ProtoJSON bytes permit standard/URL-safe alphabets, with or without padding.
+fn decode_protojson_base64(value: &str) -> std::result::Result<Vec<u8>, base64::DecodeError> {
+    use base64::{
+        alphabet,
+        engine::{
+            general_purpose::{GeneralPurpose, GeneralPurposeConfig},
+            DecodePaddingMode,
+        },
+    };
+    let alphabet = if value.contains(['-', '_']) {
+        &alphabet::URL_SAFE
+    } else {
+        &alphabet::STANDARD
+    };
+    GeneralPurpose::new(
+        alphabet,
+        GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent),
+    )
+    .decode(value)
+}
+
 // ============================================================================
 // Serde helper modules (for use with raw Vec<u8> when needed)
 // ============================================================================
@@ -36,7 +57,7 @@ pub mod base64_bytes {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        STANDARD.decode(s).map_err(serde::de::Error::custom)
+        super::decode_protojson_base64(&s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -61,8 +82,7 @@ pub mod base64_bytes_option {
     {
         let opt: Option<String> = Option::deserialize(deserializer)?;
         match opt {
-            Some(s) => STANDARD
-                .decode(s)
+            Some(s) => super::decode_protojson_base64(&s)
                 .map(Some)
                 .map_err(serde::de::Error::custom),
             None => Ok(None),
@@ -176,8 +196,7 @@ macro_rules! base64_newtype {
 
             /// Create from base64-encoded string
             pub fn from_base64(s: &str) -> Result<Self> {
-                let bytes = base64::engine::general_purpose::STANDARD
-                    .decode(s)
+                let bytes = decode_protojson_base64(s)
                     .map_err(|e| Error::InvalidEncoding(format!("invalid base64: {}", e)))?;
                 Ok(Self(bytes))
             }
@@ -452,9 +471,11 @@ impl std::fmt::Display for EntryUuid {
 pub struct LogIndex(u64);
 
 impl LogIndex {
-    pub fn new(index: u64) -> Self {
-        assert!(index <= i64::MAX as u64, "log index exceeds protobuf int64");
-        Self(index)
+    pub fn new(index: u64) -> Result<Self> {
+        if index > i64::MAX as u64 {
+            return Err(Error::Validation("log index exceeds protobuf int64".into()));
+        }
+        Ok(Self(index))
     }
 
     pub fn value(self) -> u64 {
@@ -466,8 +487,9 @@ impl LogIndex {
     }
 }
 
-impl From<u64> for LogIndex {
-    fn from(index: u64) -> Self {
+impl TryFrom<u64> for LogIndex {
+    type Error = Error;
+    fn try_from(index: u64) -> Result<Self> {
         Self::new(index)
     }
 }
@@ -510,19 +532,14 @@ impl<'de> Deserialize<'de> for LogIndex {
             {
                 let value = u64::try_from(value)
                     .map_err(|_| de::Error::custom(format!("negative log index: {value}")))?;
-                Ok(LogIndex::new(value))
+                LogIndex::new(value).map_err(de::Error::custom)
             }
 
             fn visit_u64<E>(self, value: u64) -> std::result::Result<LogIndex, E>
             where
                 E: de::Error,
             {
-                if value > i64::MAX as u64 {
-                    return Err(de::Error::custom(format!(
-                        "log index exceeds protobuf int64: {value}"
-                    )));
-                }
-                Ok(LogIndex::new(value))
+                LogIndex::new(value).map_err(de::Error::custom)
             }
 
             fn visit_str<E>(self, value: &str) -> std::result::Result<LogIndex, E>
@@ -755,8 +772,7 @@ impl Sha256Hash {
     }
 
     pub fn from_base64(s: &str) -> Result<Self> {
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(s)
+        let bytes = decode_protojson_base64(s)
             .map_err(|e| Error::InvalidEncoding(format!("invalid base64: {}", e)))?;
         Self::try_from_slice(&bytes)
     }
@@ -879,6 +895,13 @@ impl DigestBytes {
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
+
+    /// Decode an explicitly hex-encoded digest (wire JSON uses base64 instead).
+    pub fn from_hex(value: &str) -> Result<Self> {
+        hex::decode(value)
+            .map(Self)
+            .map_err(|e| Error::InvalidEncoding(e.to_string()))
+    }
 }
 
 impl AsRef<[u8]> for DigestBytes {
@@ -920,13 +943,7 @@ impl<'de> serde::Deserialize<'de> for DigestBytes {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        if s.len() % 2 == 0 && s.chars().all(|c| c.is_ascii_hexdigit()) {
-            let bytes = hex::decode(&s).map_err(serde::de::Error::custom)?;
-            return Ok(DigestBytes(bytes));
-        }
-        let bytes = base64::engine::general_purpose::STANDARD
-            .decode(&s)
-            .map_err(serde::de::Error::custom)?;
+        let bytes = decode_protojson_base64(&s).map_err(serde::de::Error::custom)?;
         Ok(DigestBytes(bytes))
     }
 }
@@ -1144,6 +1161,29 @@ impl std::fmt::Display for HexHash {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn checked_index_and_digest_wire_roundtrips() {
+        assert!(LogIndex::new(u64::MAX).is_err());
+        assert!(serde_json::from_str::<LogIndex>(&u64::MAX.to_string()).is_err());
+        for bytes in [vec![0; 48], vec![0xff; 32], vec![0xfb; 64]] {
+            let digest = DigestBytes::from_bytes(bytes.clone());
+            assert_eq!(
+                serde_json::from_str::<DigestBytes>(&serde_json::to_string(&digest).unwrap())
+                    .unwrap(),
+                digest
+            );
+            for engine in [
+                base64::engine::general_purpose::STANDARD,
+                base64::engine::general_purpose::STANDARD_NO_PAD,
+                base64::engine::general_purpose::URL_SAFE,
+                base64::engine::general_purpose::URL_SAFE_NO_PAD,
+            ] {
+                let json = serde_json::to_string(&engine.encode(&bytes)).unwrap();
+                assert_eq!(serde_json::from_str::<DigestBytes>(&json).unwrap(), digest);
+            }
+        }
+    }
 
     #[test]
     fn test_der_certificate_roundtrip() {

--- a/crates/sigstore-verify/src/verify_impl/rekor.rs
+++ b/crates/sigstore-verify/src/verify_impl/rekor.rs
@@ -39,7 +39,7 @@ pub(crate) fn verify_tlog_consistency_with_key(
                 managed_key,
             )?,
             (SignatureContent::DsseEnvelope(envelope), KindVersion::DsseV001) => {
-                verify_dsse_v001(entry, envelope, bundle)?
+                verify_dsse_v001(entry, envelope, bundle, managed_key)?
             }
             (SignatureContent::DsseEnvelope(envelope), KindVersion::IntotoV002) => {
                 verify_intoto_v002(entry, envelope, bundle, managed_key)?
@@ -79,6 +79,7 @@ fn verify_dsse_v001(
     entry: &TransparencyLogEntry,
     envelope: &sigstore_types::DsseEnvelope,
     bundle: &Bundle,
+    managed_key: Option<&DerPublicKey>,
 ) -> Result<()> {
     let body = RekorEntryBody::from_base64_json(
         &entry.canonicalized_body.to_base64(),
@@ -87,17 +88,23 @@ fn verify_dsse_v001(
     )
     .map_err(|e| Error::Verification(format!("failed to parse Rekor body: {}", e)))?;
 
-    let (expected_hash, rekor_signatures) = match &body {
-        RekorEntryBody::DsseV001(dsse_body) => (
-            &dsse_body.spec.payload_hash.value,
-            &dsse_body.spec.signatures,
-        ),
+    let (payload_hash, rekor_signatures) = match &body {
+        RekorEntryBody::DsseV001(dsse_body) => {
+            (&dsse_body.spec.payload_hash, &dsse_body.spec.signatures)
+        }
         _ => {
             return Err(Error::Verification(
                 "expected DSSE v0.0.1 body, got different type".to_string(),
             ))
         }
     };
+
+    if payload_hash.algorithm != HashAlgorithm::Sha2256 {
+        return Err(Error::Verification(
+            "unsupported DSSE payload hash algorithm".into(),
+        ));
+    }
+    let expected_hash = &payload_hash.value;
 
     // Verify payload hash (v0.0.1 uses hex encoding)
     let payload_bytes = envelope.payload.as_bytes();
@@ -111,16 +118,7 @@ fn verify_dsse_v001(
         )));
     }
 
-    // Extract the signing certificate from the bundle. Key-based bundles
-    // carry no certificate (the Rekor verifier is a public key), so only the
-    // signature bytes can be compared for them.
-    let bundle_cert = match &bundle.verification_material.content {
-        VerificationMaterialContent::X509CertificateChain { certificates } => {
-            certificates.first().map(|c| c.raw_bytes.clone())
-        }
-        VerificationMaterialContent::Certificate(cert) => Some(cert.raw_bytes.clone()),
-        VerificationMaterialContent::PublicKey { .. } => None,
-    };
+    let bundle_cert = bundle.signing_certificate();
 
     // Verify that the signature in the bundle matches what's in Rekor
     // This prevents signature substitution attacks
@@ -139,7 +137,7 @@ fn verify_dsse_v001(
             "DSSE signature in bundle does not match any signature in Rekor entry (signature or verifier mismatch)".to_string(),
         ));
     }
-    if let Some(cert) = &bundle_cert {
+    if let Some(cert) = bundle_cert {
         // Convert Rekor's PEM verifier to DER for canonical comparison
         let rekor_cert_der = rekor_sig
             .parse_certificate()
@@ -147,6 +145,26 @@ fn verify_dsse_v001(
         if cert.as_bytes() != rekor_cert_der.as_bytes() {
             return Err(Error::Verification(
                 "DSSE signature in bundle does not match any signature in Rekor entry (signature or verifier mismatch)".to_string(),
+            ));
+        }
+    } else {
+        let expected_key = managed_key.ok_or_else(|| {
+            Error::Verification(
+                "DSSE Rekor signature cannot be bound without the managed public key".into(),
+            )
+        })?;
+        let rekor_key = match rekor_sig.parse_certificate() {
+            Ok(cert) => certificate_public_key(&cert)?,
+            Err(_) => {
+                let pem = std::str::from_utf8(rekor_sig.verifier.as_bytes())
+                    .map_err(|e| Error::Verification(format!("invalid DSSE verifier: {e}")))?;
+                DerPublicKey::from_pem(pem)
+                    .map_err(|e| Error::Verification(format!("invalid DSSE verifier: {e}")))?
+            }
+        };
+        if rekor_key != *expected_key {
+            return Err(Error::Verification(
+                "DSSE managed public key does not match the Rekor verifier".into(),
             ));
         }
     }

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -371,7 +371,7 @@ fn test_full_verification_flow() {
     // Extract tlog entry info
     let entry = &bundle.verification_material.tlog_entries[0];
     assert_eq!(entry.kind_version.kind(), "dsse");
-    assert_eq!(entry.log_index, LogIndex::new(166143216));
+    assert_eq!(entry.log_index, LogIndex::new(166143216).unwrap());
 
     // Verify inclusion proof
     let proof = entry.inclusion_proof.as_ref().expect("Should have proof");
@@ -414,7 +414,7 @@ fn test_full_verification_flow_happy_path() {
     // Extract tlog entry info
     let entry = &bundle.verification_material.tlog_entries[0];
     assert_eq!(entry.kind_version.kind(), "dsse");
-    assert_eq!(entry.log_index, LogIndex::new(155690850));
+    assert_eq!(entry.log_index, LogIndex::new(155690850).unwrap());
 
     // Verify inclusion proof
     let proof = entry.inclusion_proof.as_ref().expect("Should have proof");
@@ -1458,6 +1458,68 @@ fn rekor_v2_ignores_untrusted_duplicate_inclusion_proof_fields() {
         &staging_root(),
     )
     .unwrap();
+}
+
+#[test]
+fn managed_dsse_verifier_is_bound_even_when_tlog_verification_is_skipped() {
+    use sigstore_types::*;
+    let key = sigstore_crypto::KeyPair::generate_ecdsa_p256().unwrap();
+    let public_key = key.public_key_der().unwrap();
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "_type":"https://in-toto.io/Statement/v1", "predicateType":"example", "predicate":{},
+        "subject":[{"name":"artifact","digest":{"sha256":sigstore_crypto::sha256(b"artifact").to_hex()}}]
+    })).unwrap();
+    let signature = key
+        .sign(&pae("application/vnd.in-toto+json", &payload))
+        .unwrap();
+    let envelope = DsseEnvelope::new(
+        "application/vnd.in-toto+json".into(),
+        PayloadBytes::new(payload.clone()),
+        DsseSignature {
+            sig: signature.clone(),
+            keyid: KeyId::default(),
+        },
+    );
+    let mut bundle = sigstore_bundle::BundleV03::new(
+        sigstore_bundle::VerificationMaterialV03::PublicKey {
+            hint: "opaque".into(),
+        },
+        SignatureContent::DsseEnvelope(envelope),
+    )
+    .into_bundle();
+    let other_key = sigstore_crypto::KeyPair::generate_ecdsa_p256()
+        .unwrap()
+        .public_key_der()
+        .unwrap();
+    for (verifier, valid) in [
+        (public_key.to_pem(), true),
+        (other_key.to_pem(), false),
+        ("not even a public key".into(), false),
+    ] {
+        let body = serde_json::json!({"spec":{
+            "envelopeHash":{"algorithm":"sha256","value":"unused"},
+            "payloadHash":{"algorithm":"sha256","value":sigstore_crypto::sha256(&payload).to_hex()},
+            "signatures":[{"signature":signature.to_base64(),"verifier":PemContent::new(verifier.into_bytes())}]
+        }});
+        bundle.verification_material.tlog_entries = vec![TransparencyLogEntry {
+            log_index: LogIndex::new(0).unwrap(),
+            log_id: LogId {
+                key_id: LogKeyId::from_bytes(&[0; 32]),
+            },
+            kind_version: KindVersion::DsseV001,
+            integrated_time: None,
+            inclusion_promise: None,
+            inclusion_proof: None,
+            canonicalized_body: CanonicalizedBody::new(serde_json::to_vec(&body).unwrap()),
+        }];
+        let result = Verifier::new(&production_root()).verify_with_key(
+            b"artifact",
+            &bundle,
+            &public_key,
+            &PublicKeyVerificationPolicy::default().skip_tlog_unsafe(),
+        );
+        assert_eq!(result.is_ok(), valid, "{result:?}");
+    }
 }
 
 fn managed_key_public_key() -> sigstore_types::DerPublicKey {


### PR DESCRIPTION
Stack: follows #198 (then #185).

- Make LogIndex construction fallible; propagate invalid untrusted Rekor indices instead of panicking.
- Require essential fields when constructing TlogEntryBuilder, removing its invalid default.
- Decode DigestBytes JSON as base64 only; provide an explicit from_hex constructor. Accept ProtoJSON base64 alphabets/padding for byte fields.
- Bind DSSE v0.0.1 logged verifiers to caller-supplied managed keys even when tlog inclusion verification is skipped, and check the payload hash algorithm.

Validation: workspace all-feature tests and strict all-target Clippy passed; regressions include a valid managed-key DSSE signature with correct, substituted and malformed logged verifiers.

Breaking: LogIndex::new returns Result; use TryFrom<u64> instead of From. TlogEntryBuilder::new requires entry fields. Hex digest JSON must be migrated to base64.