### PR TITLE
feat(verify)!: read-only verification results with checked evidence

### DIFF
--- a/crates/sigstore-verify/README.md
+++ b/crates/sigstore-verify/README.md
@@ -23,6 +23,15 @@ This crate provides high-level APIs for verifying Sigstore signatures. It handle
 5. Verify timestamps if present
 6. Check identity against policy (optional)
 
+## Verification results
+
+`VerificationResult` is created only by successful verification and exposes
+read-only accessors. `identity()` and `issuer()` are certificate claims;
+`certificate_verified()`, `sct_verified()`, `tlog_verified()` and
+`identity_policy_checked()` describe what was actually checked.
+`verified_timestamps()` excludes unsigned time hints. Relaxed policies must not
+be treated as equivalent to full certificate and log verification.
+
 ## Authorization
 
 `VerificationPolicy` has no default. Prefer `VerificationPolicy::new(identity, issuer)`

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -296,7 +296,7 @@ async fn main() {
                         process::exit(1);
                     }
                 };
-                if let Some(id) = &result.identity {
+                if let Some(id) = result.identity() {
                     if !re.is_match(id) {
                         eprintln!("\nVerification: FAILED");
                         eprintln!("  Identity '{}' does not match regexp '{}'", id, re_str);
@@ -310,18 +310,20 @@ async fn main() {
             }
 
             println!("\nVerification: SUCCESS");
-            if let Some(id) = &result.identity {
+            if let Some(id) = result.identity() {
                 println!("  Identity: {}", id);
             }
-            if let Some(iss) = &result.issuer {
+            if let Some(iss) = result.issuer() {
                 println!("  Issuer: {}", iss);
             }
-            if let Some(time) = result.integrated_time {
+            if let Some(time) = result.integrated_time() {
                 println!("  Signed at: {}", time);
             }
-            for warning in &result.warnings {
-                println!("  Warning: {}", warning);
-            }
+            println!("  Certificate verified: {}", result.certificate_verified());
+            println!(
+                "  Transparency-log inclusion verified: {}",
+                result.tlog_verified()
+            );
             process::exit(0);
         }
         Err(e) => {

--- a/crates/sigstore-verify/examples/verify_conda_attestation.rs
+++ b/crates/sigstore-verify/examples/verify_conda_attestation.rs
@@ -147,19 +147,20 @@ async fn main() {
             println!("Verification: SUCCESS");
             println!();
             println!("Certificate Details:");
-            if let Some(id) = &result.identity {
+            if let Some(id) = result.identity() {
                 println!("  Identity (SAN): {}", id);
             }
-            if let Some(iss) = &result.issuer {
+            if let Some(iss) = result.issuer() {
                 println!("  OIDC Issuer: {}", iss);
             }
-            if let Some(time) = result.integrated_time {
+            if let Some(time) = result.integrated_time() {
                 println!("  Signed at: {}", time);
             }
-            for warning in &result.warnings {
-                println!();
-                println!("Warning: {}", warning);
-            }
+            println!("  Certificate verified: {}", result.certificate_verified());
+            println!(
+                "  Transparency-log inclusion verified: {}",
+                result.tlog_verified()
+            );
             process::exit(0);
         }
         Err(e) => {

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -189,35 +189,77 @@ impl VerificationPolicy {
 /// Result of verification
 ///
 /// This is returned only when verification *succeeds* — any failure is reported
-/// as an [`Err`]. It carries metadata extracted during verification (identity,
-/// issuer, integrated time) plus any non-fatal warnings.
+/// as an [`Err`]. Metadata and evidence are read-only. Check the evidence
+/// getters when accepting results from callers that may use relaxed policies.
+/// Identity/issuer values are certificate claims, not proof of authorization.
+///
+/// ```compile_fail
+/// let result = sigstore_verify::VerificationResult::new();
+/// ```
+/// ```compile_fail
+/// let _: sigstore_verify::VerificationResult = Default::default();
+/// ```
 #[derive(Debug)]
 pub struct VerificationResult {
-    /// Identity from the certificate
-    pub identity: Option<String>,
-    /// Issuer from the certificate
-    pub issuer: Option<String>,
-    /// Integrated time from transparency log
-    pub integrated_time: Option<jiff::Timestamp>,
-    /// Any warnings during verification
-    pub warnings: Vec<String>,
+    identity: Option<String>,
+    issuer: Option<String>,
+    integrated_time: Option<jiff::Timestamp>,
+    certificate_verified: bool,
+    sct_verified: bool,
+    tlog_verified: bool,
+    identity_policy_checked: bool,
+    verified_timestamps: Vec<jiff::Timestamp>,
 }
 
 impl VerificationResult {
     /// Create an empty result to be populated as verification proceeds.
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             identity: None,
             issuer: None,
             integrated_time: None,
-            warnings: Vec::new(),
+            certificate_verified: false,
+            sct_verified: false,
+            tlog_verified: false,
+            identity_policy_checked: false,
+            verified_timestamps: Vec::new(),
         }
     }
-}
 
-impl Default for VerificationResult {
-    fn default() -> Self {
-        Self::new()
+    /// Certificate SAN claim, if present; see [`Self::certificate_verified`].
+    pub fn identity(&self) -> Option<&str> {
+        self.identity.as_deref()
+    }
+    /// Certificate OIDC issuer claim, if present.
+    pub fn issuer(&self) -> Option<&str> {
+        self.issuer.as_deref()
+    }
+    /// An authenticated Rekor v1 integrated time, if inclusion was verified.
+    pub fn integrated_time(&self) -> Option<jiff::Timestamp> {
+        self.integrated_time
+    }
+    /// Whether the signing certificate's chain, EKU and validity were checked.
+    pub fn certificate_verified(&self) -> bool {
+        self.certificate_verified
+    }
+    /// Whether the signing certificate's SCT was verified.
+    pub fn sct_verified(&self) -> bool {
+        self.sct_verified
+    }
+    /// Whether transparency-log inclusion and checkpoints were verified.
+    pub fn tlog_verified(&self) -> bool {
+        self.tlog_verified
+    }
+    /// Whether an identity and/or issuer constraint was matched.
+    ///
+    /// Matching claims is not authorization unless the certificate was also verified.
+    pub fn identity_policy_checked(&self) -> bool {
+        self.identity_policy_checked
+    }
+    /// All authenticated times used during verification (not unsigned hints).
+    /// Managed-key verification does not use TSA tokens for certificate validation.
+    pub fn verified_timestamps(&self) -> &[jiff::Timestamp] {
+        &self.verified_timestamps
     }
 }
 
@@ -418,8 +460,11 @@ impl Verifier {
                     issuer_spki.as_bytes(),
                     &self.trusted_root,
                 )?;
+                result.sct_verified = true;
             }
+            result.certificate_verified = true;
         }
+        result.verified_timestamps = validation_times;
 
         // (3): Verify against the given `VerificationPolicy`.
 
@@ -460,6 +505,8 @@ impl Verifier {
             }
         }
 
+        result.identity_policy_checked = policy.identity.is_some() || policy.issuer.is_some();
+
         // (4): Verify the inclusion proof and signed checkpoint for the log entry.
         // (5): Verify the inclusion promise for the log entry, if present.
         // (6): Verify the timely insertion of the log entry against the validity
@@ -472,6 +519,7 @@ impl Verifier {
                 cert_info.not_after,
             )?;
 
+            result.tlog_verified = true;
             if let Some(time) = integrated_time {
                 result.integrated_time = Some(time);
             }
@@ -643,9 +691,11 @@ impl Verifier {
                             jiff::Timestamp::now(),
                         )?;
                         result.integrated_time = Some(time);
+                        result.verified_timestamps.push(time);
                     }
                 }
             }
+            result.tlog_verified = true;
         }
 
         // Verify the signature

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -41,10 +41,10 @@ pub fn verify_tlog_entries(
         // Verify Merkle inclusion proof, checkpoint signature and SET
         verify_entry_inclusion(entry, trusted_root)?;
 
-        // Only Rekor v1 authenticates integratedTime via the SET. Rekor v2
-        // uses RFC 3161 timestamps; ignore an unauthenticated top-level value.
+        // Only a Rekor v1 SET authenticates integratedTime. An inclusion proof
+        // authenticates the body, not this separate timestamp field.
         let is_rekor_v2 = entry.kind_version == KindVersion::HashedRekordV002;
-        if !is_rekor_v2 {
+        if !is_rekor_v2 && entry.inclusion_promise.is_some() {
             if let Some(time) = entry.integrated_time {
                 validate_integrated_time(time, jiff::Timestamp::now(), not_before, not_after)?;
                 integrated_time_result = Some(time);

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -231,7 +231,7 @@ fn test_verify_with_policy() {
     assert!(result.is_ok(), "Verification failed: {:?}", result.err());
 
     let verification = result.unwrap();
-    assert!(verification.integrated_time.is_some());
+    assert!(verification.integrated_time().is_some());
 }
 
 #[test]
@@ -248,7 +248,7 @@ fn test_verify_extracts_integrated_time() {
 
     // The integrated time in the bundle is 1738060096 (2025-01-28)
     assert_eq!(
-        result.integrated_time,
+        result.integrated_time(),
         Some(jiff::Timestamp::from_second(1738060096).unwrap())
     );
 }
@@ -385,7 +385,7 @@ fn test_full_verification_flow() {
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root()).unwrap();
     assert_eq!(
-        result.integrated_time,
+        result.integrated_time(),
         Some(jiff::Timestamp::from_second(1738060096).unwrap())
     );
 }
@@ -428,7 +428,7 @@ fn test_full_verification_flow_happy_path() {
 
     let result = verify(artifact_digest, &bundle, &policy, &production_root()).unwrap();
     assert_eq!(
-        result.integrated_time,
+        result.integrated_time(),
         Some(jiff::Timestamp::from_second(1734374576).unwrap())
     );
 }
@@ -946,14 +946,14 @@ fn test_verify_conda_package_attestation() {
 
     let verification = result.unwrap();
     assert_eq!(
-        verification.identity.as_deref(),
+        verification.identity(),
         Some("https://github.com/prefix-dev/sigstore-example/.github/workflows/action.yaml@refs/heads/main")
     );
     assert_eq!(
-        verification.issuer.as_deref(),
+        verification.issuer(),
         Some("https://token.actions.githubusercontent.com")
     );
-    assert!(verification.integrated_time.is_some());
+    assert!(verification.integrated_time().is_some());
 }
 
 fn conda_attestation_policy() -> VerificationPolicy {
@@ -976,7 +976,7 @@ fn test_verify_conda_package_attestation_from_sync_reader() {
             &conda_attestation_policy(),
         )
         .unwrap();
-    assert!(verification.integrated_time.is_some());
+    assert!(verification.integrated_time().is_some());
 }
 
 #[tokio::test]
@@ -1131,6 +1131,51 @@ async fn invalid_certificate_does_not_consume_readers() {
         .await
         .is_err());
     assert_eq!(reader.position(), 0);
+}
+
+#[test]
+fn verification_results_report_only_checked_evidence() {
+    let bundle = Bundle::from_json(COSIGN_V3_BLOB_BUNDLE).unwrap();
+    let bytes = include_bytes!("../test_data/bundles/cosign-v3-blob.txt");
+    let verifier = Verifier::new(&production_root());
+    for (policy, chain, sct, tlog) in [
+        (VerificationPolicy::any_identity(), true, true, true),
+        (
+            VerificationPolicy::any_identity().skip_sct(),
+            true,
+            false,
+            true,
+        ),
+        (
+            VerificationPolicy::any_identity().skip_certificate_chain(),
+            false,
+            false,
+            true,
+        ),
+        (
+            VerificationPolicy::any_identity().skip_tlog_unsafe(),
+            true,
+            true,
+            false,
+        ),
+    ] {
+        let result = verifier.verify(bytes, &bundle, &policy).unwrap();
+        assert_eq!(result.certificate_verified(), chain);
+        assert_eq!(result.sct_verified(), sct);
+        assert_eq!(result.tlog_verified(), tlog);
+        assert_eq!(result.integrated_time().is_some(), tlog);
+        assert!(!result.identity_policy_checked());
+        assert_eq!(result.verified_timestamps().len(), 2);
+        let authorized =
+            VerificationPolicy::new(result.identity().unwrap(), result.issuer().unwrap());
+        assert!(verifier
+            .verify(bytes, &bundle, &authorized)
+            .unwrap()
+            .identity_policy_checked());
+        assert!(verifier
+            .verify(bytes, &bundle, &authorized.require_identity("wrong signer"))
+            .is_err());
+    }
 }
 
 #[test]
@@ -1379,7 +1424,7 @@ fn rekor_v2_does_not_report_unauthenticated_integrated_time() {
     )
     .unwrap();
 
-    assert_eq!(result.integrated_time, None);
+    assert_eq!(result.integrated_time(), None);
 }
 
 #[test]
@@ -1570,7 +1615,12 @@ fn test_verifier_with_key_accepts_digest_and_reports_integrated_time() {
         )
         .unwrap();
 
-    assert_eq!(result.integrated_time, expected_time);
+    assert_eq!(result.integrated_time(), expected_time);
+    assert!(result.tlog_verified());
+    assert!(!result.certificate_verified());
+    assert!(!result.sct_verified());
+    assert!(!result.identity_policy_checked());
+    assert_eq!(result.verified_timestamps(), &[expected_time.unwrap()]);
 }
 
 #[test]

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -1134,6 +1134,26 @@ async fn invalid_certificate_does_not_consume_readers() {
 }
 
 #[test]
+fn inclusion_proof_alone_does_not_authenticate_integrated_time() {
+    let mut bundle = Bundle::from_json(COSIGN_V3_BLOB_BUNDLE).unwrap();
+    let entry = &mut bundle.verification_material.tlog_entries[0];
+    entry.inclusion_promise = None;
+    entry.integrated_time =
+        Some(entry.integrated_time.unwrap() + jiff::SignedDuration::from_secs(1));
+    // The independent TSA timestamp still authenticates the signing time.
+    let result = verify(
+        include_bytes!("../test_data/bundles/cosign-v3-blob.txt"),
+        &bundle,
+        &VerificationPolicy::any_identity(),
+        &production_root(),
+    )
+    .unwrap();
+    assert_eq!(result.integrated_time(), None);
+    assert_eq!(result.verified_timestamps().len(), 1);
+    assert!(result.tlog_verified());
+}
+
+#[test]
 fn verification_results_report_only_checked_evidence() {
     let bundle = Bundle::from_json(COSIGN_V3_BLOB_BUNDLE).unwrap();
     let bytes = include_bytes!("../test_data/bundles/cosign-v3-blob.txt");


### PR DESCRIPTION
Small follow-up to #209.

Make VerificationResult construction private and remove Default/public mutable fields. Accessors distinguish certificate, SCT, log inclusion and identity-policy checks, and expose only authenticated timestamps. Remove the unused warnings list; examples report verification evidence instead.

Validation: verifier tests, compile-fail constructor checks and strict workspace Clippy passed. Regressions cover relaxed certificate/SCT/tlog policies, signer mismatch and managed-key evidence.