### PR TITLE
refactor(crypto): share certificate, managed-key and TSA algorithm resolution

### DIFF
--- a/crates/sigstore-crypto/src/x509.rs
+++ b/crates/sigstore-crypto/src/x509.rs
@@ -10,8 +10,6 @@ use x509_cert::der::{Decode, Encode};
 use x509_cert::Certificate;
 
 // OID constants for algorithm identification
-use const_oid::db::rfc5912::{ID_EC_PUBLIC_KEY, RSA_ENCRYPTION, SECP_256_R_1, SECP_384_R_1};
-use const_oid::db::rfc8410::ID_ED_25519;
 use const_oid::ObjectIdentifier;
 
 /// Fulcio issuer OID: 1.3.6.1.4.1.57264.1.1
@@ -58,7 +56,7 @@ pub fn parse_certificate_info(cert_der: &[u8]) -> Result<CertificateInfo> {
     let public_key = DerPublicKey::new(public_key_der);
 
     // Determine key algorithm from algorithm OID and parameters
-    let key_algorithm = determine_key_algorithm(public_key_info)?;
+    let key_algorithm = KeyAlgorithm::from_spki(&public_key)?;
 
     // Extract identity from SAN extension
     let identity = extract_san_identity(&cert)?;
@@ -74,48 +72,6 @@ pub fn parse_certificate_info(cert_der: &[u8]) -> Result<CertificateInfo> {
         public_key,
         key_algorithm,
     })
-}
-
-/// Determine the key algorithm from SubjectPublicKeyInfo
-fn determine_key_algorithm(
-    spki: &x509_cert::spki::SubjectPublicKeyInfoOwned,
-) -> Result<KeyAlgorithm> {
-    let alg_oid = spki.algorithm.oid;
-
-    if alg_oid == ID_EC_PUBLIC_KEY {
-        // EC key - need to check curve parameter
-        if let Some(params) = &spki.algorithm.parameters {
-            // params.value() returns the raw OID bytes (without tag/length)
-            // Use from_bytes which expects raw OID content bytes
-            let curve_oid = ObjectIdentifier::from_bytes(params.value()).map_err(|e| {
-                Error::InvalidCertificate(format!("failed to parse EC curve OID: {}", e))
-            })?;
-
-            if curve_oid == SECP_256_R_1 {
-                return Ok(KeyAlgorithm::EcdsaP256);
-            } else if curve_oid == SECP_384_R_1 {
-                return Ok(KeyAlgorithm::EcdsaP384);
-            } else {
-                return Err(Error::InvalidCertificate(format!(
-                    "unsupported EC curve OID: {}",
-                    curve_oid
-                )));
-            }
-        } else {
-            return Err(Error::InvalidCertificate(
-                "EC key missing curve parameters".to_string(),
-            ));
-        }
-    } else if alg_oid == RSA_ENCRYPTION {
-        return Ok(KeyAlgorithm::Rsa);
-    } else if alg_oid == ID_ED_25519 {
-        return Ok(KeyAlgorithm::Ed25519);
-    }
-
-    Err(Error::InvalidCertificate(format!(
-        "unsupported public key algorithm OID: {}",
-        alg_oid
-    )))
 }
 
 /// Extract identity from Subject Alternative Name (SAN) extension

--- a/crates/sigstore-tsa/src/verify.rs
+++ b/crates/sigstore-tsa/src/verify.rs
@@ -12,7 +12,7 @@ use cms::signed_data::{SignedData, SignerIdentifier};
 use const_oid::ObjectIdentifier;
 use jiff::Timestamp;
 use rustls_pki_types::CertificateDer;
-use sigstore_crypto::{verify_signature, SigningScheme};
+use sigstore_crypto::{verify_signature, KeyAlgorithm};
 use sigstore_types::{DerPublicKey, SignatureBytes, TsaAuthority};
 use x509_cert::Certificate;
 
@@ -26,9 +26,6 @@ const OID_MESSAGE_DIGEST: ObjectIdentifier = const_oid::db::rfc6268::ID_MESSAGE_
 const OID_SHA256: ObjectIdentifier = const_oid::db::rfc5912::ID_SHA_256;
 const OID_SHA384: ObjectIdentifier = const_oid::db::rfc5912::ID_SHA_384;
 const OID_SHA512: ObjectIdentifier = const_oid::db::rfc5912::ID_SHA_512;
-const OID_EC_PUBLIC_KEY: ObjectIdentifier = const_oid::db::rfc5912::ID_EC_PUBLIC_KEY;
-const OID_SECP256R1: ObjectIdentifier = const_oid::db::rfc5912::SECP_256_R_1;
-const OID_SECP384R1: ObjectIdentifier = const_oid::db::rfc5912::SECP_384_R_1;
 
 /// Verification options for RFC 3161 timestamps.
 ///
