### PR TITLE
feat(features): make default verification independent of HTTP and Tokio

### DIFF
--- a/crates/sigstore-rekor/Cargo.toml
+++ b/crates/sigstore-rekor/Cargo.toml
@@ -9,9 +9,10 @@ rust-version.workspace = true
 
 [features]
 default = ["rustls"]
-rustls = ["reqwest/rustls"]
-native-tls = ["reqwest/native-tls"]
-cache = ["sigstore-cache"]
+client = ["dep:reqwest"]
+rustls = ["client", "reqwest/rustls"]
+native-tls = ["client", "reqwest/native-tls"]
+cache = ["client", "dep:sigstore-cache"]
 
 [dependencies]
 sigstore-types = { workspace = true }
@@ -20,7 +21,7 @@ sigstore-cache = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 jiff = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, optional = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 

--- a/crates/sigstore-rekor/README.md
+++ b/crates/sigstore-rekor/README.md
@@ -2,6 +2,13 @@
 
 Rekor transparency-log client for [sigstore-rust](https://github.com/sigstore/sigstore-rust).
 
+## Features
+
+Default features enable the HTTP `client` with `rustls`. For offline entry/body
+parsing and `LogEntry::to_bundle_entry`, use `default-features = false`; neither
+reqwest nor Tokio is then required. `native-tls` selects the alternative HTTP TLS
+backend, and `cache` enables client response caching.
+
 ## Supported APIs
 
 | Capability | Rekor v1 | Rekor v2 |

--- a/crates/sigstore-rekor/src/lib.rs
+++ b/crates/sigstore-rekor/src/lib.rs
@@ -5,15 +5,16 @@
 //!
 //! # Features
 //!
-//! - `cache` - Enable caching support for log info and public key responses.
-//!   When enabled, use [`RekorClientBuilder::with_cache`] to configure a cache adapter.
+//! - `client` - HTTP clients. Enabled by the default `rustls` feature.
+//! - `cache` - HTTP response caching via `RekorClientBuilder::with_cache`.
+//! - Disable default features for offline entry types and bundle conversion.
 //!
 //! # Example
 //!
 //! ```no_run
-//! use sigstore_rekor::RekorClient;
-//!
+//! # #[cfg(feature = "client")]
 //! # async fn example() -> Result<(), sigstore_rekor::Error> {
+//! use sigstore_rekor::RekorClient;
 //! let client = RekorClient::public();
 //! let log_info = client.get_log_info().await?;
 //! println!("Tree size: {}", log_info.tree_size);
@@ -34,11 +35,13 @@
 //! ```
 
 pub mod body;
+#[cfg(feature = "client")]
 pub mod client;
 pub mod entry;
 pub mod error;
 
 pub use body::RekorEntryBody;
+#[cfg(feature = "client")]
 pub use client::{
     get_public_log_info, RekorClient, RekorClientBuilder, RekorV2Client, RekorV2EntryBundle,
     RekorV2Tile,

--- a/crates/sigstore-rekor/tests/v2_client.rs
+++ b/crates/sigstore-rekor/tests/v2_client.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "client")]
+
 use base64::Engine;
 use sigstore_rekor::{HashedRekordV2, RekorV2Client, RekorV2KeyDetails};
 use sigstore_types::{DerCertificate, KindVersion, Sha256Hash, SignatureBytes};

--- a/crates/sigstore-sign/Cargo.toml
+++ b/crates/sigstore-sign/Cargo.toml
@@ -11,10 +11,10 @@ rust-version.workspace = true
 sigstore-types = { workspace = true }
 sigstore-crypto = { workspace = true }
 sigstore-bundle = { workspace = true }
-sigstore-rekor = { workspace = true }
+sigstore-rekor = { workspace = true, features = ["client"] }
 sigstore-fulcio = { workspace = true }
 sigstore-oidc = { workspace = true }
-sigstore-tsa = { workspace = true }
+sigstore-tsa = { workspace = true, features = ["client"] }
 sigstore-trust-root = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }

--- a/crates/sigstore-tsa/Cargo.toml
+++ b/crates/sigstore-tsa/Cargo.toml
@@ -9,8 +9,9 @@ rust-version.workspace = true
 
 [features]
 default = ["rustls"]
-rustls = ["reqwest/rustls"]
-native-tls = ["reqwest/native-tls"]
+client = ["dep:reqwest"]
+rustls = ["client", "reqwest/rustls"]
+native-tls = ["client", "reqwest/native-tls"]
 
 [dependencies]
 sigstore-types = { workspace = true }
@@ -18,7 +19,7 @@ sigstore-crypto = { workspace = true }
 aws-lc-rs = { workspace = true }
 der = { workspace = true }
 const-oid = { workspace = true, features = ["db"] }
