### PR TITLE
ci(msrv): declare and test Rust 1.86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,16 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  msrv:
+    name: MSRV (Rust 1.86)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: rustup toolchain install 1.86.0 --profile minimal
+      - run: cargo +1.86.0 check --workspace --all-features --locked
+
   audit:
     name: Cargo Audit
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/prefix-dev/sigstore-rust"
-rust-version = "1.70"
+rust-version = "1.86"
 
 [workspace.dependencies]
 # Serialization

--- a/crates/sigstore-crypto/src/hash.rs
+++ b/crates/sigstore-crypto/src/hash.rs
@@ -441,7 +441,7 @@ mod tests {
         struct Failing;
         impl Read for Failing {
             fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
-                Err(io::Error::new(io::ErrorKind::Other, "disk on fire"))
+                Err(io::Error::other("disk on fire"))
             }
         }
         let mut hasher = Sha256Hasher::new();

--- a/crates/sigstore-crypto/src/keyring.rs
+++ b/crates/sigstore-crypto/src/keyring.rs
@@ -57,7 +57,7 @@ impl Keyring {
             .filter(|entry| {
                 entry
                     .validity
-                    .map_or(true, |validity| validity.contains(time))
+                    .is_none_or(|validity| validity.contains(time))
             })
             .map(|entry| &entry.key)
     }
@@ -76,7 +76,7 @@ impl Keyring {
             .filter(|entry| {
                 entry
                     .validity
-                    .map_or(true, |validity| validity.has_started_by(time))
+                    .is_none_or(|validity| validity.has_started_by(time))
             })
             .map(|entry| &entry.key)
     }
@@ -96,7 +96,7 @@ impl Keyring {
             (id.as_bytes()[..4] == hint
                 && entry
                     .validity
-                    .map_or(true, |validity| validity.has_started_by(time)))
+                    .is_none_or(|validity| validity.has_started_by(time)))
             .then_some(&entry.key)
         })
     }

--- a/crates/sigstore-trust-root/src/trusted_root.rs
+++ b/crates/sigstore-trust-root/src/trusted_root.rs
@@ -168,7 +168,7 @@ pub type ValidityPeriod = TimeRange;
 /// whose window has not started yet are excluded; expired instances are kept
 /// because historical entries/certificates were created while they were valid.
 fn usable_for_verification(valid_for: Option<&ValidityPeriod>, now: Timestamp) -> bool {
-    valid_for.map_or(true, |period| period.has_started_by(now))
+    valid_for.is_none_or(|period| period.has_started_by(now))
 }
 
 fn key_id(log_id: &LogKeyId) -> Result<Sha256Hash> {
@@ -263,7 +263,7 @@ impl TrustedRoot {
                 let valid = tlog
                     .public_key
                     .valid_for
-                    .map_or(true, |period| period.contains(time));
+                    .is_none_or(|period| period.contains(time));
                 if valid {
                     return Ok(tlog.public_key.raw_bytes.clone());
                 }

--- a/crates/sigstore-tsa/src/verify.rs
+++ b/crates/sigstore-tsa/src/verify.rs
@@ -274,7 +274,7 @@ pub fn verify_timestamp_for_authority(
     let authorized = authority
         .valid_for
         .as_ref()
-        .map_or(true, |window| window.contains(result.time));
+        .is_none_or(|window| window.contains(result.time));
     if !authorized {
         return Err(Error::TimestampOutsideValidity { time: result.time });
     }

--- a/crates/sigstore-types/src/time_range.rs
+++ b/crates/sigstore-types/src/time_range.rs
@@ -37,7 +37,7 @@ impl TimeRange {
     ///
     /// A missing `end` is unbounded on that side.
     pub fn contains(&self, time: Timestamp) -> bool {
-        time >= self.start && self.end.map_or(true, |end| time <= end)
+        time >= self.start && self.end.is_none_or(|end| time <= end)
     }
 
     /// Whether this window had started by `time` (i.e. `start <= time`),


### PR DESCRIPTION
Small follow-up to #202.

- Declare the actual Linux MSRV for the locked dependencies and check it in CI.
- Apply the is_none_or/Error::other suggestions that Clippy enables at this MSRV.

Validation: cargo +1.86.0 check --workspace --all-features --locked and strict workspace Clippy passed.