### PR TITLE
fix(io): cancellable OAuth callbacks and atomic cache records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/crates/sigstore-cache/Cargo.toml
+++ b/crates/sigstore-cache/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { workspace = true, features = ["fs", "sync", "time"] }
 
 # Directory utilities
 directories.workspace = true
+tempfile.workspace = true
 
 # Time
 jiff.workspace = true

--- a/crates/sigstore-cache/README.md
+++ b/crates/sigstore-cache/README.md
@@ -94,7 +94,10 @@ let staging_cache = FileSystemCache::staging()?;
 let custom_cache = FileSystemCache::for_instance("https://my-sigstore.example.com")?;
 ```
 
-Using `default_location()` without URL namespacing is still available but not recommended if you use multiple instances.
+`default_location()` uses the production namespace. Give each custom endpoint
+its own cache; in-memory adapters must also not be shared across instances.
+Filesystem entries now store expiration and data in one atomically replaced
+`.entry` file. Legacy `.cache`/`.meta` pairs are ignored and removed by `clear()`.
 
 ## Custom Adapters
 

--- a/crates/sigstore-cache/src/filesystem.rs
+++ b/crates/sigstore-cache/src/filesystem.rs
@@ -103,7 +103,25 @@ impl CacheAdapter for FileSystemCache {
                 std::fs::create_dir_all(&dir)?;
                 let mut temp = tempfile::NamedTempFile::new_in(dir)?;
                 temp.write_all(&bytes)?;
-                temp.persist(path).map_err(|e| e.error)?;
+                let mut retries = 0;
+                loop {
+                    match temp.persist(&path) {
+                        Ok(_) => break,
+                        // Windows can temporarily deny replacement while a reader
+                        // holds the previous generation open. Keep the old record
+                        // intact and retry; never delete it before publishing.
+                        Err(error)
+                            if cfg!(windows)
+                                && matches!(error.error.raw_os_error(), Some(5 | 32))
+                                && retries < 10 =>
+                        {
+                            temp = error.file;
+                            retries += 1;
+                            std::thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(error) => return Err(error.error.into()),
+                    }
+                }
                 Ok(())
             })
             .await

--- a/crates/sigstore-cache/src/filesystem.rs
+++ b/crates/sigstore-cache/src/filesystem.rs
@@ -1,5 +1,6 @@
-//! File system based cache implementation
+//! File system cache: expiration and payload are published as one atomic record.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -9,203 +10,79 @@ use tokio::fs;
 
 use crate::{default_cache_dir, CacheAdapter, CacheKey, Result};
 
-/// Convert a URL to a safe directory name
-///
-/// This URL-encodes the URL to create a safe filesystem path, similar to
-/// how sigstore-python handles TUF repository URLs.
-///
-/// # Example
-/// ```ignore
-/// url_to_dirname("https://sigstore.dev") // -> "https%3A%2F%2Fsigstore.dev"
-/// ```
 fn url_to_dirname(url: &str) -> String {
-    // URL-encode the URL to make it safe for use as a directory name
-    // We encode everything except alphanumerics and some safe chars
-    let mut result = String::with_capacity(url.len() * 3);
-    for c in url.chars() {
-        match c {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => {
-                result.push(c);
+    let mut result = String::new();
+    for byte in url.bytes() {
+        match byte {
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'.' => {
+                result.push(byte as char)
             }
-            _ => {
-                // Percent-encode other characters
-                for byte in c.to_string().as_bytes() {
-                    result.push_str(&format!("%{:02X}", byte));
-                }
-            }
+            _ => result.push_str(&format!("%{byte:02X}")),
         }
     }
     result
 }
 
-/// Metadata stored alongside cached values
-#[derive(Debug, Serialize, Deserialize)]
-struct CacheMetadata {
-    /// When the cache entry was created
-    created_at: Timestamp,
-    /// When the cache entry expires
+#[derive(Serialize, Deserialize)]
+struct CacheRecord {
     expires_at: Timestamp,
+    data: Vec<u8>,
 }
 
-/// File system based cache
+/// File system cache with atomic replacement of expiration and payload.
 ///
-/// Stores cached values as files on disk. Each cache key maps to a file,
-/// with a companion metadata file tracking expiration.
-///
-/// # Directory Structure
-///
-/// ```text
-/// cache_dir/
-/// ├── rekor_public_key.cache
-/// ├── rekor_public_key.meta
-/// ├── fulcio_trust_bundle.cache
-/// ├── fulcio_trust_bundle.meta
-/// └── ...
-/// ```
-///
-/// # Example
-///
-/// ```no_run
-/// use sigstore_cache::{FileSystemCache, CacheAdapter, CacheKey};
-/// use std::time::Duration;
-///
-/// # async fn example() -> Result<(), sigstore_cache::Error> {
-/// // Use default location
-/// let cache = FileSystemCache::default_location()?;
-///
-/// // Or specify custom directory
-/// let cache = FileSystemCache::new("/tmp/my-sigstore-cache")?;
-///
-/// // Cache a value
-/// cache.set(
-///     CacheKey::RekorPublicKey,
-///     b"public-key-data",
-///     Duration::from_secs(86400)
-/// ).await?;
-/// # Ok(())
-/// # }
-/// ```
+/// Each key maps to a single `.entry` JSON record. Legacy `.cache`/`.meta`
+/// pairs are ignored, since they cannot guarantee matching generations.
+/// Expired records remain on disk until replaced or explicitly cleared: a
+/// reader must not unlink a concurrent writer's replacement.
 #[derive(Debug, Clone)]
 pub struct FileSystemCache {
-    /// Base directory for cache files
     cache_dir: PathBuf,
 }
 
-/// Sigstore production instance base URL
 pub const SIGSTORE_PRODUCTION_URL: &str = "https://sigstore.dev";
-
-/// Sigstore staging instance base URL
 pub const SIGSTORE_STAGING_URL: &str = "https://sigstage.dev";
 
 impl FileSystemCache {
-    /// Create a new file system cache at the specified directory
-    ///
-    /// The directory will be created if it doesn't exist when writing.
+    /// Use a directory dedicated to one Sigstore instance.
     pub fn new(cache_dir: impl AsRef<Path>) -> Result<Self> {
         Ok(Self {
             cache_dir: cache_dir.as_ref().to_path_buf(),
         })
     }
 
-    /// Create a cache at the default platform-specific location
-    ///
-    /// See [`default_cache_dir`] for the exact locations.
-    ///
-    /// **Warning**: This cache is not namespaced by instance URL. If you use
-    /// multiple Sigstore instances (e.g., production and staging), use
-    /// [`FileSystemCache::for_instance`] instead to avoid cache collisions.
+    /// Use the default cache directory for the production instance.
     pub fn default_location() -> Result<Self> {
-        Self::new(default_cache_dir()?)
+        Self::production()
     }
 
-    /// Create a cache namespaced to a specific Sigstore instance URL
-    ///
-    /// This creates a subdirectory based on the URL, preventing cache collisions
-    /// when using multiple Sigstore instances (e.g., production vs staging).
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use sigstore_cache::FileSystemCache;
-    ///
-    /// # fn example() -> Result<(), sigstore_cache::Error> {
-    /// // Cache for production instance
-    /// let prod_cache = FileSystemCache::for_instance("https://sigstore.dev")?;
-    ///
-    /// // Cache for staging instance (separate directory)
-    /// let staging_cache = FileSystemCache::for_instance("https://sigstage.dev")?;
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// Namespace cache records by instance URL.
     pub fn for_instance(base_url: &str) -> Result<Self> {
-        let namespace = url_to_dirname(base_url);
-        let path = default_cache_dir()?.join(namespace);
-        Self::new(path)
+        // The prefix also keeps values like ".." from becoming parent paths.
+        Self::new(default_cache_dir()?.join(format!("instance-{}", url_to_dirname(base_url))))
     }
 
-    /// Create a cache for the Sigstore production instance
-    ///
-    /// Equivalent to `FileSystemCache::for_instance("https://sigstore.dev")`.
     pub fn production() -> Result<Self> {
         Self::for_instance(SIGSTORE_PRODUCTION_URL)
     }
 
-    /// Create a cache for the Sigstore staging instance
-    ///
-    /// Equivalent to `FileSystemCache::for_instance("https://sigstage.dev")`.
     pub fn staging() -> Result<Self> {
         Self::for_instance(SIGSTORE_STAGING_URL)
     }
 
-    /// Get the path for a cache file
     fn cache_path(&self, key: CacheKey) -> PathBuf {
-        self.cache_dir.join(format!("{}.cache", key.as_str()))
-    }
-
-    /// Get the path for a metadata file
-    fn meta_path(&self, key: CacheKey) -> PathBuf {
-        self.cache_dir.join(format!("{}.meta", key.as_str()))
-    }
-
-    /// Ensure the cache directory exists
-    async fn ensure_dir(&self) -> Result<()> {
-        fs::create_dir_all(&self.cache_dir).await?;
-        Ok(())
-    }
-
-    /// Read and validate metadata, returning None if expired or missing
-    async fn read_valid_metadata(&self, key: CacheKey) -> Result<Option<CacheMetadata>> {
-        let meta_path = self.meta_path(key);
-
-        match fs::read_to_string(&meta_path).await {
-            Ok(content) => {
-                let metadata: CacheMetadata = serde_json::from_str(&content)?;
-                if Timestamp::now() < metadata.expires_at {
-                    Ok(Some(metadata))
-                } else {
-                    // Expired - clean up
-                    let _ = self.remove(key).await;
-                    Ok(None)
-                }
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        self.cache_dir.join(format!("{}.entry", key.as_str()))
     }
 }
 
 impl CacheAdapter for FileSystemCache {
     fn get(&self, key: CacheKey) -> crate::CacheGetFuture<'_> {
         Box::pin(async move {
-            // Check if metadata exists and is valid
-            if self.read_valid_metadata(key).await?.is_none() {
-                return Ok(None);
-            }
-
-            // Read the cached data
-            let cache_path = self.cache_path(key);
-            match fs::read(&cache_path).await {
-                Ok(data) => Ok(Some(data)),
+            match fs::read(self.cache_path(key)).await {
+                Ok(bytes) => {
+                    let record: CacheRecord = serde_json::from_slice(&bytes)?;
+                    Ok((Timestamp::now() < record.expires_at).then_some(record.data))
+                }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
                 Err(e) => Err(e.into()),
             }
@@ -213,62 +90,57 @@ impl CacheAdapter for FileSystemCache {
     }
 
     fn set(&self, key: CacheKey, value: &[u8], ttl: Duration) -> crate::CacheOpFuture<'_> {
-        let value = value.to_vec();
+        let data = value.to_vec();
         Box::pin(async move {
-            self.ensure_dir().await?;
-
-            let now = Timestamp::now();
-            let ttl = SignedDuration::try_from(ttl)
-                .unwrap_or_else(|_| SignedDuration::from_secs(24 * 60 * 60));
-            let metadata = CacheMetadata {
-                created_at: now,
-                expires_at: now + ttl,
-            };
-
-            // Write metadata first (atomic-ish - if this fails, cache entry is invalid)
-            let meta_path = self.meta_path(key);
-            let meta_json = serde_json::to_string_pretty(&metadata)?;
-            fs::write(&meta_path, meta_json).await?;
-
-            // Write the actual data
-            let cache_path = self.cache_path(key);
-            fs::write(&cache_path, &value).await?;
-
-            Ok(())
+            let ttl = SignedDuration::try_from(ttl).map_err(|e| crate::Error::Io(e.to_string()))?;
+            let expires_at = Timestamp::now()
+                .checked_add(ttl)
+                .map_err(|e| crate::Error::Io(e.to_string()))?;
+            let bytes = serde_json::to_vec(&CacheRecord { expires_at, data })?;
+            let dir = self.cache_dir.clone();
+            let path = self.cache_path(key);
+            tokio::task::spawn_blocking(move || -> Result<()> {
+                std::fs::create_dir_all(&dir)?;
+                let mut temp = tempfile::NamedTempFile::new_in(dir)?;
+                temp.write_all(&bytes)?;
+                temp.persist(path).map_err(|e| e.error)?;
+                Ok(())
+            })
+            .await
+            .map_err(|e| crate::Error::Io(e.to_string()))?
         })
     }
 
     fn remove(&self, key: CacheKey) -> crate::CacheOpFuture<'_> {
         Box::pin(async move {
-            let cache_path = self.cache_path(key);
-            let meta_path = self.meta_path(key);
-
-            // Ignore errors - files might not exist
-            let _ = fs::remove_file(&cache_path).await;
-            let _ = fs::remove_file(&meta_path).await;
-
-            Ok(())
+            match fs::remove_file(self.cache_path(key)).await {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(e) => Err(e.into()),
+            }
         })
     }
 
     fn clear(&self) -> crate::CacheOpFuture<'_> {
         Box::pin(async move {
-            // Remove all .cache and .meta files in the cache directory
             let mut entries = match fs::read_dir(&self.cache_dir).await {
                 Ok(entries) => entries,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
                 Err(e) => return Err(e.into()),
             };
-
             while let Some(entry) = entries.next_entry().await? {
                 let path = entry.path();
-                if let Some(ext) = path.extension() {
-                    if ext == "cache" || ext == "meta" {
-                        let _ = fs::remove_file(&path).await;
+                if matches!(
+                    path.extension().and_then(|ext| ext.to_str()),
+                    Some("entry" | "cache" | "meta")
+                ) {
+                    match fs::remove_file(path).await {
+                        Ok(()) => (),
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (),
+                        Err(e) => return Err(e.into()),
                     }
                 }
             }
-
             Ok(())
         })
     }
@@ -277,102 +149,68 @@ impl CacheAdapter for FileSystemCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     #[tokio::test]
-    async fn test_filesystem_cache_roundtrip() {
-        let temp_dir = std::env::temp_dir().join("sigstore-cache-test");
-        let cache = FileSystemCache::new(&temp_dir).unwrap();
-
-        // Clean up from previous runs
-        let _ = cache.clear().await;
-
+    async fn atomic_records_do_not_mix_payloads_and_expiration() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FileSystemCache::new(dir.path()).unwrap();
         let key = CacheKey::RekorPublicKey;
-        let value = b"test-public-key-data";
-
-        // Initially empty
         assert!(cache.get(key).await.unwrap().is_none());
-
-        // Set and get
         cache
-            .set(key, value, Duration::from_secs(3600))
+            .set(key, b"fresh", Duration::from_secs(3600))
             .await
             .unwrap();
-        let retrieved = cache.get(key).await.unwrap().unwrap();
-        assert_eq!(retrieved, value);
-
-        // Remove
+        assert_eq!(cache.get(key).await.unwrap().unwrap(), b"fresh");
+        cache.set(key, b"expired", Duration::ZERO).await.unwrap();
+        assert!(cache.get(key).await.unwrap().is_none());
+        // An uncommitted replacement cannot renew the expired generation.
+        fs::write(dir.path().join("unfinished.tmp"), b"partial new record")
+            .await
+            .unwrap();
+        assert!(cache.get(key).await.unwrap().is_none());
+        let writer = async {
+            for _ in 0..30 {
+                cache
+                    .set(key, b"fresh", Duration::from_secs(3600))
+                    .await
+                    .unwrap();
+                cache.set(key, b"expired", Duration::ZERO).await.unwrap();
+            }
+        };
+        let reader = async {
+            for _ in 0..100 {
+                if let Some(bytes) = cache.get(key).await.unwrap() {
+                    assert_eq!(bytes, b"fresh");
+                }
+            }
+        };
+        tokio::join!(writer, reader);
         cache.remove(key).await.unwrap();
         assert!(cache.get(key).await.unwrap().is_none());
-
-        // Clean up
-        let _ = std::fs::remove_dir_all(&temp_dir);
-    }
-
-    #[tokio::test]
-    async fn test_filesystem_cache_expiration() {
-        let temp_dir = std::env::temp_dir().join("sigstore-cache-expiry-test");
-        let cache = FileSystemCache::new(&temp_dir).unwrap();
-        let _ = cache.clear().await;
-
-        let key = CacheKey::FulcioConfiguration;
-        let value = b"test-config";
-
-        // Set with very short TTL (already expired)
-        cache.set(key, value, Duration::from_secs(0)).await.unwrap();
-
-        // Should be expired
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        assert!(cache.get(key).await.unwrap().is_none());
-
-        // Clean up
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        cache.clear().await.unwrap();
     }
 
     #[test]
-    fn test_url_to_dirname() {
-        // Basic URL encoding
-        assert_eq!(
-            url_to_dirname("https://sigstore.dev"),
-            "https%3A%2F%2Fsigstore.dev"
+    fn instances_are_namespaced() {
+        assert_ne!(
+            FileSystemCache::production().unwrap().cache_dir,
+            FileSystemCache::staging().unwrap().cache_dir
         );
         assert_eq!(
-            url_to_dirname("https://sigstage.dev"),
-            "https%3A%2F%2Fsigstage.dev"
+            FileSystemCache::default_location().unwrap().cache_dir,
+            FileSystemCache::production().unwrap().cache_dir
         );
-
-        // URLs with paths
         assert_eq!(
-            url_to_dirname("https://example.com/path/to/resource"),
-            "https%3A%2F%2Fexample.com%2Fpath%2Fto%2Fresource"
+            url_to_dirname("https://example.com"),
+            "https%3A%2F%2Fexample.com"
         );
-
-        // URLs with ports
         assert_eq!(
-            url_to_dirname("https://localhost:8080"),
-            "https%3A%2F%2Flocalhost%3A8080"
+            FileSystemCache::for_instance("..")
+                .unwrap()
+                .cache_dir
+                .file_name()
+                .unwrap(),
+            "instance-.."
         );
-
-        // Safe characters should not be encoded
-        assert_eq!(url_to_dirname("abc-123_test.txt"), "abc-123_test.txt");
-    }
-
-    #[test]
-    fn test_production_and_staging_paths_differ() {
-        let prod = FileSystemCache::production().unwrap();
-        let staging = FileSystemCache::staging().unwrap();
-
-        // Production and staging should have different cache directories
-        assert_ne!(prod.cache_dir, staging.cache_dir);
-
-        // Both should contain URL-encoded paths
-        assert!(prod
-            .cache_dir
-            .to_string_lossy()
-            .contains("https%3A%2F%2Fsigstore.dev"));
-        assert!(staging
-            .cache_dir
-            .to_string_lossy()
-            .contains("https%3A%2F%2Fsigstage.dev"));
     }
 }

--- a/crates/sigstore-cache/src/memory.rs
+++ b/crates/sigstore-cache/src/memory.rs
@@ -96,14 +96,13 @@ impl InMemoryCache {
 impl CacheAdapter for InMemoryCache {
     fn get(&self, key: CacheKey) -> crate::CacheGetFuture<'_> {
         Box::pin(async move {
-            let entries = self.entries.read().await;
+            // Check expiration and remove the entry under the same lock.
+            let mut entries = self.entries.write().await;
 
             match entries.get(&key) {
                 Some(entry) if !entry.is_expired() => Ok(Some(entry.data.clone())),
                 Some(_) => {
                     // Entry exists but is expired - clean it up
-                    drop(entries);
-                    let mut entries = self.entries.write().await;
                     entries.remove(&key);
                     Ok(None)
                 }
@@ -117,7 +116,9 @@ impl CacheAdapter for InMemoryCache {
         Box::pin(async move {
             let entry = CacheEntry {
                 data: value,
-                expires_at: Instant::now() + ttl,
+                expires_at: Instant::now()
+                    .checked_add(ttl)
+                    .ok_or_else(|| crate::Error::Io("cache TTL exceeds supported range".into()))?,
             };
 
             let mut entries = self.entries.write().await;

--- a/crates/sigstore-oidc/src/oauth.rs
+++ b/crates/sigstore-oidc/src/oauth.rs
@@ -15,8 +15,9 @@ use crate::token::IdentityToken;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
 use url::Url;
 
@@ -63,7 +64,7 @@ impl OAuthConfig {
 }
 
 /// Token response from the OAuth server
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TokenResponse {
     /// Access token
     pub access_token: String,
@@ -75,6 +76,15 @@ pub struct TokenResponse {
     /// ID token (this is what we want for Sigstore)
     #[serde(default)]
     pub id_token: Option<String>,
+}
+
+impl std::fmt::Debug for TokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenResponse")
+            .field("token_type", &self.token_type)
+            .field("expires_in", &self.expires_in)
+            .finish_non_exhaustive()
+    }
 }
 
 /// The authentication mode being used
@@ -150,7 +160,7 @@ impl AuthCallback for DefaultAuthCallback {
         print!("Enter verification code: ");
         io::stdout().flush()?;
         let mut code = String::new();
-        io::stdin().lock().read_line(&mut code)?;
+        io::stdin().read_line(&mut code)?;
         Ok(code.trim().to_string())
     }
 
@@ -360,26 +370,41 @@ impl OAuthClient {
             .await
             .map_err(|e| Error::OAuth(format!("failed to accept connection: {}", e)))?;
 
-        // Convert to std TcpStream for synchronous reading
-        let std_stream = stream
-            .into_std()
-            .map_err(|e| Error::OAuth(format!("failed to convert stream: {}", e)))?;
-
-        std_stream
-            .set_nonblocking(false)
-            .map_err(|e| Error::OAuth(format!("failed to set blocking mode: {}", e)))?;
-
-        let mut reader = BufReader::new(&std_stream);
-        let mut request_line = String::new();
-        reader
-            .read_line(&mut request_line)
-            .map_err(|e| Error::OAuth(format!("failed to read request: {}", e)))?;
-
-        // Parse the request path
-        let path = request_line
-            .split_whitespace()
-            .nth(1)
-            .ok_or_else(|| Error::OAuth("invalid HTTP request".to_string()))?;
+        // Bound the whole header block, including an unterminated request line.
+        // All socket I/O remains async so the enclosing callback timeout works.
+        const MAX_HEADERS: usize = 8192;
+        let mut reader = BufReader::new(stream.take((MAX_HEADERS + 1) as u64));
+        let mut headers = Vec::new();
+        loop {
+            let n = reader
+                .read_until(b'\n', &mut headers)
+                .await
+                .map_err(|e| Error::OAuth(format!("failed to read request: {e}")))?;
+            if n == 0 || headers.len() > MAX_HEADERS {
+                return Err(Error::OAuth("incomplete or oversized HTTP headers".into()));
+            }
+            if headers.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        let headers = std::str::from_utf8(&headers)
+            .map_err(|_| Error::OAuth("invalid HTTP headers".into()))?;
+        let mut request = headers
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .split_whitespace();
+        let method = request.next();
+        let path = request
+            .next()
+            .ok_or_else(|| Error::OAuth("invalid HTTP request".into()))?;
+        if method != Some("GET")
+            || !path.starts_with("/callback?")
+            || request.next() != Some("HTTP/1.1")
+            || request.next().is_some()
+        {
+            return Err(Error::OAuth("invalid callback request".into()));
+        }
 
         let url = Url::parse(&format!("http://localhost{}", path))
             .map_err(|e| Error::OAuth(format!("failed to parse callback URL: {}", e)))?;
@@ -400,15 +425,6 @@ impl OAuthClient {
             }
         }
 
-        // Drain request headers to avoid TCP RST
-        let mut header = String::new();
-        while let Ok(bytes_read) = reader.read_line(&mut header) {
-            if bytes_read == 0 || header == "\r\n" || header == "\n" {
-                break;
-            }
-            header.clear();
-        }
-
         // Send response to browser using templates
         let (status, html) = if let Some(ref err) = error {
             let error_msg = error_description.as_deref().unwrap_or(err);
@@ -424,14 +440,12 @@ impl OAuthClient {
             html
         );
 
-        // Use the raw stream for writing
-        let mut write_stream = std_stream;
-        write_stream
+        reader
+            .get_mut()
+            .get_mut()
             .write_all(response.as_bytes())
-            .map_err(|e| Error::OAuth(format!("failed to send response: {}", e)))?;
-        write_stream
-            .flush()
-            .map_err(|e| Error::OAuth(format!("failed to flush response: {}", e)))?;
+            .await
+            .map_err(|e| Error::OAuth(format!("failed to send response: {e}")))?;
 
         // Check for errors
         if let Some(err) = error {
@@ -469,6 +483,7 @@ impl OAuthClient {
         let response = self
             .client
             .post(&self.config.token_url)
+            .timeout(Duration::from_secs(30))
             .form(&params)
             .send()
             .await
@@ -476,17 +491,23 @@ impl OAuthClient {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(Error::OAuth(format!(
-                "token exchange failed: {} - {}",
-                status, body
-            )));
+            return Err(Error::OAuth(format!("token exchange failed: {status}")));
         }
 
-        let token_response: TokenResponse = response
-            .json()
+        let mut response = response;
+        let mut body = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
             .await
-            .map_err(|e| Error::OAuth(format!("failed to parse token response: {}", e)))?;
+            .map_err(|e| Error::Http(e.to_string()))?
+        {
+            if body.len() + chunk.len() > 1024 * 1024 {
+                return Err(Error::OAuth("token response exceeds 1 MiB".into()));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        let token_response: TokenResponse = serde_json::from_slice(&body)
+            .map_err(|e| Error::OAuth(format!("failed to parse token response: {e}")))?;
 
         let id_token = token_response
             .id_token
@@ -546,6 +567,60 @@ pub async fn get_identity_token_with_options(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn callback_is_bounded_cancellable_and_checks_state() {
+        let client = OAuthClient::sigstore();
+        let callback = DefaultAuthCallback;
+        for (request, valid) in [
+            (
+                "GET /callback?code=ok&state=expected HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                    .to_owned(),
+                true,
+            ),
+            (
+                "GET /callback?code=ok&state=wrong HTTP/1.1\r\n\r\n".to_owned(),
+                false,
+            ),
+            ("x".repeat(8193), false),
+        ] {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let mut socket = tokio::net::TcpStream::connect(listener.local_addr().unwrap())
+                .await
+                .unwrap();
+            socket.write_all(request.as_bytes()).await.unwrap();
+            let result = tokio::time::timeout(
+                Duration::from_secs(1),
+                client.wait_for_callback(&listener, "expected", &callback),
+            )
+            .await
+            .unwrap();
+            assert_eq!(result.is_ok(), valid);
+        }
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mut socket = tokio::net::TcpStream::connect(listener.local_addr().unwrap())
+            .await
+            .unwrap();
+        socket.write_all(b"GET /callback").await.unwrap();
+        assert!(tokio::time::timeout(
+            Duration::from_millis(20),
+            client.wait_for_callback(&listener, "expected", &callback)
+        )
+        .await
+        .is_err());
+    }
+
+    #[test]
+    fn token_response_debug_is_redacted() {
+        let token = TokenResponse {
+            access_token: "access-secret".into(),
+            token_type: "Bearer".into(),
+            expires_in: None,
+            id_token: Some("id-secret".into()),
+        };
+        let debug = format!("{token:?}");
+        assert!(!debug.contains("access-secret") && !debug.contains("id-secret"));
+    }
 
     #[test]
     fn test_oauth_config_sigstore() {

--- a/crates/sigstore-oidc/src/token.rs
+++ b/crates/sigstore-oidc/src/token.rs
@@ -6,12 +6,18 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 
 /// An OIDC identity token
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct IdentityToken {
     /// The raw JWT token
     raw: String,
     /// Parsed claims
     claims: TokenClaims,
+}
+
+impl std::fmt::Debug for IdentityToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdentityToken").finish_non_exhaustive()
+    }
 }
 
 /// Standard OIDC claims we care about
@@ -73,7 +79,10 @@ pub struct FederatedClaims {
 }
 
 impl IdentityToken {
-    /// Parse a JWT token string
+    /// Parse claims from a JWT without authenticating its signature.
+    ///
+    /// These claims are untrusted; Fulcio authenticates the supplied token.
+    /// This method must not be used as an OIDC token verifier.
     pub fn from_jwt(token: &str) -> Result<Self> {
         // JWT format: header.payload.signature
         let parts: Vec<&str> = token.split('.').collect();
@@ -213,5 +222,6 @@ mod tests {
         assert_eq!(token.subject(), "user123");
         assert_eq!(token.email(), Some("test@example.com"));
         assert!(!token.is_expired());
+        assert!(!format!("{token:?}").contains(&jwt));
     }
 }


### PR DESCRIPTION
Stack: follows #199.

- Keep OAuth callback sockets async and bound the total request headers, so the existing deadline cannot be defeated by a partial request.
- Bound token exchange responses/deadlines and redact bearer tokens from Debug/error output.
- Check/remove expired memory entries under one lock.
- Replace filesystem expiration and data together using an existing workspace dependency (tempfile); never unlink a replacement during expiry reads. Reject overflowing TTLs.
- Default filesystem caches to the production namespace. Legacy two-file records are ignored.

Validation: all-feature tests and strict all-target Clippy for sigstore-cache and sigstore-oidc. Regressions cover partial/oversized callbacks, state mismatch, redaction, expiry and concurrent cache access.