-reqwest = { workspace = true }
+reqwest = { workspace = true, optional = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 rand = { workspace = true }

--- a/crates/sigstore-tsa/README.md
+++ b/crates/sigstore-tsa/README.md
@@ -15,6 +15,10 @@ Timestamps provide trusted third-party evidence of when a signature was created,
 - **Timestamp verification**: Verify timestamp tokens against TSA certificates
 - **Multiple TSAs**: Built-in support for Sigstore TSA and FreeTSA
 
+HTTP clients require the `client` feature, enabled by the default `rustls` feature.
+Use `default-features = false` for offline ASN.1 parsing and timestamp verification
+without reqwest or Tokio. `native-tls` enables the client with the alternative TLS backend.
+
 ## Usage
 
 ```rust
@@ -22,10 +26,7 @@ use sigstore_tsa::TimestampClient;
 
 // Get a timestamp from the Sigstore TSA
 let client = TimestampClient::sigstore();
-let timestamp_token = client.timestamp_sha256(&digest).await?;
-
-// Or use the convenience function
-let token = sigstore_tsa::timestamp_sigstore(&digest).await?;
+let timestamp_token = client.timestamp_signature(&signature).await?;
 ```
 
 ## ASN.1 Types

--- a/crates/sigstore-tsa/src/lib.rs
+++ b/crates/sigstore-tsa/src/lib.rs
@@ -4,6 +4,7 @@
 //! including request creation, response parsing, and timestamp verification.
 
 pub mod asn1;
+#[cfg(feature = "client")]
 pub mod client;
 pub mod error;
 pub mod verify;
@@ -11,6 +12,7 @@ pub mod verify;
 pub use asn1::{
     AlgorithmIdentifier, Asn1MessageImprint, PkiStatus, TimeStampReq, TimeStampResp, TstInfo,
 };
+#[cfg(feature = "client")]
 pub use client::TimestampClient;
 pub use error::{Error, Result};
 pub use sigstore_types::TsaAuthority;

--- a/crates/sigstore-verify/Cargo.toml
+++ b/crates/sigstore-verify/Cargo.toml
@@ -45,14 +45,6 @@ sigstore-trust-root = { workspace = true, features = ["tuf"] }
 
 [features]
 default = ["rustls"]
-rustls = [
-  "sigstore-rekor/rustls",
-  "sigstore-tsa/rustls",
-  "sigstore-trust-root/rustls",
-]
-native-tls = [
-  "sigstore-rekor/native-tls",
-  "sigstore-tsa/native-tls",
-  "sigstore-trust-root/native-tls",
-]
+rustls = ["sigstore-trust-root/rustls"]
+native-tls = ["sigstore-trust-root/native-tls"]
 tuf = ["sigstore-trust-root/tuf"]

--- a/crates/sigstore-verify/README.md
+++ b/crates/sigstore-verify/README.md
@@ -23,6 +23,13 @@ This crate provides high-level APIs for verifying Sigstore signatures. It handle
 5. Verify timestamps if present
 6. Check identity against policy (optional)
 
+## Offline verification
+
+The default `sigstore-verify` dependency tree has no HTTP client or Tokio runtime.
+Verification always uses the supplied trusted root and never fetches artifacts
+or keys. Enable `tuf` plus `rustls` (default) or `native-tls` when the application
+also needs network trust-root refreshes.
+
 ## Verifier construction
 
 `Verifier::new(&root)?` prepares Rekor/CT keyrings and Fulcio trust anchors before

--- a/scripts/check-features.py
+++ b/scripts/check-features.py
@@ -18,3 +18,20 @@ for package in metadata["packages"]:
             ["cargo", "check", "--locked", "--package", package["name"], *flags],
             check=True,
         )
+
+# Offline consumers must not regain a hidden HTTP/runtime dependency.
+for package, flags in [
+    ("sigstore-verify", []),
+    ("sigstore-verify", ["--no-default-features"]),
+    ("sigstore-bundle", []),
+    ("sigstore-rekor", ["--no-default-features"]),
+    ("sigstore-tsa", ["--no-default-features"]),
+]:
+    tree = subprocess.check_output(
+        ["cargo", "tree", "--locked", "--package", package,
+         "--edges", "normal", "--prefix", "none", *flags], text=True,
+    )
+    dependencies = {line.split()[0] for line in tree.splitlines() if line.strip()}
+    forbidden = dependencies & {"reqwest", "hyper", "tokio"}
+    if forbidden:
+        raise SystemExit(f"{package} unexpectedly requires {sorted(forbidden)}")


### PR DESCRIPTION
Small follow-up to #212: feature gates and dependency declarations, not a transport abstraction.

- Gate Rekor/TSA HTTP clients and reqwest behind client features.
- Keep their existing client+rustls defaults; signing explicitly enables clients.
- Verification uses offline entry types and timestamp validation; its TLS features only configure optional TUF refreshes.
- Assert offline dependency boundaries in the isolated-feature CI check.

Validation: workspace all-feature tests, strict Clippy, Rust 1.86, docs, isolated features, native-TLS checks and no-default-feature Rekor/TSA/verifier tests passed. Default sigstore-verify and sigstore-bundle, plus offline Rekor/TSA builds, have no reqwest/hyper/Tokio normal dependencies.