### PR TITLE
docs(release): repair examples, license and trust-bootstrap guidance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/prefix-dev/sigstore-rust"
+repository = "https://github.com/sigstore/sigstore-rust"
 rust-version = "1.86"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ Add the crates you need to your `Cargo.toml`:
 ```toml
 [dependencies]
 # For verification only
-sigstore-verify = "0.1"
-sigstore-trust-root = "0.1"
+sigstore-verify = "0.11"
+sigstore-trust-root = "0.11"
+sigstore-types = "0.11"
 
 # For signing
-sigstore-sign = "0.1"
+sigstore-sign = "0.11"
+sigstore-oidc = "0.11"
 ```
 
 ## Usage
@@ -53,25 +55,22 @@ let verifier = Verifier::new(&root);
 // Parse the bundle (contains signature, certificate, transparency log entry)
 let bundle: sigstore_types::Bundle = serde_json::from_str(&bundle_json)?;
 
-// Verify the signature
-verifier.verify(&bundle, artifact_bytes)?;
-
-// Or verify with identity policy
-let policy = VerificationPolicy::new()
-    .issuer("https://token.actions.githubusercontent.com")
-    .subject_regex(r"^https://github\.com/myorg/.*$")?;
-
-verifier.verify_with_policy(&bundle, artifact_bytes, &policy)?;
+// Authorize the expected signer, not just any valid Sigstore identity.
+let policy = VerificationPolicy::default()
+    .require_issuer("https://token.actions.githubusercontent.com")
+    .require_identity("https://github.com/myorg/myrepo/.github/workflows/release.yml@refs/tags/v1.0.0");
+verifier.verify(artifact_bytes, &bundle, &policy)?;
 ```
 
 ### Signing an Artifact
 
 ```rust
-use sigstore_sign::{Signer, SigningConfig};
+use sigstore_sign::{SigningContext, SigningConfig};
 
-// Create a signer (will authenticate via OIDC)
-let config = SigningConfig::production();
-let signer = Signer::new(config).await?;
+let endpoints = sigstore_trust_root::SigningConfig::production().await?;
+let config = SigningConfig::from_tuf_config(&endpoints)?;
+let token = sigstore_oidc::get_identity_token(config.oidc_url.as_deref()).await?;
+let signer = SigningContext::with_config(config).signer(token);
 
 // Sign the artifact - returns a Sigstore bundle
 let bundle = signer.sign(artifact_bytes).await?;
