### PR TITLE
ci(features): check isolated crates and make TLS checks fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
       - run: rustup toolchain install 1.86.0 --profile minimal
       - run: cargo +1.86.0 check --workspace --all-features --locked
 
+  isolated-features:
+    name: Isolated crate features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: rustup toolchain install
+      - run: python3 scripts/check-features.py
+
   audit:
     name: Cargo Audit
     runs-on: ubuntu-latest

--- a/scripts/check-features.py
+++ b/scripts/check-features.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Check each workspace crate without workspace-wide feature unification."""
+import json
+import subprocess
+
+metadata = json.loads(subprocess.check_output(
+    ["cargo", "metadata", "--no-deps", "--format-version", "1"], text=True
+))
+for package in metadata["packages"]:
+    variants = [[], ["--no-default-features"]]
+    variants += [
+        ["--no-default-features", "--features", feature]
+        for feature in package["features"]
+        if feature != "default"
+    ]
+    for flags in variants:
+        subprocess.run(
+            ["cargo", "check", "--locked", "--package", package["name"], *flags],
+            check=True,
+        )

--- a/scripts/check-native-tls.sh
+++ b/scripts/check-native-tls.sh
@@ -1,90 +1,20 @@
 #!/bin/bash
-# Check that a specific crate is not pulled in as a dependency
-# Useful for verifying feature flag configurations (e.g., native-tls vs rustls)
-
+# Check normal dependencies; Cargo failures must not look like a clean tree.
 set -euo pipefail
-
-# =============================================================================
-# Configuration - customize these for your repository
-# =============================================================================
-
-# Crate to check for (script fails if this crate is found in dependency tree)
-FORBIDDEN_CRATE="rustls"
-
-# Features to exclude when testing (space-separated)
-# These features will NOT be enabled during the check
-# Note: Auto-generated features for optional deps (dep:X) are automatically excluded
-EXCLUDE_FEATURES="rustls default tuf"
-
-# Packages to skip entirely (space-separated)
-# Use this for packages that are known to require the forbidden crate
-SKIP_PACKAGES="sigstore-trust-root"
-
-# =============================================================================
-# Script logic - typically no changes needed below
-# =============================================================================
-
-# Build jq filter for excluded features
-exclude_filter=""
-for feat in $EXCLUDE_FEATURES; do
-    if [ -n "$exclude_filter" ]; then
-        exclude_filter="$exclude_filter and "
-    fi
-    exclude_filter="${exclude_filter}.key != \"$feat\""
-done
-
-# Get workspace metadata once
 metadata=$(cargo metadata --no-deps --format-version 1)
-
-# Get all workspace packages
-packages=$(echo "$metadata" | jq -r '.packages[].name')
-
-failed=0
-checked=0
-skipped=0
-
-for package in $packages; do
-    # Skip packages that are known to require the forbidden crate
-    if [ -n "$SKIP_PACKAGES" ] && echo "$SKIP_PACKAGES" | grep -qw "$package"; then
-        echo "SKIP: $package (known $FORBIDDEN_CRATE dependency)"
-        ((++skipped))
-        continue
-    fi
-
-    ((++checked))
-
-    features=$(echo "$metadata" | jq -r --arg pkg "$package" '
-        .packages[] | select(.name == $pkg) | .features | to_entries[] |
-        select(.value != ["dep:\(.key)"]) |
-        select('"$exclude_filter"') |
-        .key
-    ' | tr '\n' ',' | sed 's/,$//')
-
-    # Run cargo tree with all features except excluded features (prod dependencies only)
+for package in $(echo "$metadata" | jq -r '.packages[].name'); do
+    features=$(echo "$metadata" | jq -r --arg package "$package" '
+        .packages[] | select(.name == $package) | .features | keys |
+        map(select(. == "native-tls" or . == "tuf" or . == "fetch" or . == "cache")) | join(",")
+    ')
+    args=(--package "$package" --locked --no-default-features --edges normal --prefix none)
     if [ -n "$features" ]; then
-        output=$(cargo tree -i "$FORBIDDEN_CRATE" --no-default-features --features "$features" --package "$package" --locked --edges=normal 2>&1 || true)
-    else
-        output=$(cargo tree -i "$FORBIDDEN_CRATE" --no-default-features --package "$package" --locked --edges=normal 2>&1 || true)
+        args+=(--features "$features")
     fi
-
-    if echo "$output" | grep -q "^$FORBIDDEN_CRATE"; then
-        echo "FAIL: $package has $FORBIDDEN_CRATE dependency"
-        if [ -n "$features" ]; then
-            echo "Reproduce: cargo tree -i $FORBIDDEN_CRATE --no-default-features --features \"$features\" --package \"$package\" --locked --edges=normal"
-        else
-            echo "Reproduce: cargo tree -i $FORBIDDEN_CRATE --no-default-features --package \"$package\" --locked --edges=normal"
-        fi
-        echo "$output" | head -20
-        echo ""
-        ((++failed))
-    else
-        echo "OK:   $package"
+    tree=$(cargo tree "${args[@]}")
+    if grep -q '^rustls v' <<< "$tree"; then
+        echo "FAIL: $package pulls in rustls without its rustls feature" >&2
+        exit 1
     fi
+    echo "OK: $package"
 done
-
-echo ""
-echo "Summary: $checked checked, $failed failed, $skipped skipped"
-
-if [ $failed -gt 0 ]; then
-    exit 1
-fi

--- a/scripts/check-native-tls.sh
+++ b/scripts/check-native-tls.sh
@@ -2,8 +2,9 @@
 # Check normal dependencies; Cargo failures must not look like a clean tree.
 set -euo pipefail
 metadata=$(cargo metadata --no-deps --format-version 1)
-for package in $(echo "$metadata" | jq -r '.packages[].name'); do
-    features=$(echo "$metadata" | jq -r --arg package "$package" '
+# jq -j avoids native Windows CRLF leaking into Cargo's package/features arguments.
+for package in $(echo "$metadata" | jq -j '.packages[].name + " "'); do
+    features=$(echo "$metadata" | jq -j --arg package "$package" '
         .packages[] | select(.name == $package) | .features | keys |
         map(select(. == "native-tls" or . == "tuf" or . == "fetch" or . == "cache")) | join(",")
     ')


### PR DESCRIPTION
Small follow-up to #203.

Check each crate with default features, no default features, and each named feature independently. Simplify the native-TLS dependency check so Cargo failures no longer look like success; include the previously skipped trust-root crate.

Validation: both scripts passed locally across the workspace.