@@ -525,37 +522,28 @@ fn verify_ecdsa_signature(
     use x509_cert::der::Encode;
 
     let spki = &certificate.tbs_certificate.subject_public_key_info;
-    if spki.algorithm.oid != OID_EC_PUBLIC_KEY {
-        return Err(Error::SignatureVerificationError(format!(
-            "not an EC key: {}",
-            spki.algorithm.oid
-        )));
-    }
-    let curve_oid = spki
-        .algorithm
-        .parameters
-        .as_ref()
-        .ok_or_else(|| {
-            Error::SignatureVerificationError("missing EC curve parameters".to_string())
-        })?
-        .decode_as::<ObjectIdentifier>()
-        .map_err(|e| {
-            Error::SignatureVerificationError(format!("failed to decode curve OID: {e}"))
-        })?;
-    let scheme = match (&curve_oid, digest_alg_oid) {
-        (&OID_SECP256R1, &OID_SHA256) => SigningScheme::EcdsaP256Sha256,
-        (&OID_SECP384R1, &OID_SHA256) => SigningScheme::EcdsaP384Sha256,
-        (&OID_SECP384R1, &OID_SHA384) => SigningScheme::EcdsaP384Sha384,
-        _ => {
-            return Err(Error::SignatureVerificationError(format!(
-                "unsupported curve/digest combination: {curve_oid} / {digest_alg_oid}"
-            )))
-        }
-    };
     let public_key = DerPublicKey::new(spki.to_der().map_err(|e| {
         Error::SignatureVerificationError(format!("failed to encode signer public key: {e}"))
     })?);
 
+    let algorithm = KeyAlgorithm::from_spki(&public_key)
+        .map_err(|e| Error::SignatureVerificationError(e.to_string()))?;
+    if !matches!(algorithm, KeyAlgorithm::EcdsaP256 | KeyAlgorithm::EcdsaP384) {
+        return Err(Error::SignatureVerificationError("not an EC key".into()));
+    }
+    let hash = match *digest_alg_oid {
+        OID_SHA256 => sigstore_types::HashAlgorithm::Sha2256,
+        OID_SHA384 => sigstore_types::HashAlgorithm::Sha2384,
+        OID_SHA512 => sigstore_types::HashAlgorithm::Sha2512,
+        _ => {
+            return Err(Error::SignatureVerificationError(format!(
+                "unsupported digest algorithm: {digest_alg_oid}"
+            )))
+        }
+    };
+    let scheme = algorithm
+        .resolve_signing_scheme(hash)
+        .map_err(|e| Error::SignatureVerificationError(e.to_string()))?;
     verify_signature(
         &public_key,
         message,

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -6,7 +6,7 @@ use crate::artifact::{ArtifactRequirements, PreparedArtifact};
 use crate::error::{Error, Result};
 use sigstore_bundle::validate_bundle_with_options;
 use sigstore_bundle::ValidationOptions;
-use sigstore_crypto::{parse_certificate_info, KeyAlgorithm, SigningScheme, VerificationKey};
+use sigstore_crypto::{parse_certificate_info, KeyAlgorithm, SigningScheme};
 use sigstore_trust_root::TrustedRoot;
 
 use sigstore_types::bundle::VerificationMaterialContent;
@@ -790,7 +790,7 @@ fn prepare_public_key(
         ));
     }
     validate_structure(bundle, policy.verify_tlog)?;
-    signing_scheme_for_content(public_key_algorithm(public_key)?, &bundle.content)
+    signing_scheme_for_content(KeyAlgorithm::from_spki(public_key)?, &bundle.content)
 }
 
 fn verify_message_signature_crypto(
@@ -837,28 +837,6 @@ pub fn verify<'a>(
     trusted_root: &TrustedRoot,
 ) -> Result<VerificationResult> {
     Verifier::new(trusted_root).verify(artifact, bundle, policy)
-}
-
-/// Derive the key algorithm from the public key's SPKI algorithm identifier.
-///
-/// Parsing goes through [`VerificationKey::from_spki`], so malformed
-/// SPKI structures, unknown algorithm OIDs, and unsupported EC curves are
-/// rejected eagerly with precise errors (TOB-SIGSTORE-6). The scheme itself
-/// is still resolved from the bundle content afterwards, so a declared
-/// SHA-384 message digest keeps selecting ECDSA-P256-SHA384.
-fn public_key_algorithm(public_key: &sigstore_types::DerPublicKey) -> Result<KeyAlgorithm> {
-    let key = VerificationKey::from_spki(public_key)
-        .map_err(|e| Error::Verification(format!("invalid public key: {e}")))?;
-    match key.scheme() {
-        SigningScheme::Ed25519 => Ok(KeyAlgorithm::Ed25519),
-        SigningScheme::EcdsaP256Sha256 | SigningScheme::EcdsaP256Sha384 => {
-            Ok(KeyAlgorithm::EcdsaP256)
-        }
-        other => Err(Error::Verification(format!(
-            "unsupported public key scheme: {}",
-            other.name()
-        ))),
-    }
 }
 
 /// Convenience function to verify a managed-key bundle with a caller-supplied


### PR DESCRIPTION
Small follow-up to #207: 20 added lines, 98 removed, three files.

Route certificate extraction, managed-key verification and TSA ECDSA scheme selection through the checked crypto resolver. This removes duplicate OID/curve parsing and allows managed P-384/RSA/ML-DSA SPKIs to reach their supported verification paths instead of being rejected by the old P-256/Ed25519-only adapter.

Validation: workspace all-feature tests and strict all-target Clippy passed, including existing P-384/SHA-384 and TSA fixtures.