@@ -162,12 +161,15 @@ This library uses [aws-lc-rs](https://github.com/aws/aws-lc-rs) as its cryptogra
 - SHA-256/SHA-384/SHA-512 hashing
 - X.509 certificate parsing and validation
 
-AWS-LC is [FIPS 140-3 validated](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816), making this library suitable for environments with compliance requirements.
+AWS-LC has a [FIPS 140-3 validated module](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816).
+This workspace does not enable a FIPS build by default and does not claim FIPS
+validation for sigstore-rust. Compliance depends on the exact module build,
+configuration, platform, and approved operations.
 
 ## Minimum Supported Rust Version
 
-Rust 1.70 or later.
+Rust 1.86 or later (checked in CI for the locked dependency set on Linux).
 
 ## License
 
-BSD-3-Clause
+Apache-2.0; see [LICENSE](LICENSE).

--- a/crates/sigstore-bundle/README.md
+++ b/crates/sigstore-bundle/README.md
@@ -50,4 +50,4 @@ Used by:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-cache/README.md
+++ b/crates/sigstore-cache/README.md
@@ -139,4 +139,4 @@ Used by:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-crypto/README.md
+++ b/crates/sigstore-crypto/README.md
@@ -52,4 +52,4 @@ This crate provides cryptographic operations for:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-fulcio/README.md
+++ b/crates/sigstore-fulcio/README.md
@@ -40,4 +40,4 @@ Used by:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-merkle/README.md
+++ b/crates/sigstore-merkle/README.md
@@ -46,4 +46,4 @@ Used by:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-oidc/README.md
+++ b/crates/sigstore-oidc/README.md
@@ -62,4 +62,4 @@ Used by:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-sign/README.md
+++ b/crates/sigstore-sign/README.md
@@ -87,4 +87,4 @@ For Tokio files/streams, enable `tokio-util`'s `compat` feature and call
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -52,6 +52,7 @@ async fn main() {
     let mut token: Option<String> = None;
     let mut output: Option<String> = None;
     let mut instance: Option<String> = None;
+    let mut tuf_root_path: Option<String> = None;
     let mut staging = false;
     let mut use_v2 = false;
     let mut positional: Vec<String> = Vec::new();
@@ -83,6 +84,13 @@ async fn main() {
                 }
                 instance = Some(args[i].clone());
             }
+            "--tuf-root" => {
+                i += 1;
+                tuf_root_path = Some(args.get(i).cloned().unwrap_or_else(|| {
+                    eprintln!("Error: --tuf-root requires a file path");
+                    process::exit(2);
+                }));
+            }
             "--staging" => {
                 staging = true;
             }
@@ -111,6 +119,11 @@ async fn main() {
         process::exit(1);
     }
 
+    if (instance.is_some() && staging) || instance.is_some() != tuf_root_path.is_some() {
+        eprintln!("Error: select --staging or --instance with --tuf-root");
+        process::exit(2);
+    }
+
     let artifact_path = &positional[0];
     let output_path = output.unwrap_or_else(|| format!("{}.sigstore.json", artifact_path));
 
@@ -131,9 +144,13 @@ async fn main() {
     // Create signing context with appropriate API version
     let tuf_config = if let Some(ref url) = instance {
         println!("  Using: custom instance ({})", url);
+        let bootstrap = fs::read(tuf_root_path.as_ref().unwrap()).unwrap_or_else(|e| {
+            eprintln!("Error reading trusted TUF bootstrap: {e}");
+            process::exit(2);
+        });
         let config = sigstore_trust_root::tuf::TufConfig::custom(
             url,
-            sigstore_trust_root::tuf::TufBootstrap::UnsafeCachedRoot,
+            sigstore_trust_root::tuf::TufBootstrap::trusted(bootstrap),
         );
         sigstore_trust_root::SigningConfig::from_tuf(config)
             .await
@@ -251,7 +268,11 @@ async fn main() {
     }
 
     let extra_flags = if let Some(ref url) = instance {
-        format!("--instance {} ", url)
+        format!(
+            "--instance {} --tuf-root {} ",
+            url,
+            tuf_root_path.as_ref().unwrap()
+        )
     } else if staging {
         "--staging ".to_string()
     } else {
@@ -304,7 +325,9 @@ fn print_usage(program: &str) {
     eprintln!("Options:");
     eprintln!("  -o, --output <FILE>  Output bundle path (default: <artifact>.sigstore.json)");
     eprintln!("  -t, --token <TOKEN>  OIDC identity token (skips interactive auth)");
-    eprintln!("      --instance <URL> Use a custom Sigstore instance");
+    eprintln!(
+        "      --instance <URL> --tuf-root <FILE>  Custom instance with trusted TUF bootstrap"
+    );
     eprintln!("      --staging        Use Sigstore staging infrastructure");
     eprintln!("      --v2             Use Rekor V2 API (uses log2025-1.rekor.sigstore.dev)");
     eprintln!("  -h, --help           Print this help message");

--- a/crates/sigstore-trust-root/README.md
+++ b/crates/sigstore-trust-root/README.md
@@ -114,4 +114,4 @@ Used by:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-tsa/README.md
+++ b/crates/sigstore-tsa/README.md
@@ -46,4 +46,4 @@ Used by:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-tuf/README.md
+++ b/crates/sigstore-tuf/README.md
@@ -67,4 +67,4 @@ Used by:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-types/README.md
+++ b/crates/sigstore-types/README.md
@@ -47,4 +47,4 @@ This crate is typically used indirectly through the higher-level APIs:
 
 ## License
 
-BSD-3-Clause
+Apache-2.0

--- a/crates/sigstore-verify/README.md
+++ b/crates/sigstore-verify/README.md
@@ -110,4 +110,4 @@ let policy = VerificationPolicy::default()
 
 ## License
 
-BSD-3-Clause
+Apache-2.0


### PR DESCRIPTION
Small follow-up to #202.

- Fix README snippets to use current APIs and explicit signer requirements.
- Align license/repository/version/MSRV documentation with Cargo and LICENSE; qualify FIPS claims.
- Require `--tuf-root` with custom instances in the signing example, matching the verification example.

Most changed files contain only the one-line license correction. Validation: examples, workspace tests, documentation build and Clippy passed.
